### PR TITLE
OPL: Update versioning to new scheme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,20 +102,25 @@ script:
 # Let's build Open PS2 Loader!
 - cd ${opl_build_dir}/
 
-## Builg Lang Pack and Latest Changelog
-- . make_changelog.sh
-- . lng_pack.sh
-
 ## Export main variables
-- export opl_version=$(cat include/opl.h | grep OPL_VERSION | cut -f 3 | tr -d '"' | cut -c -5)
-- export opl_revision=$(cat DETAILED_CHANGELOG | head -11 | tail -n 1 | cut -d " " -f 1 | tr -d "rev" | tr -d "commit")
-- export opl_extraversion=$(cat include/opl.h | grep OPL_VERSION | cut -f 3 | tr -d '"' | cut -c 7-)
+- export opl_version=$(cat Makefile | grep "VERSION =" | head -1 | cut -d " " -f 3)
+- export opl_subversion=$(cat Makefile | grep "SUBVERSION =" | head -1 | cut -d " " -f 3)
+- export opl_patchlevel=$(cat Makefile | grep "PATCHLEVEL =" | head -1 | cut -d " " -f 3)
+- export opl_revision=$(cat Makefile | grep "REVISION =" | head -1 | cut -d " " -f 3)
+- export opl_extraversion=$(cat Makefile | grep "EXTRAVERSION =" | head -1 | cut -d " " -f 3)
+- if [ ${opl_extraversion} ]; then export opl_extraversion=-${opl_extraversion}; fi
 - export opl_git=$(git rev-parse --short=7 HEAD | head -1)
-- export opl_version=${opl_version}.${opl_revision}-${opl_extraversion}
-- export opl_set="OPNPS2LD-${opl_version}-${opl_git}"
+- if [ ${opl_git} ]; then export opl_git=-${opl_git}; fi
+- export opl_version=${opl_version}.${opl_subversion}.${opl_patchlevel}.${opl_revision}
+- export opl_set="OPNPS2LD-${opl_version}${opl_extraversion}${opl_git}"
 
 ## Build OPL with ALL
-- make VMC=1 GSM=1 IGS=1 CHEAT=1 rebuild
+- make clean
+- make release
+
+## Build Lang Pack and Latest Changelog
+- . make_changelog.sh
+- . lng_pack.sh
 
 ## Pack it on zip
 - mkdir -p ${opl_build_dir}/out/

--- a/DETAILED_CHANGELOG
+++ b/DETAILED_CHANGELOG
@@ -8,3 +8,950 @@
 
 Open PS2 Loader detailed ChangeLog:
 
+commit947 - uyjulian - run clang-format on all .c and .h files - Wed Oct 19 20:32:12 2016 -0200
+commit946 - uyjulian - add .clang-format configuration file - Wed Oct 19 20:32:12 2016 -0200
+commit945 - Caio Oliveira - .gitignore: Change from .hgignore and add more entries - Wed Oct 19 11:00:18 2016 -0200
+commit944 - Caio Oliveira - TravisCI: Initial Template - Wed Oct 19 11:00:18 2016 -0200
+commit943 - Caio Oliveira - lng_pack: Add script to pack all Langs in a zip - Wed Oct 19 11:00:18 2016 -0200
+commit942 - Caio Oliveira - make_changelog: Update it to GIT format - Wed Oct 19 11:00:18 2016 -0200
+commit941 - Caio Oliveira - README: Create a symlink need by GitHub - Wed Oct 19 09:47:19 2016 -0200
+commit940 - Caio Oliveira - CREDITS: Make same style in whole file - Wed Oct 19 09:47:19 2016 -0200
+commit939 - doctorxyz - Skip Videos: Three methods (0 PSS/sceMpegIsEnd/BIK) on a single place Now Skip Videos (a.k.a. 0 PSS) not only skips PSS files (by zeroing their sizes) but also skips Bink .BIK (new technique) and sceMpegIsEnd based ones - All of them from a single place: Game Settings->Customized Settings->Mode 4(Skip Videos) - sceMpegIsEnd and BIK approaches has been implemented on ee_core's patches, while 0 PSS code has been kept intact (on iopcore's cdvdman) - Renamed '0 PSS' for 'Skip Videos' according to each language (NB: Basic Google translation. Native speakers can improve it) - Removed now-redundant GSM's Skip Videos sceMpegIsEnd related stuff (ontheflypatcher) - Since sceMpegIsEnd isn't GSM-dependant anymore - Wed Oct 19 08:53:05 2016 -0200
+commit938 - doctorxyz - BLURT output (for debugging purposes) It accumulates and shows the line sequence of code executed (or not) on OPL's GUI. To use it, simply add 'BLURT;' macros in the start of lines you want (preferably the ones from the same file) and compile OPL as usual. To enable it on GUI, go to [Settings]->[Disable Debug Colors] and set it to [Off] - Tue Oct 11 10:28:29 2016 -0300
+commit937 - doctorxyz - I also like to commit in two-phases...:p - Mon Oct 10 01:20:59 2016 -0300
+commit936 - doctorxyz - Optional FMV fix (enabled by setting UNALIGNED_BUFFER_PATCH to 0) It improves videos performance as much as possible, with risk of stalling DMA channel (since there is no silver bullet) Discussion: http://psx-scene.com/forums/f150/open-ps2-loader-project-v0-9-3-a-62141/index152.html#post1209206 - Sun Oct 9 21:06:03 2016 -0300
+commit935 - doctorxyz - Minor changes - Fri Oct 7 11:54:10 2016 -0300
+commit934 - doctorxyz - Auto Start Last Game fix - Thu Oct 6 16:43:19 2016 -0300
+commit933 - doctorxyz - GSM: Improved DISPFBx and DISPLAYx patching (both enabled as default). IGS: Bitmap/TXT Files created with the same automatic number - Mon Oct 3 15:24:30 2016 -0300
+commit932 - doctorxyz - GSM: Fixes and improvements on Core Flags and Skip Videos (FMVs) functionality restoration - Mon Oct 3 07:28:47 2016 -0300
+commit931 - doctorxyz - IGS improvements Compilation: Now the GSM compilation directive is automatically enabled (GSM = 1) whenever the IGS one is activated (IGS = 1) InGame: Pad Combo only works if GSM is enabled (on OPL game settings) BMP and TXT files: Sequential numbering feature, which avoids to overwrite previously created files - Sat Oct 1 19:08:01 2016 -0300
+commit930 - doctorxyz - SP193: USB Fragmentation Check enabled as default (http://psx-scene.com/forums/f150/open-ps2-loader-project-v0-9-3-a-62141/index152.html#post1208854) - Sat Oct 1 18:11:28 2016 -0300
+commit929 - doctorxyz - IGS: 24-bit Pixel Storage Size memory alignment fix - Wed Sep 28 18:45:51 2016 -0300
+commit928 - doctorxyz - IGS: 16-bit Pixel Storage Size (PSMCT16 and PSMCT16S) fix - Tue Sep 27 21:17:43 2016 -0300
+commit927 - doctorxyz - IGS source code refactoring (several improvements and fixes) - Tue Sep 27 06:11:30 2016 -0300
+commit926 - doctorxyz - IGS some header/api fixes/improvements. - Mon Sep 19 11:57:49 2016 -0300
+commit925 - doctorxyz - IGS (InGame Screenshot Feature) initial commit. Update on GSM version & credits. - Thu Sep 15 20:13:41 2016 -0300
+commit924 - doctorxyz - GSM Core additions - Built-in DTV480P vmode (replacement code for SetGsCrt), based on the same DTV576P and DTV1080P approach as seeen on commit 2b8273a (https://bitbucket.org/ifcaro/open-ps2-loader/commits/2b8273a2d7f17056c5fe00be337dac173b4b44bb) - More GS Registers being trapped: PMODE, SMODE1, SRFSH, SYNCH1, SYNCH2, DISPFB1 and DISPFB2 - Thu Sep 15 18:35:06 2016 -0300
+commit923 - El_Patas - Update languages - Thu Sep 15 04:32:32 2016 -0300
+commit922 - El_Patas - Changed old lang_Turkish_0.9.3.lng useless name - Thu Sep 15 02:00:27 2016 +0000
+commit921 - El_Patas - Changed old lang_TChinese_0.9.3.lng useless name - Thu Sep 15 01:59:37 2016 +0000
+commit920 - El_Patas - Changed old lang_Swedish_0.9.3.lng useless name - Thu Sep 15 01:58:48 2016 +0000
+commit919 - El_Patas - Changed old lang_Spanish_0.9.3.lng useless name - Thu Sep 15 01:58:05 2016 +0000
+commit918 - El_Patas - Changed old lang_Russian_0.9.3.lng useless name - Thu Sep 15 01:57:11 2016 +0000
+commit917 - El_Patas - Changed old lang_Portuguese_BR_0.9.3.lng useless name - Thu Sep 15 01:56:21 2016 +0000
+commit916 - El_Patas - Changed old lang_Portuguese_0.9.3.lng useless name - Thu Sep 15 01:55:33 2016 +0000
+commit915 - El_Patas - Changed old lang_Polish_0.9.3.lng useless name - Thu Sep 15 01:54:41 2016 +0000
+commit914 - El_Patas - Changed old lang_Laotian_0.9.3.lng useless name - Thu Sep 15 01:53:53 2016 +0000
+commit913 - El_Patas - Changed old lang_Italian_0.9.3.lng useless name - Thu Sep 15 01:52:59 2016 +0000
+commit912 - El_Patas - Changed old lang_Indonesian_0.9.3.lng useless name - Thu Sep 15 01:51:56 2016 +0000
+commit911 - El_Patas - Changed old lang_German_0.9.3.lng useless name - Thu Sep 15 01:51:10 2016 +0000
+commit910 - El_Patas - Changed old lang_French_0.9.3.lng useless name - Thu Sep 15 01:49:31 2016 +0000
+commit909 - El_Patas - Changed old lang_English_0.9.3.lng useless name - Thu Sep 15 01:47:57 2016 +0000
+commit908 - El_Patas - Changed old lang_Czech_0.9.3.lng useless name - Thu Sep 15 01:42:49 2016 +0000
+commit907 - El_Patas - Changed old lang_Bulgarian_0.9.3.lng useless name - Thu Sep 15 01:40:28 2016 +0000
+commit906 - El_Patas - Changed old useless name - Thu Sep 15 01:33:16 2016 +0000
+commit905 - doctorxyz - GSM Internals: New SMODE1, SYNCH1, SYNCH2 & SYNCV macros; magic numbers on predef VModes replaced to their corresponding SYNCV values - Sun Sep 11 16:05:38 2016 -0300
+commit904 - doctorxyz - GSM & Cheat Engine gardening -GSM: Deleted duplicated VGA mode(VGA 640x960i @60Hz). Code simplification (for new features to come). -Cheat Engine: More fluidity when booting games; Quick warnings instead of message boxes (now on all OPL modes) - Sat Sep 10 07:36:08 2016 -0300
+commit903 - doctorxyz - Cheat Engine: Warning instead of a message box, when no cheats have been found - Sat Sep 10 07:00:01 2016 -0300
+commit902 - doctorxyz - Proper naming of VMC, GSM and CHEAT preprocessor conditionals - Sat Sep 10 06:46:16 2016 -0300
+commit901 - doctorxyz - VGA GSM vmode adjustments - Mon Sep 5 02:29:10 2016 -0300
+commit900 - doctorxyz - VGA GSM vmode fixes - Sat Sep 3 09:45:58 2016 -0300
+commit899 - doctorxyz - Re-added several VGA GSM vmodes for better game compatibility - Tue Aug 30 16:57:49 2016 -0300
+commit898 - doctorxyz - ConsoleRegion functionality fix It was broken since commit r890 (https://bitbucket.org/ifcaro/open-ps2-loader/commits/2dcd8324c58cf27f23315f51ea00619caea3cfb5) - Mon Aug 29 07:27:19 2016 -0300
+commit897 - doctorxyz - Rollback changes made to delay() for avoiding BSOD inline -> Eliminate the function-call overhead, making execution faster as well. - Fri Aug 26 15:34:41 2016 -0300
+commit896 - doctorxyz - Some revisions on Makefiles - Fri Aug 26 12:03:54 2016 -0300
+commit895 - doctorxyz - EE Core debug message bugfix - Fri Aug 26 11:59:48 2016 -0300
+commit894 - doctorxyz - PS2Logo (less time on its GUI debug warning messages) - Fri Aug 26 11:57:15 2016 -0300
+commit893 - doctorxyz - PS2Logo bugfix - Fri Aug 26 11:54:51 2016 -0300
+commit892 - doctorxyz - 'Playstation 2' boot logo GUI setting (on/off) Due to its minimal IOP memory footprint, now PS2 Logo is a built-in OPL feature, hosen directly from the GUI (Settings->PS2 Logo->on/off). NB: Even when enabled, it will be displayed if - and only if - there exists a valid disc logo that matches the console's region. - Thu Aug 25 21:01:42 2016 -0300
+commit891 - doctorxyz - Gardening - Thu Aug 25 14:22:26 2016 -0300
+commit890 - doctorxyz - IGR: Green and Blue Debug Colors adjust Proper location (to complete the previous commit): The green debug color appears right before stopping GSM, and the blue one right before stopping PS2 Cheat Engine. - Mon Aug 22 10:13:15 2016 -0300
+commit889 - doctorxyz - IGR: Yellow Debug Color adjust In its previous location, it wasn't useful at all; now it tracks the IOP reset completion. - Mon Aug 22 08:31:19 2016 -0300
+commit888 - doctorxyz - PS2LOGO improvements and new GUI Warning messages PS2LOGO - Displayed only if disc logo is valid and matches with console region. GUI Debugging - More warning messages. NB: They will appear only when 'Debug Colors' option is proper selected (Settings->Disable Debug Colors->Off) - Fri Aug 19 20:55:58 2016 -0300
+commit887 - doctorxyz - guiWarning: tweaks for displaying multi-line strings - Fri Aug 19 20:42:22 2016 -0300
+commit886 - doctorxyz - New Makefile variable (for developers) Nor stripping neither compressing binary ELF after compiling: Accelerates Debugging Process - for instance with XLink(PC-Side) and PS2Link(PS2-Side). - Fri Aug 19 20:36:58 2016 -0300
+commit885 - doctorxyz - PS2LOGO flag fixes (in Makefile) - Sun Aug 14 08:41:36 2016 -0300
+commit884 - doctorxyz - IOP Memory Usage Warning (works together with Debug Colors). It shows the initial memory usage by the OPL IOP Replacement modules and their optional features (if any), right before booting games. The CDVDFSV+CDVDMAN size depends on mode chosen (from smallest to biggest: HDD, USB and ETH), whereas VMC/PS2LOGO size does not. - Sat Aug 13 19:51:42 2016 -0300
+commit883 - doctorxyz - Functions added: guiWarning(GUI) & delay(Util) - Fri Aug 12 11:42:28 2016 -0300
+commit882 - doctorxyz - 'Playstation 2' boot logo & startup sound - l_oliveira's code optimizations - Tue Aug 9 00:00:44 2016 -0300
+commit881 - doctorxyz - SP193: PS3 BC(Backwards Compatible) fixes http://psx-scene.com/forums/f150/possible-get-opl-work-decently-backwards-compatible-ps3-over-network-155082/ - Mon Aug 8 16:19:43 2016 -0300
+commit880 - doctorxyz - 'Playstation 2' boot logo & startup sound Since this feature consumes a few extra IOP RAM bytes, it must be enabled by 'PS2LOGO' Makefile directive. NB: It will be properly displayed only if both disc and console region match. Thanks SP193(tips), l_oliveira(guidance) and Vedita BR(feature request/testing) - Mon Aug 8 10:21:15 2016 -0300
+commit879 - doctorxyz - Reduced PS2RD string size in About Screen - Sun Aug 7 18:18:13 2016 -0300
+commit878 - doctorxyz - Updated for compiling with latest PS2SDK revision - Thu Aug 4 15:33:21 2016 -0300
+commit877 - BatRastard - () Turns out Hommi's ASM is in the PS2SDK as "Exit(0)" so replicating it here is redundant. Sooo uh ... yeah ... ;) - Sat May 14 12:29:00 2016 -0400
+commit876 - BatRastard - (*) Changed the "sysExecExit()" function call, reverted it to Hominem's original ASM code. The result is people can use the "Exit" function to go back to OSDSYS/Browser. The IGR Path however can be left empty or used as intended before the OPL/GSM integration. OPL will show a baby-blue screen after an IGR and then boot the ELF if the path is valid. If you get a red screen followed by FMCB reinitializing/rebooting, then your IGR path is invalid. Most likely culprit is a syntax error regarding case-senitivity. Note that only physcial memory cards can be used for valid IGR paths at this time as the bug(s) regarding those paths remain ... - Sat May 14 00:28:03 2016 -0400
+commit875 - doctorxyz - GSM 0.38 Core readded (now fully PS2RD compatible)* It is based on 0.38 standalone version and also still rellocatable and per-game based. The DTV576P** and DTV1080P*** vmodes are powered by a replacement code for SetGsCrt. The Skip FMVs (Full Motion Videos) toggle has came back, it is based on NachBrenner's method #1****. *Thanks Vedita BR for asking and testing it. **Without this, only PSTwos (BIOS >= 220) have native support. ***None PS2 natively support it; it has been made possible by SP193 (research & development) and reprep (research). ****TODO: Implement other NachBrenner's methods, maybe merging with per-game OPL's appy_patches. PS: VGA vmodes higher than 60Hz can reduce eye strain, depending on your monitor. - Tue Jan 5 05:19:55 2016 -0500
+commit874 - El_Patas - Restorations and addtions - Wed Dec 23 13:00:14 2015 +0100
+commit873 - doctorxyz - About Menu: Credits added - Wed Nov 4 18:48:54 2015 -0500
+commit872 - El_Patas - Updated changelog - Wed Nov 4 02:16:05 2015 +0100
+commit871 - El_Patas - lang_Turkish.lng deleted - Wed Nov 4 00:38:44 2015 +0000
+commit870 - El_Patas - lang_TChinese.lng deleted - Wed Nov 4 00:38:17 2015 +0000
+commit869 - El_Patas - lang_Swedish.lng deleted - Wed Nov 4 00:37:48 2015 +0000
+commit868 - El_Patas - lang_Spanish.lng deleted - Wed Nov 4 00:37:21 2015 +0000
+commit867 - El_Patas - lang_Russian.lng deleted - Wed Nov 4 00:36:55 2015 +0000
+commit866 - El_Patas - lang_Portuguese_BR.lng deleted - Wed Nov 4 00:36:21 2015 +0000
+commit865 - El_Patas - lang_Portuguese.lng deleted - Wed Nov 4 00:35:45 2015 +0000
+commit864 - El_Patas - lang_Polish.lng deleted - Wed Nov 4 00:35:19 2015 +0000
+commit863 - El_Patas - lang_Laotian.lng deleted - Wed Nov 4 00:34:36 2015 +0000
+commit862 - El_Patas - lang_Italian.lng deleted - Wed Nov 4 00:33:50 2015 +0000
+commit861 - El_Patas - lang_Indonesian.lng deleted - Wed Nov 4 00:33:12 2015 +0000
+commit860 - El_Patas - lang_German.lng deleted - Wed Nov 4 00:32:35 2015 +0000
+commit859 - El_Patas - lang_French.lng deleted - Wed Nov 4 00:31:25 2015 +0000
+commit858 - El_Patas - lang_English.lng deleted - Wed Nov 4 00:30:21 2015 +0000
+commit857 - El_Patas - lang_Czech.lng deleted - Wed Nov 4 00:26:29 2015 +0000
+commit856 - El_Patas - lang_Bulgarian.lng deleted - Wed Nov 4 00:23:36 2015 +0000
+commit855 - El_Patas - lang_Arabic.lng deleted online with Bitbucket - Wed Nov 4 00:19:25 2015 +0000
+commit854 - El_Patas - Updated languages - Wed Nov 4 01:07:43 2015 +0100
+commit853 - El_Patas - Update languages - Sun Oct 25 13:05:27 2015 +0100
+commit852 - doctorxyz - writeMCIcon MC Folder Creation fix - Reported by Grahf, fixed by SP193 - Fri Oct 23 13:30:20 2015 -0400
+commit851 - doctorxyz - Change version to 'OPL 0.9.4 WIP', re-enable development build flag - Fri Oct 23 04:16:22 2015 -0400
+commit850 - doctorxyz - Added tag 0.9.3 for changeset 9b5321def22d - Wed Oct 21 00:59:28 2015 -0400
+commit849 - doctorxyz - Massive language update: Arabic, Brazilian Portuguese, Bulgarian, French, Portuguese, Russian, Spanish and Traditional Chinese. The content of language files were preserved whenever possible. Take in account that some fixes/adjustments were needed and made for better comparison and adherence to English template. The [ALT]+[TAB] approach were used as long with many Google Translate queries for a better comprehension of our Tower of Babel ;-) - Wed Oct 21 00:49:42 2015 -0400
+commit848 - doctorxyz - Updated: Polish language - Mon Oct 19 16:16:25 2015 -0400
+commit847 - doctorxyz - About Menu: Contributors added, followed by case-insensitive sorting - Mon Oct 19 15:37:15 2015 -0400
+commit846 - doctorxyz - SP193 - Fixed renaming functionality for USBExtreme games + DEV9 will not be activated unless either Ethernet or ATA is used: 1. Fixed renaming functionality for USBExtreme games (Broken since 113ede7 on 2010/12/19). 2. Updated to use the new design for the HDD and PFS modules from PS2SDK (better maintainability). 3. Changed support for USBExtreme games to use a structure and to not use the buffered I/O functions (which are for text config files). 4. Changed loading of DEV9 to only load when either the Ethernet or ATA interfaces have to be used, so that fat PS2s will not always have their expansion bays activated. 5. Fix from AKuHAK to textures.c, to be more compliant with C. - Sat Oct 17 21:47:36 2015 -0400
+commit845 - doctorxyz - Jay-Jay'n'gledson999:Portuguese BR language fix - Thu Oct 8 01:45:29 2015 -0400
+commit844 - doctorxyz - Updated Portuguese BR language - Mon Oct 5 14:07:48 2015 -0400
+commit843 - doctorxyz - SP193: HDD unit will be checked for fonts only if HDD support is set to AUTO. - Mon Oct 5 08:33:33 2015 -0400
+commit842 - doctorxyz - Added Traditional Chinese language (It was missing in r840... Sorry) - Sun Oct 4 20:55:55 2015 -0400
+commit841 - Jay-Jay - Update German Language and Update Theme Icons - Sun Oct 4 05:21:30 2015 -0700
+commit840 - doctorxyz - Readded width specifiers on Game Settings Page. Let's help each other and work as a team ;-) - Sun Oct 4 06:51:43 2015 -0400
+commit839 - doctorxyz - Translations Updated (French, Portuguese BR and Spanish) and Added (Traditional Chinese). Let's help each other and work as a team ;-) - Sun Oct 4 06:34:32 2015 -0400
+commit838 - Jay-Jay - Update Language Translation Files - Sat Oct 3 17:12:30 2015 -0700
+commit837 - Jay-Jay - Update Language Translation Files - Sat Oct 3 13:54:36 2015 -0700
+commit836 - doctorxyz - Newest SP193's 0.9.3 patch - Mode x Labels :-) Remember guys we still need updated language files for 0.9.3 :-( - Sat Oct 3 07:07:24 2015 -0400
+commit835 - doctorxyz - Here is SP193's 0.9.3 patch :-) But we still need updated language files :-( - Sat Oct 3 02:06:26 2015 -0400
+commit834 - El_Patas - Update Spanish translation - Wed Sep 30 20:46:49 2015 +0200
+commit833 - doctorxyz - About Menu: Credits listed in alphabetical order - Tue Sep 29 21:16:38 2015 -0400
+commit832 - doctorxyz - Deleted: scripts/out.txt - Tue Sep 29 08:20:27 2015 +0000
+commit831 - doctorxyz - Auto Start Last Game - Configureable Countdown : Value in second(s), 0 to disable auto start - Mon Sep 28 10:43:25 2015 -0400
+commit830 - doctorxyz - Fixes for VMC (compilation warning) and Auto-start Last Game (bugs and conflicts) - Sun Sep 27 21:09:19 2015 -0400
+commit829 - doctorxyz - Auto-start feature fix - Wait for pending operations to finish - Wed Sep 23 14:00:43 2015 -0400
+commit828 - doctorxyz - Added Autostart toggle for Last Played Game feature: When enabled, starts the chosen game automatically within a few seconds - unless the user presses any valid key. - Wed Sep 23 05:16:42 2015 -0400
+commit827 - doctorxyz - OPL Spanish translation by El_Patas - Sat Sep 19 06:55:27 2015 -0400
+commit826 - Jay-Jay - update language files and also fonts - Thu Sep 17 01:21:16 2015 -0700
+commit825 - Jay-Jay - update language files - Sat Sep 5 22:05:46 2015 -0700
+commit824 - doctorxyz - Now Last Played Game feature starts the chosen game automatically within a few seconds - unless the user presses any valid key. - Thu Sep 3 02:54:19 2015 -0400
+commit823 - SP193 - Rollback: removed FAT driver from in-game. New universal system added to support non-standard sector sizes. - Sun Aug 30 02:46:25 2015 +0800
+commit822 - SP193 - Added support for downloading compatibility entries through the Internet from the OPL-CL service. Changed hasCompatibilityMode of iosupport.h to flags, so that it can also be used to indicate the lack of support (by APPS mode) for network updates. - Fri Aug 21 18:52:47 2015 +0800
+commit821 - SP193 - Removed locking semaphore for game list, GUI OPs will now be cleared before the menu is cleared prior to game list updating (so that old commands will not be executed) and added checks for file-open problems under USB support. - Sat Aug 15 18:03:17 2015 +0800
+commit820 - SP193 - Updated to support the new PS2SDK changes (SIF CMD buffer set, USBHDFSDV SIF CMD ID changed to 0), USBHDFSD IOCTL codes consolidated into usb-ioctl.h, standardized which "prefix" buffer to use within usbsupport.c (was unable to access game files when a prefix is set, due to the path getting incorrectly generated), removed cdrom_lseek64 as it is not implemented in the SONY CDVDMAN, changed cdrom_dclose to become cdrom_close since close() and dclose() are the same here and SONY does it that way too, simplified cdrom_lseek to be more tolerant to errors like the SONY original, adjusted CBT to apply to reading operations as well, adjusted CBT to be 5000us, adjusted speed limit for Accurate Reads to 2800KB/s (timed to the 36.864MHz IOP clock). - Sat Aug 15 12:59:47 2015 +0800
+commit819 - Jay-Jay - update lang Arabic; new lang Portuguese-Brazilian. - Wed Aug 5 21:05:54 2015 -0700
+commit818 - Jay-Jay - updated lang Arabic 90% translated; new lang Portuguese-Brazilian 100% translated. - Wed Aug 5 20:51:23 2015 -0700
+commit817 - Jay Jay - Merged ifcaro/open-ps2-loader into default - Mon Aug 3 22:15:17 2015 -0700
+commit816 - doctorxyz - Re-added 'VGA 640x480i @60Hz' again GSM vmode for better game compatibility (avoid BSOD/freezing/no signal on certain games and VGA monitors) - Mon Aug 3 22:40:45 2015 -0400
+commit815 - Jay-Jay - Update LNG files to support OPL r813 changes, removed obsolete LNG files that need an overhaul. - Mon Aug 3 18:29:26 2015 -0700
+commit814 - Jay Jay - Merged ifcaro/open-ps2-loader into default - Sun Aug 2 20:14:16 2015 -0700
+commit813 - SP193 - Merged the CallBack Timer setting into Accurate Reads compat mode (applies to everything other than reads), new compat mode (High module storage @ 0x01C00000), EE core linkfile adjusted to have the stack before _end for better manageability, EE core will now always reset stack pointer to _end, and fixed blockSize within fat.c overflowing (resulted in extremely poor performance). - Mon Aug 3 03:31:02 2015 +0800
+commit812 - SP193 - Fixed VMC size parameter for USB support, simplified LSN calculation for the first phase of cdrom_read() since integer division will truncate anyway, changed stray memcpy() call in fat.c to mips_memcpy(), fixed (updated) the delete and rename functions within supportbase, and fixed updating of the game list under USB mode after an item has been deleted/renamed. - Mon Aug 3 01:13:56 2015 +0800
+commit811 - Jay-Jay - Update LNG files credits and dates for OPL r811. - Sat Aug 1 16:37:38 2015 -0700
+commit810 - Woon Yung Liu - Merged in Jay-Jay/open-ps2-loader (pull request #23) - Sun Aug 2 03:39:44 2015 +0800
+commit809 - SP193 - Imported fixes for SMAP (wrong watermark value) and IOMAN (incorrect declaration for lseek) stuff, fixed GSM extension's "ok" button, added patch entry for SRW IMPACT LE, removed NBNS's Rules.make file in favour of the common one, and adjusted in-game FAT driver's parameters and strategy to improve seeking performance. - Sun Aug 2 03:38:49 2015 +0800
+commit808 - Jay-Jay - Update more LNG files. - Tue Jul 28 13:29:14 2015 -0700
+commit807 - Jay-Jay - restored Makefile changes to default from last pushed commit, sorry - Tue Jul 28 09:13:12 2015 -0700
+commit806 - Jay-Jay - added a new word to LNG SRC files so it can be used to replace the word SETTINGS in the footer of main page so it can abbreviated in the LNG files without affecting the same full word in other areas; updated LNG files to include new changes in recent commits; French LNG updated 100% translated. - Tue Jul 28 09:08:30 2015 -0700
+commit805 - Woon Yung Liu - Merged in Jay-Jay/open-ps2-loader (pull request #22) - Tue Jul 28 20:11:29 2015 +0800
+commit804 - SP193 - Added missing files from previous commit, removed leftover SMB DMA address definition (disused since long ago) and removed leftover code that updated ReadPos (is now updated by CDVDMAN itself, not by the individual drivers). - Tue Jul 28 15:39:25 2015 +0800
+commit803 - SP193 - Added a small FAT driver to in-game USB support. USB support no longer needs total disc image defragmentation and all sector sizes should be supported. For as little impact on performance as possible, use as large cluster sizes as possible (up to 64KB). - Tue Jul 28 14:21:03 2015 +0800
+commit802 - Jay-Jay - Updating some LNG files. - Mon Jul 27 01:46:03 2015 -0700
+commit801 - SP193 - Changed game list-locking mechanism to use a semaphore, game list will now be locked when updated and drawn (mutually exclusive operations), deferred GUI operations will be cleared when the GUI is to be suspended (otherwise a crash might result because the requests would be for the previous GUI instance), fixed ELFLDR (wrong compile-time flags, hence IOP reset missing) by removing the RESET_IOP option, re-ordered code that checks for outstanding deferred GUI operations (guiHandleDeferredOps) to prevent potential crash if the linked-list is modified as it waits for the list to be unlocked (not done here, but IF), lowered the priority of the running thread to 90 in ioBlockOps() as it was starving lower-priority (NETMAN) threads, and removed redundant calls to SifInitRpc() in sysExecElf and sysLaunchLoaderElf. - Mon Jul 27 05:12:21 2015 +0800
+commit800 - SP193 - Refactored config reading system to allow reading of config file from RAM (for future use), fixed IOMAN crashing due to the request list being set to NULL as it waits for the process sema to be released, fixed OPL getting stuck if HDLDump server could not be started, refactored directory-creation system to be unified and without the need for a redundant check, changed GSM controls to become read-only if GSM is disabled, completed moving the GSM stuff into pggsm.h, added missing "childproof" target into Makefile, consolidated the different IO handler types into opl.h, updated to build with the latest PS2SDK revision, added support for DNS (for future use and manual static setting will not be saved!), added a setting into opl.h that determiens whether the OPL source is a development version, blocking I/O operations in IOMAN will no longer pause I/O execution (oustanding I/O operations will be completed), the I/O request sema will be locked when the number of I/O requests are counted, error messages will now be cleared when HDLDump server is started, failures to start the HDLDump server will be stated, CFG folder will now be "CFG-DEV" instead for development builds, changed config-handling code to use the limits from config.h for key and value management, and changed network initialization to prevent deadlocks that occur during simultaneous initialization of HDLDump and SMB support. - Sun Jul 26 03:40:05 2015 +0800
+commit799 - SP193 - Fixed SMB auto-refresh (CD, DVD and USBExtreme lists checked one-by-one) and refactored code in CDVDMAN and MCEMU for better coherency (USB, SMB and HDD-split up into individual files, for as much as possible). - Sun Jul 12 20:40:11 2015 +0800
+commit798 - SP193 - BUGFIX: Replaced all calls (and related macros) to the FILEIO RPC service with FILEXIO. OPL is intermittently unstable when listing games, as the rom0:FILEIO module does not suspend interrupts before the DMA transfers for the dread() and getstat() functions (SONY BUGBUG!!). - Sat Jul 11 03:25:55 2015 +0800
+commit797 - SP193 - Fixes: Added check for streaming status into CDVDMAN streaming system (for games that read after starting streaming), fixed broken CDVDMAN debug build, changed ambiguous debug strings in CDVDMAN, fixed length checking of ISO filenames and improved on error-handling code in supportbase.c. - Sat Jul 11 03:17:13 2015 +0800
+commit796 - SP193 - Fixed and enhanced streaming support: 1. BUG: sceCdStRead() incorrectly updates the remaining amount to read. 2. BUG: sceCdStRead() may lock up because it clears event flag bit 8 after ReadSectors() is run, but the drive might have re-set the bit before that is done. 3. Moved EE-side streaming support into CDVDMAN to avoid needing to use memcpy into the CDVDFSV DMA buffer. SCEI had two sets of the streaming mechanism for the EE and IOP, but we want to save memory for SMB support. 4. Changed the reading thread signaling system back to using a semaphore because the streaming callback (run from reading thread itself) could not issue another read request directly. The use of SetAlarm introduces a needless delay. - Sun Jun 28 18:18:52 2015 +0800
+commit795 - SP193 - Consolidated error codes, added error codes for HDD mode, sync'ed with updates to HDD and PFS from PS2SDK, added workaround for clone/compatible network adaptors and corrected UV coordinates for texture-drawing. - Sat Jun 20 20:06:02 2015 +0800
+commit794 - SP193 - Fixed NBNS support (unable to resolve NB names after first attempt), revised timeout clock value and adjusted code to prevent some other race-conditions from occuring, adjusted SMB support initialization code to always retry until the link mode can be set successfully, changed link mode setting and DHCP completion-checking intervals to 1 second (reduce strain on IOP), link mode will now be set once at initialization before the TCP/IP stack is initialized (avoid double-initializing the SMAP). Updated to support the new PS2SDK revision. - Tue Jun 16 21:50:14 2015 +0800
+commit793 - SP193 - Fixed SMB intialization when built within VMC support, by moving the SMB initialization function into the "oplsmb" export table. Added new message for Ethernet link errors (no connection). Updated the APA, PFS and USB drivers (changes from PS2SDK). Fixed incorrect address for adjusting the storage location of the UDNL module, within src/system.c. - Sat May 30 13:02:35 2015 +0800
+commit792 - SP193 - Moved SMB authentication code into a SMBINIT IOP module, so that SMB code can be modular and won't be part of the EE core itself. Fixed support for the USBLD format under SMB mode, renamed mode 5 to "Emulate DVD-DL", fixed filesystem selection within cdvdman_findfile() for mode 5, fixed NBNS support to check against the transaction ID as specified in the RFCs, changed the EE-side libnbns library into a normal C file for simplicity, and lowered the module storage region so that the occupied region will be as low as possible since SMB authentication code is now in an IOP module. - Thu Apr 16 21:59:05 2015 +0800
+commit791 - SP193 - Rolled back the new changes to the UI's behaviour, added error-reporting code (reports READCF* errors) to reading functions within CDVDFSV, got ReadIOPM and ReadChain functions within CDVDFSV to report read progress to the EE library, added a new workaround for the SIF becoming unusable after an IOP reset with ongoing DMA transfers. - Sun Mar 29 16:35:13 2015 +0800
+commit790 - SP193 - Updated to use the new SIF register definitions, to support automatic screen switching and hiding, USB, HDD and APP modes are now always enabled, added a toggle for hiding advanced network options, fixed CDVDFSV initialization (Initializing SIF on the main thread causes the IOP reset to stall; refer to SCE docs), fixed open(), dopen(), read(), dread() and getstat() to first wait for the, drive to become ready (and for read, forever attempt to read) to be in-line with the original behaviour of CDVDMAN, DEV9 will no longer be powered-off during IGR, the SIF register BOOTEND flag will now be cleared before every IOP reset, within the EE core to ensure correct behaviour, updated network support to ensure that timeouts are accurate regardless of the current video mode. - Sun Mar 22 19:14:28 2015 +0800
+commit789 - SP193 - Updated to support the new PS2SDK revision, changed module management so that only the necessary modules will remain resident in-game, changed unloadPad() to call padEnd() instead of padReset() in order to actually stop the PADMAN RPC service, re-added the "ei" instruction to crt0, fixed the logic that determines whether the IP address config has been changed (When DHCP is enabled, re-arranged the EE core so that modules (0x0009A000) will now be stored after the EE core (0x00088000). - Tue Mar 3 21:35:40 2015 +0800
+commit788 - SP193 - Updated to work with the new update to the PS2SDK (mainly with the renaming of the EE PS2IP over SIF RPC library, ps2ip, to ps2ips). - Sat Feb 28 21:32:31 2015 +0800
+commit787 - SP193 - Changed OPL to use NETMAN and PS2IPS for full control over the network subsystem, SMAP (re-)initialization will no longer be done whenever unnecessary (valid link state = not needed) and renamed "smap" to become "smap-ingame". - Sat Feb 28 15:58:29 2015 +0800
+commit786 - SP193 - Updated to support the new PS2SDK PS2IP module (LWIP v1.4.1) and updated PS2ETH SMAP driver, while yet maintaining support for the (in-game) SMSTCPIP stack which was based on an ancient version of LWIP. - Sat Feb 28 14:38:40 2015 +0800
+commit785 - SP193 - Added support for the NBNS protocol, added functions for changing the visibility and type of UI elements without hardcoding the element's index number, changed the keyboard to hide passwords, and adjusted language string and some function names. - Sun Feb 22 16:24:52 2015 +0800
+commit784 - SP193 - Added patches for Oneechanbara, Ratchet and Clank: Up Your Arsenal and updated SMAP. - Fri Feb 20 13:44:46 2015 +0800
+commit783 - SP193 - Removed space-filler code in EESYNC, which is found only in some EESYNC versions, presumed to make up for the lesser space taken up by a Debug SECRMAN module. The export table has been removed too, as no module ever links with it. - Fri Feb 13 15:28:26 2015 +0800
+commit782 - SP193 - New compatibility mode 1 (accurate reads) and the user callback will no longer be called during streaming (incorrect behaviour). - Fri Feb 13 15:23:56 2015 +0800
+commit781 - SP193 - Fixed IOP resets with command lines that are not NULL-terminated (e.g. SOCOM games), added path-purification for cdrom_getstat(), "untweaked" the TCP/IP stack for GUI mode (better performance), fixed screen rendering (screen cut-off) under 480P mode, fixed default-theme scaling, added/fixed missing/incorrect UI hints. - Sun Feb 1 21:22:41 2015 +0800
+commit780 - Jay-Jay - upload new background image - Wed Jan 28 23:09:41 2015 -0800
+commit779 - Jay Jay - Merged ifcaro/open-ps2-loader into default - Wed Jan 28 22:59:46 2015 -0800
+commit778 - Jay-Jay - remove background image to be able to sync with ifcaro repo - Wed Jan 28 22:59:06 2015 -0800
+commit777 - Jay-Jay - upload new background image - Wed Jan 28 22:35:58 2015 -0800
+commit776 - Jay-Jay - replace old background image - Wed Jan 28 22:31:55 2015 -0800
+commit775 - SP193 - Updated to compile w/o warnings on new PS2SDK revision, modified GUI to support loading of embedded resources for the internal theme, added menu hints, added an option for changing the select button. - Wed Jan 28 23:18:46 2015 +0800
+commit774 - Jay-Jay - include bg_overlay.png background image - Tue Jan 27 23:35:32 2015 -0800
+commit773 - Jay Jay - Merged ifcaro/open-ps2-loader into default - Sat Jan 24 03:21:25 2015 -0800
+commit772 - SP193 - Increased buffer size for path parsing to 32-bytes to handle slightly-malformed paths like how SCE does, fixed broken debug printf() statement, removed unnecessary checks that should be only used for debugging (as SCE doesn't perform them), added an additional backslash to SMB paths for compatibility with some SMB servers and changed the ELF-loading error screen (white) to be always shown regardless of the debug enabled/disabled setting. - Thu Jan 22 21:39:00 2015 +0800
+commit771 - Jay Jay - Merged ifcaro/open-ps2-loader into default - Tue Jan 20 15:12:41 2015 -0800
+commit770 - SP193 - Changed cdrom_open() to set f->mode to O_RDONLY for games that fail to specify O_RDONLY, re-adjusted the path-sanitizing code to function from only cdrom_open() in order to not affect cdrom_dopen(), and corrected non-compliant behaviour of (in-game) SMB support. Fixes for non-compliant SMB support: 1. Client capabilities, when specified for SetupSessionAndX, will now be the server's reported capabilities AND'ed with the client's. 2. Flags2 of every command will now have the SMB_FLAGS2_32BIT_STATUS bit set. Also so that error codes will be properly handled by packet-sniffers like WireShark. - Tue Jan 20 20:13:51 2015 +0800
+commit769 - Jay-Jay - update opl.icn made it smaller in size with help from sav3r and updated icon load png files to match new modified opl logo key - Mon Jan 19 01:39:50 2015 -0800
+commit768 - Jay-Jay - made opl.icn smaller in size with help from sav3r and updated load png files to math new OPL logo key - Mon Jan 19 01:32:13 2015 -0800
+commit767 - SP193 - Fixed DVD-DL parameter passing for USB and SMB modes, fixed ISO filename handling (ISO file name without the startup file name) in USB mode. - Sat Jan 17 18:30:20 2015 +0800
+commit766 - Jay Jay - Merged ifcaro/open-ps2-loader into default - Fri Jan 16 23:29:57 2015 -0800
+commit765 - SP193 - Replaced the path-sanitizing code with something closer to the SCE-original, and fixed cdrom_dread() to NULL-terminate the filename. This replacement of the path-sanitizing code is also to get rid of the mistake that I made, which was to directly handle the filename of the file on the disc image, without first copying it out and NULL-terminating it. - Sat Jan 17 12:22:24 2015 +0800
+commit764 - SP193 - Fixed DVD-DL detection over SMB for images >4GB, fixed DVD-DL handling for USB and SMB, updated OPL to support the new GCC 3.2.3 toolchain. - Sat Jan 17 12:17:15 2015 +0800
+commit763 - Jay-Jay - update logo.png in gfx folder - Tue Jan 13 01:39:53 2015 -0800
+commit762 - SP193 - Fixed USBD module loading, DVD9 detection, one printf string in CDVDMAN (potential use of uninitialized pointer)  and EP's name in the credits. - Sun Jan 11 14:22:16 2015 +0800
+commit761 - SP193 - Prototype attempt at fixing DVD-DL support within PS2ESDL for USB and SMB modes. - Sat Jan 10 23:08:56 2015 +0800
+commit760 - SP193 - Fixed UI freezing while user cycles through the games list, rolled back changes to the rename() function of the APA driver, integer values in the UI can now wrap around, changed module loading for better performance, fixed theme loading from USB devices, users no longer have to name their ISO images in a specific format and removed debugging code from regular OPL builds. - Sat Jan 10 13:47:04 2015 +0800
+commit759 - Jay-Jay - made new gfx icons, removed logo.old, change default theme background color. - Fri Jan 2 13:28:22 2015 -0800
+commit758 - Jay-Jay - add missing logo.old to gfx folder - Wed Dec 31 14:32:48 2014 -0800
+commit757 - Jay-Jay - clean up old gfx files - Wed Dec 31 14:16:10 2014 -0800
+commit756 - Jay Jay - Merged ifcaro/open-ps2-loader into default - Wed Dec 31 14:02:07 2014 -0800
+commit755 - Bat Rastard - Aaand the Scheisse-Kopf Award goes to yours truly. For having convinced a sick and hopped-up-on-serious-meds SP193 in helping me break CHEAT in the most annoying ways. *facepalm* - Sun Dec 28 07:57:58 2014 -0500
+commit754 - Bat Rastard - Removed broken game label in GSM screen; removed developer comments. - Wed Dec 24 12:28:28 2014 -0500
+commit753 - SP193 - Fixed cheats support again, renamed the extension to .CHT from .cht (to be uniform with the naming convention of other OPL-related files), and corrected boundary-limiting when printing the path to the cheat record file in all modes. - Thu Dec 25 00:57:51 2014 +0800
+commit752 - Jay Jay - Merged ifcaro/open-ps2-loader into default - Wed Dec 24 08:33:10 2014 -0800
+commit751 - SP193 - Fixed cheats support. - Thu Dec 25 00:18:17 2014 +0800
+commit750 - SP193 - Removed unused compatibility mode 9 strings, added missing cheats status/error messages, updated art assets and modified the cheats engine to not use memory at 0x00080000 directly. - Thu Dec 25 00:01:21 2014 +0800
+commit749 - Jay-Jay - delete logo.old_old file from gfx folder - Wed Dec 24 03:17:31 2014 -0800
+commit748 - Jay-Jay - update gfx artwork - Wed Dec 24 02:55:10 2014 -0800
+commit747 - SP193 - Fixed SMB support and updated changelog. - Wed Dec 24 10:06:56 2014 +0800
+commit746 - SP193 - Updated changelog files, removed unused UI strings, updated UI string labels, replaced the hardcoded use of tools within Makefiles with variables like $BIN2S, merged support for the CXD9566R into general DEV9 support, and removed power-on code from in-game DEV9 driver. - Tue Dec 23 23:35:00 2014 +0800
+commit745 - Bat Rastard - (*) Our "About" menu now has a "Quality Assurance" section, officially showing thanks to those who test our Alphas, keep us from neglecting USB mode, author tools the compliment our work, and being the first to tell us either something in OPL or the homebrew PS2SDK is broken. - Thu Dec 18 13:35:27 2014 -0500
+commit744 - SP193 - Re-added the GET HEADER IOCTL2 function, to the APA driver. Updated the English translation template. - Sat Dec 13 14:52:32 2014 +0800
+commit743 - SP193 - Sync'ing with the HDD and PFS driver updates from PS2SDK, fixed freezing when the HDLDump server is closed and the games list is reopened, completed TODOs in ioman.c, removed workaround from config.c, added missing UI hints and changed the region-handling code to default to Japan. - Sat Dec 13 00:38:24 2014 +0800
+commit742 - SP193 - Removed tag 0.9.3 - Fri Dec 12 16:06:42 2014 +0800
+commit741 - SP193 - Removed tag 0.9.3 - Fri Dec 12 16:06:37 2014 +0800
+commit740 - SP193 - Removed tag 0.9.3 - Fri Dec 12 16:06:36 2014 +0800
+commit739 - SP193 - Removed tag 0.9.3 - Fri Dec 12 16:06:36 2014 +0800
+commit738 - SP193 - Removed tag 0.9.3 - Fri Dec 12 16:06:35 2014 +0800
+commit737 - SP193 - Removed tag 0.9.3 - Fri Dec 12 16:06:34 2014 +0800
+commit736 - SP193 - Removed tag 0.9.3 - Fri Dec 12 16:06:07 2014 +0800
+commit735 - SP193 - Rewrote HDD support to use the PS2 APA driver instead of HDLDump's code. HDLDump's code was not designed properly for deleting partitions. - Wed Dec 10 22:37:03 2014 +0800
+commit734 - SP193 - Dumbed-down the locking mechanism to use only sync_flag, as the use of the event flag APIs will still not totally protect against simultaneous access from an interrupt handler (It'll probably only fully work if the whole code was run from a syscall, but even SCE never did that). - Sun Nov 30 16:02:34 2014 +0800
+commit733 - SP193 - Modified cdrom_read() to minimize the number of copy processes. - Sun Nov 30 15:57:45 2014 +0800
+commit732 - SP193 - Added a fully streaming system. - Sun Nov 30 15:55:35 2014 +0800
+commit731 - SP193 - Fixed sceCdChangeThreadPriority to not change the main thread priority* and added RPC support for it, added thread IDs for OPL's threads**, and added support for a streaming function callback***. *Although the original SCE code was broken there (main thread priority adjusted to 8, but not changed back), it might not work well for OPL because its main thread priority is 15. **For debugging. ***For the new streaming system, which will be implemented in the next commit. - Sun Nov 30 15:29:16 2014 +0800
+commit730 - SP193 - Replaced the old signaling system with one that works more like the SCE original, and fixed an age-long offset-calculation bug in CDVDFSV. - Sun Nov 30 15:09:37 2014 +0800
+commit729 - SP193 - Removed the use of (internal & non-standard) sceCdRead0 function, old (unused) reading core and refactored the reading system. - Sun Nov 30 14:13:05 2014 +0800
+commit728 - Bat Rastard - (*) Useless GSM VMODE Removal (1st draft) (*) Cosmetic changes (ala SARDINE) (*) Updated DETAILED_CHANGELOG (*) Repository frozen - BatRastard inactive until further notice. - Thu Nov 20 04:11:28 2014 -0500
+commit727 - Bat Rastard - (*) Hey Bat, try not to break non-GSM builds of OPL next time, willya?!? *LOL* - Mon Nov 10 13:09:00 2014 -0500
+commit726 - Bat Rastard - (*) Decided to let the new logo escape the asylum. Those who want to classic logo back, rename the two files accordingly. (*) Logo may be temporary - animated splash screens were mentioned! ;) (*) Sync-Merge with Ifcaro - repo frozen until SARDINE is done. - Mon Nov 10 04:42:25 2014 -0500
+commit725 - Bat Rastard - Sync-Merged with ifcaro/open-ps2-loader - Sun Nov 9 16:11:59 2014 -0500
+commit724 - Woon Yung Liu - Merged in Aced14/open-ps2-loader/ps2rd-max-codes-250 (pull request #11) - Sun Nov 9 19:16:08 2014 +0800
+commit723 - Aced14 - Increased ps2rd's cheat line limit (MAX_CODES) to 250. - Sun Nov 9 04:25:05 2014 -0500
+commit722 - Bat Rastard - (*) Per-Game GSM is COMPLETE! Repository frozen for now. Thanks to SP193 for the code needed in supportbase.c. That was light at the end of that tunnel. - Sat Nov 8 16:25:46 2014 -0500
+commit721 - Bat Rastard - (*) Whoops! - Sat Nov 8 10:30:24 2014 -0500
+commit720 - Bat Rastard - (*) Went to far re-globalizing GSM (*) Fixed compilation error in supportbase.c (*) No activity here for the weekend unless I start feeling better. Seeing chiropractor Monday afternoon, and there's a chance he won't adjust my neck and upper back without an MRI. I'm prepared to sign a waiver; it's hard to get an MRI and the results in a two week window. - Fri Nov 7 22:05:32 2014 -0500
+commit719 - Bat Rastard - (*) Re-globalized GSM (*) (SP193) Modified supportbase.c that should grab GSM's settings upon game launch. Keyword being should. Untested as I'm ressurecting a tin of sardines. (*) For some reason, the game label doesn't show up in the "Configure GSM" screen. Ignore it for now. - Wed Nov 5 19:51:47 2014 -0500
+commit718 - Bat Rastard - (*) Per-Game GSM Complete (I think). There were two solutions to the issue. I made a test build for RandQalan based on "Solution One" and pushed this commit based on "Solution Two" that I'll be testing shortly. I have slightly higher confidence in "Solution Two" as it only changes my integration and clean up code, and leaves "guiShowGSConfig()" alone (as opposed to "Solution One" which alters "guiShowGSConfig()" and leaves the integration and clean up code alone). Expect an OBT real soon! - Mon Nov 3 23:31:15 2014 -0500
+commit717 - Bat Rastard - Merged ifcaro/open-ps2-loader into default - Mon Nov 3 15:34:49 2014 -0500
+commit716 - SP193 - Improved IGR stability (E P), fixed MC slot 1 use when a VMC is mounted as the 2nd slot (E P), fixed art drawing, fixed poor game list loading performance and brought forward texture cache initialization. Other notes: 1. A stray line was draw for game art covers as their UV coordinates were not centered. 2. Poor game list loading performance resulted from the GUI taking up too much CPU time, so the main thread's priority was lowered. 3. Texture cache initialization was originally done after the game lists and art are loaded. However, that would take a long time if the user has a long of games and/or art, leaving the user to stare at a blank screen. It has been moved forward so that the user will get to see at least the OPL logo, as a sign that OPL is alive and running. - Mon Nov 3 21:35:05 2014 +0800
+commit715 - Bat Rastard - Added tag 0.9.3 for changeset 1fbd6857681b - Sat Nov 1 10:26:48 2014 -0400
+commit714 - Bat Rastard - (*) Per-Game GSM (In One Commit) - couldn't make sense of the shit I had committed in phases. So I made a backup, restored, remerged, and stripped the previous "phase" commits. All the previous issues still remain. It looks like I need something in "hddsupport.c" in the game launch section but I can't be certain anymore ... (*) Anything else from the 'phase' commits that was not GSM related was removed in order to make sync-merging life easier. SP193 has outstanding commits to Ifcaro that he'll most likely push by Monday. - Sat Nov 1 10:26:12 2014 -0400
+commit713 - SP193 - Replaced all obsolete Makefile rule files with a common file and integrated the discID module into the EE side. - Tue Oct 14 22:29:01 2014 +0800
+commit712 - SP193 - Changed auto-refresh behaviour and fixed the SMB reconnect option: 1. USB mode will always have auto-refresh enabled, regardless of the setting. 2. SMB mode's auto-refresh has been changed to 300 frames. 3. The SMB reconnect option has been fixed; it will appear even after an error 300 (connection error) occurs. - Sun Oct 12 23:13:38 2014 +0800
+commit711 - SP193 - Updated the GUI to have device-dependent refresh rates and moved some of the static buffers in CDVDMAN onto the stack. 1. The device-dependent refresh rates is to cater for the unique needs of the different interfaces. 2. Improved on USB device detection, by increasing the frequency of polls on the USB device and using the new USBHDFSD APIs that allow the software to check on the USB device's status. This should allow faster detection of connects/disconnects without significantly increasing the strain on the IOP. 3. Some of the buffers (Within cdvdman_locatefile and related functions) in CDVDMAN were shrunk and moved onto the stack to reduce its memory footprint. - Fri Oct 10 23:19:40 2014 +0800
+commit710 - Woon Yung Liu - README edited online with Bitbucket - Tue Oct 7 09:20:45 2014 +0000
+commit709 - Woon Yung Liu - README edited online with Bitbucket - Tue Oct 7 09:18:40 2014 +0000
+commit708 - SP193 - Fixed DEVCTL code handling in CDVDMAN, syntax errors and SMB mode error handling when there isn't a network adaptor attached. - Tue Oct 7 16:57:28 2014 +0800
+commit707 - SP193 - Improved on the reliability of USB support, added more error messages for SMB and removed VSYNC mode: 1. I've attempted to make USBHDFSD follow the USB Bulk-Only Transport standard, so that it will not freeze when dealing with malfunctioning devices. 2. SMB support now has new error codes: 304 and 305. 3. The VSync setting has been removed, so that the main thread will sleep and give the lower-priority threads CPU time. - Tue Oct 7 01:57:13 2014 +0800
+commit706 - SP193 (ysai187 - Fix for Crash Bandicoot: The Wrath of Cortex. Raised thread priorities of the TCP/IP stack and USB modules, to work around the bug in games like Crash Bandicoot: they have thread(s) that busy-loop. MUST BE COMPILED WITH THE NEW PS2SDK REVISION. - Mon Oct 6 00:00:36 2014 +0800
+commit705 - SP193 (pirorin187 - Fixes: 1. The CDVDMAN callback timer is not initialized if the user does not input a value. 2. DiskID within CDVDMAN is not copied properly (started at offset 1 instead of 0). - Sun Oct 5 08:31:44 2014 +0800
+commit704 - sp193 (pirorin187 - Fixes and optimizations: 1. Fixed the poweroff behaviour when IGR is disabled. 2. Optimized CDVDFSV and CDVDMAN to use switch/case statement blocks instead of just hardcoded jump tables, in order to allow the compiler to decide on the best way to optimize the modules. 3. Removed code from the GUI's ioman module which dealt with manual thread-switching. 4. Reduced the stack sizes of CDVDMAN's internal threads. - Sat Oct 4 09:39:20 2014 +0800
+commit703 - sp193 (pirorin187 - Rewritten the patching system and how parameters are passed to IOPCORE, for maintainability. Other fixes/enhancements: 1. Corrected the ID for Super Robot Wars IMPACT. 2. Modified USBHDFSD to use iomanX, so that the rename function can be accessed by OPL. The rename function should now be working for USB devices. 3. When IGR is disabled, pressing the power button should switch off the console. - Sat Oct 4 03:45:38 2014 +0800
+commit702 - Woon Yung Liu (pirorin187 - Added a patch for Super Robot Wars IMPACT, and optimized CDVDMAN's callback functionality. Special thanks to SilverBull for the patch details! - Fri Oct 3 05:35:49 2014 +0800
+commit701 - sp193 (pirorin187 - Fixed CDVDMAN initialization. Fixes: SSX World Tour and the Harry Potter series. - Tue Sep 30 08:54:16 2014 +0800
+commit700 - sp193 (pirorin187 - Updated USBHDFSD to support disks >1TB and <=2TB (Sync'ed with PS2SDK update). - Tue Sep 30 01:01:15 2014 +0800
+commit699 - sp193 (ysai187 - Corrected path handling, which was broken in commit e5e85f0. Added the missing udnl_asm.s file to udnl-t300, for DTL-T10000 support. - Sun Sep 28 09:44:28 2014 +0800
+commit698 - sp193 - Fixes and updates: 1. Updated to use the updated USBD module from the PS2SDK, which has been fixed to support the PS3 and appears to not suffer from that pause which occurs whenever any of its previous versions load. 2. Removed support for the USB delay option. I think that it's just working around a threading problem within CDVDMAN, which I've solved by adding a call to DelayThread() within the USB device initialization loop. That should give the USB drivers CPU time and not freeze up the IOP. 3. Updated the GUI to use an enum for its GUI IDs, so that the code will be easier to maintain and would be neater. - Mon Sep 8 20:36:57 2014 +0800
+commit697 - sp193 - in-game SMB fixes and enhancements: *Fixed the size of the WriteAndXRequest structure of the SMB module. *Attempted to replace most of the hardcoded values with sizeof() statements. *Optimized SMB support by hardcoding some of the fixed values, to save CPU time during reads and writes. - Wed Aug 20 22:47:26 2014 +0800
+commit696 - SP193 - Added an option for DTL-T100dded an option for DTL-T10000 support, since this unit can have a different set of IOP modules in its flash ROM. The option will cause OPL to not use the undocumented SIO2 modules from ROM (SIO2MAN, MCMAN, MCSERV and PADMAN). The IOP will be also reset with "rom0:UDNL" as the command instead, in order to get the TOOL to load the standard debugstation modules. ibootp must be set to 0x100 and ebootp to 0x000F0000. - Mon Aug 4 13:07:19 2014 +0800
+commit695 - doctorxyz - SP193: FreeType fix - Sat Jul 12 16:07:03 2014 -0300
+commit694 - doctorxyz - More Makefile fixes - In order to CHILDPROOF, RTL, GSM and CHEAT switches work properly - Wed Jul 9 19:37:45 2014 -0300
+commit693 - doctorxyz - Makefile fix to build without PS2RD Cheat Engine (CHEAT = 0) - Wed Jul 9 15:43:00 2014 -0300
+commit692 - doctorxyz - EE Core - Only Install PadOpen Hook if IGR is enabled - Fri Jul 4 08:47:43 2014 -0300
+commit691 - SP193 - Merged doctorxyz's commit with mine. I've also removed the old alternate EE core Makefile and linkfile, and replaced the "sync; ei" instruction sequence within ee_core/src/padhook.c with ExitHandler(). - Thu Jun 26 19:13:48 2014 +0800
+commit690 - doctorxyz - OPL+PS2RD Cheat Engine Integration - Mon Jun 23 08:20:53 2014 -0300
+commit689 - SP193 - Updated OPL to compile with the new PS2SDK. Applied the month field fix to the USBHDFSD, HDD and PFS modules, as well as OSDHistory.c. The old CDVDMAN module does not automatically file off the most significant bit of the month field, hence why it must be done. Removed vmc/mcman, since it is unused and seemed to not be special... - Mon Jun 23 18:39:24 2014 +0800
+commit688 - SP193 - Fixed the theme bug and improved code: 1. Theme-loading bug fixed: the theme setting will not get reset if the video mode and/or VSYNC setting(s) are not left at their defaults. 2. Rewrote OPL to not used hardcoded buffer length values when invoking functions like strncmp, strncpy and snprintf. 3. Renamed include/usbld.h to include/opl.h. - Sun Jun 15 18:52:00 2014 +0800
+commit687 - SP193 - Sync'ing with the PS2SDK commit for today: the main point behind this commit is the rollback of the use of the pre and post-DMA callbacks within DEV9, for compatibility with a certain clone adaptor. The rest of the changes are related to the (minor) bugfixes from the PS2SDK commit. - Tue Jun 10 21:47:33 2014 +0800
+commit686 - Woon Yung Liu - Merged in psx_core/open-ps2-loader/psx_core/the-most-accurate-and-correct-translatio-1384761167035 (pull request #6) - Sun Jun 1 19:35:01 2014 +0800
+commit685 - SP193 - Fixed a buffer overflow problem in CDVDFSV and refactored all CDVDMAN defines: 1. In CDVDFSV, the code that reads data into the buffer defined by CDVDFSV_BUF_SECTORS can actually read up to CDVDFSV_BUF_SECTORS+1. This resulted in CDVDMAN's buffer overflowing. 2. In the process of remedying the problem, I've moved all the common CDVDMAN definitions from cdvdman.c and cdvdfsv.c into common/cdvdman.h, to reduce redundancy and to improve coherency. 3. Updated the README file of the UDNL module. - Fri May 9 21:50:36 2014 +0800
+commit684 - SP193 - Added a proper patch for Choujikuu Yousai Macross (SLPM-65405). - Thu May 1 17:01:58 2014 +0800
+commit683 - SP193 - Completed the integrated DECI2 debugging system and updated some log messages. 1. The UDNL module is now the first module in the module list. This is so that the DECI2-enabled version of this module can be moved into kernel RAM when required. 2. An integrated DECI2 debugging system has been added. It is based on RDB, which makes it share the same limitations as the Sony TDB startup card. 3. However, it seems like there may be problems with the ingame SMAP driver. It might be the old bug (where the network stack stops responding), since the problem now is that the network interface becomes totally unusable if DECI2 is loaded. 4. As a result, the normal SMAP driver will be used if DECI2 debugging is used. - Tue Apr 22 00:57:53 2014 +0800
+commit682 - SP193 (pirorin187 - Completed the incomplete modifications from the previous commit + enhanced IGR. 1. The new EE core was supposed to use the embedded UDNL module instead because the one in ROM does not disable DMA. USB support suffers because its DMA channel is capable of transfers without the IOP. 2. Added prototype DECI2 support (integrated RDB), but it is currently dysfunctional because there isn't enough EE RAM to store everything. Still a WIP... 3. Modified IGR to not hook threads during LoadExecPS2() and IOP resets. Also done for the sake of performance in SMB mode. 4. Re-added these instructions to the ends of interrupt handlers: "ei" and "sync". I was wrong about them not being required, after studying the Sony documents thoroughly. - Mon Apr 21 22:21:07 2014 +0800
+commit681 - SP193 (pirorin187 - changes.txt - Sat Apr 19 13:52:29 2014 +0800
+commit680 - SP193 (pirorin187 - Updated OPL to be fully compatible (compiles without the deprecated warnings) with the HEAD revision of the PS2SDK. There should be no differences in functionality from the previous revision. - Sat Jan 11 20:27:05 2014 +0800
+commit679 - psx_core - The most accurate and correct translation from english to russian by RA1n. (lang_Russian.lng edited online with Bitbucket) - Mon Nov 18 07:52:59 2013 +0000
+commit678 - SP193 (pirorin187 - *Changed the configGetString function to return a const value, since the configuration keys are not to be changed without configSetStr(), except for two lines within themes.c. This is to safeguard against accidental configuration corruption/overwriting. *Added a slightly modified version of the OSD game history updating system from FMCB, although it's disabled because it still isn't working right. - Wed Nov 6 13:16:17 2013 +0800
+commit677 - BatRastard - * Updating LNG files - Ethernet modes (among other things) were missing. * Reverting Arabic LNG with a backup. RTL probably broken. Hopefully, our   Arabic users will know how to fix it themselves. I'm tired of fighting   with it all. * CHANGELOG and DETAILED_CHANGELOG updated. - Fri Nov 1 12:42:36 2013 -0400
+commit676 - sp193 - Reverting the change in the previous commit. - Fri Nov 1 20:32:26 2013 +0800
+commit675 - sp193 - Fix for the workaround for the Chinese SATA network adaptor: I forgot that the register is 16-bit, which means that the adaptor probably reports 0xFFFF as its version number. - Fri Nov 1 17:43:16 2013 +0800
+commit674 - sp193 - *Ported over the workaround for Chinese SATA network adaptors (See the PS2SDK update for today). *png_init_io() is now called instead of png_set_read_fn() with a NULL value specified as the function argument. While the results are similar, it's probably not a good idea. *(mark_k) Replaced all PNG images with optimized PNG images (Optimized with PNGOUT), to save space. - Fri Nov 1 13:47:59 2013 +0800
+commit673 - BatRastard - * Rev672 tapped for release - updated changelogs. - Fri Oct 25 17:52:49 2013 -0400
+commit672 - SP193 (pirorin187 - *Replaced the TLB reinitialization mechanism with a built-in one. No more patching/hooking onto the EE kernel for that! Done partly for compatibility with the PSX. *Cleaned up code (Removed unreferenced definitions). *Changed all long ints in ee_core/src/des.c to just integers to save space and for the performance. *Removed leftover derelict GSM-enabling code from elfldr. *Ported the loader (elfldr in OPL) from FMCB v1.93, since I had already refined the loader there. *Fixed the saving of the result code from the SMB logon step. The correct SMB connection/logon error message should be displayed now. *Changed SysExecElf() to not accept any arguments since it was previously not coded properly to support that. No caller function every used that functionality anyway. - Thu Oct 24 15:13:40 2013 +0800
+commit671 - BatRastard - * Hey Bat! Try not to commit non-default changes to Makefiles next time, will   ya! ;) - Tue Oct 22 14:06:16 2013 -0400
+commit670 - BatRastard - * MASSIVE UPDATE - Consider deleting and re-cloning your local repos if   "hg pull -u" gives you merge issues! * Re-integrated GSM core (Version 0.36.R). This GSM core removes support for   576p, 1080p, any mode supported by 0.37. and 0.38. This is temporary as   GSM 0.38 is being reworked for more robust and stable re-integration. * GSM's "Skip FMVs" is no longer functional with this core, but it wasn't   removed since that could break something else, and it'll be coming back   anyway upon upgrading GSM back to 0.38 at a later date. * Modified Makefile - GSM not included in "Childproof" builds. * Modified GUI to refresh Main Menu when configuration is re-loaded. This fixes   a quirk where HDLSERV and GSM Settings didn't appear immediately. * Vanilla OPL no longer displays GSM-related functions such as the toggle and   GSM Settings Menu. * Launching a GSM-build of OPL after an IGR from Vanilla OPL could result in a   BSOD. Probably related to GSM and EELOAD. Powercyle the PS2 beforehand. * GSM-builds are now IGR compatible due to the 0.36.R core (YAY!) * Alpha tests reveal possible issues with SCPH-39006 and SCPH-15000 models not   launching OPL that may be related to either ps2-packer or GUI modifications   that were made to disable GSM-related options when "GSM=0" is set in the   Makefile. We need more test reports to determine the true nature of the beast   or if was just a one-off quirk. Considered a bug nonetheless ... - Tue Oct 22 13:55:08 2013 -0400
+commit669 - BatRastard - * Massive changes to GSM function calls - some of which were so similar that   they made ongoing progress about as fugly and frustrating as peeling apart a   grilled cheeze. So "gGSM" is now "gEnableGSM" and the previous EnableGSM()   is now StartGSM(), and so on and so forth. We needed some linguistic distance   between "Enabling/Disabling" a GUI function and "Starting/Stopping" a   module/service/thread etc. (Sorry if too drastic, SP193) ... * Rephrased some GSM menu items and hint dialog. * Massive lang refesh - again ... - Mon Oct 21 17:29:56 2013 -0400
+commit668 - BatRastard - * Anticipating blood-curdling scream from SP193! * Changed GSM toggle to "Show GSM on Main Menu" * Fixed the configSetStr() for GSM toggle * Temorarily restored some #ifdefs to system.c - they exist for the sake of   Vanilla OPL *ONLY*. It fails to compile due to GSM's function calls not   being properly defined via headers, thus throwing "undeclared function"   and "explicit declaration" warnings when compiling Vanilla OPL is attempted   (i.e. when "GSM=0" in the Makefile). * Cue blood-curdling scream from SP193! ;) * Joins SP193 in blood-curdling scream! *LOL* - Fri Oct 18 12:43:06 2013 -0400
+commit667 - BatRastard - * Cleaned up GSM code * Removed redundant #ifdefs - Wed Oct 16 17:05:23 2013 -0400
+commit666 - BatRastard - Added tag 0.9.2 for changeset 3eb5ac59e7a5 - Sat Oct 12 06:59:14 2013 -0400
+commit665 - BatRastard - (*) Refreshed language files (*) Set "GSM=0" in Makefile as default (*) Repository frozen (for real this time) - merge-ready into Ifcaro :D - Sat Oct 12 06:57:49 2013 -0400
+commit664 - BatRastard - (*) Aaaand after a half-assed busted GUI staring me dead in the face for over     week, the new "GSM Settings" on Main Menu item and "Reveal GSM On Main Menu"     toggle in "Settings" is LIVE! (and boy am I'm tired of looking at it! ;)     Once enabled, press Start twice on Main Menu to refresh the GUI ... (*) Repository frozen; ready for merge into Ifcaro ... - Fri Oct 11 17:49:17 2013 -0400
+commit663 - BatRastard - Updating CHANGELOG ahead of release - actual release revision can be added when necessary. Saves us some tedium. - Wed Oct 2 11:29:13 2013 -0400
+commit662 - BatRastard - * Rebase complete * Using unified Makefile - OPL and OPLGSM compiles from single source. * Vanilla OPL builds from this base will contain GSM settings under   "Display Settings" but toying with them could prove catastrophic as the    integrated GSM is not embedded when "GSM=0" is set in the Makefile. This    was done to preserve compatbility with PS2RD/Codebreaker. It is   HIGHLY recommended you leave "VMODE" to AUTO and ignore the GSM settings   completely. A future revision/release will contain a GSM on/off toggle   in "Settings" that'll automatically hide/display GSM options here much like   HDLSERV is hidden unless "Enable Rename and Delete" is on. * OPLGSM builds from this codebase should function properly with the usual   caveats such as IGR causing a problem with the GS chip on the PS2 that   triggers an IOP crash and incompatibility with CB/PS2rd. Also, there's a   chance that loading builds of OPLGSM from this codebase after IGRing from   a vanilla OPL build may cause a BSOD. Powercycle the PS2 first prior to   launching builds of OPLGSM from this code base if you experiance this. - Tue Oct 1 16:43:01 2013 -0400
+commit661 - SP193 (pirorin187 - *Modified compatibility mode 7 to not affect sceCdStRead(), as the streaming functions are already underperforming. *Updated the detailed changelog. - Wed Oct 2 00:17:01 2013 +0800
+commit660 - SP193 (pirorin187 - *Sync'ing the HDD module updates for the PSX. OPL should now run properly on the PSX. *Updated the HDPro ATAD module. *Removed the old compatibility mode 7 code. *Added a new compatibility mode 7: IOP threading hack. This is applicable to only the HDD mode, and basically causes a thread context switch (to give other threads more CPU time) before every read is made. This fixes stuttering in some games like DDR and Pop 'n Music. *CDVDFSV had its internal functions declared as static, and function type definitions have been added for the jump tables within it. - Tue Oct 1 23:04:45 2013 +0800
+commit659 - SP193 (pirorin187 - *Sync'ing HDD updates... again. *Updated modules/hdd/ps2hdd. I just realized that it wasn't updated in a long time. - Sun Sep 29 19:22:24 2013 +0800
+commit658 - SP193 (pirorin187 - *Sync'ing the updates in the PS2SDK with the ATAD modules here: common/include/atahw.h was updated, and all ATAD modules are using the commands defined within atahw.h. *Removed the "UDMA 5" and "UDMA 6" transfer modes from the UI, since the PlayStation 2 never supported those modes. *Updated SMB support to have better error messages for the common connection problems. *The network error codes have been changed slightly: 300 for connection errors, 301 for logon errors, 302 for errors related to the ECHO isalive test failing, and 303 for share opening errors. - Fri Sep 27 18:22:17 2013 +0800
+commit657 - sp193 (ysai187 - *Optimized CDVDMAN (Declared internal structures and functions as static). *Replaced inline assembly code that invokes syscall #14 with a call to SetVCommonHandler. *Removed the code that plays with the system initialization/restarting functions. That was put in place because the unpatched Protokernels had a ExecPS2() syscall that didn't clean up the kernel. With the complete Protokernel patch, this entire system is redundant. *Replaced code within the UI that manually powers off the DEV9 interface and the console with a simple call to poweroffShutdown(). *Modified the TLB initialization code to use _InitTLB (syscall #130) instead, if the amount of EE RAM is not 32MB. This is for compatibility with the PSX (DVR unit). *(doctorxyz): Fixed the Kingdom Hearts 2 Final Mix JPN Gummi Ship missions patch. *(doctorxyz): Exiting from the main menu will use the IGR exit path as well. *(doctorxyz): All coloured debug screens within the EE core will be disabled, when they are to be disabled. *(doctorxyz): Fixed Makefiles of those modules that generate map files to delete the mapfiles when they are cleaned up. - Mon Sep 2 15:21:49 2013 +0800
+commit656 - sp193 (ysai187 - The original files I modified couldn't be committed directly into the repository, so I had to check out a new copy of the repository and copy my changes over manually. Unfortunately, I forgot to copy the changes for SMAP driver in the UI. Sorry. - Thu Aug 8 14:22:12 2013 +0800
+commit655 - sp193 (ysai187 - *Updated ATAD (Normal ATAD and the HDPro version) to be the same as the ones from the PS2SDK. *Replaced the SMAP driver: 	1. modules/network/smap is a modified version of the ps2eth/smap-new driver, with the thread removed and with inline assembly to speed up word copying to and from the FIFOs. 	2. ps2eth/smap-new will be used for the UI, as it has better support for handling changes in the link state. 	3. smstcpip was modified to be support both SMAP drivers (Packed input within the normal thread context for the smap-new driver, and within the interrupt context for the modules/network/smap driver). *Added comments regarding the modified lwip_recvfrom function (It was always modified, but nobody mentioned that). *Removed code that transfers data to the uncached segment from CDVDMAN/smb.c. The uncached segment is a EE-thing, and doesn't refer to physical memory. *Ported a modified version of the Ethernet speed and duplex setting override control from doctorxyz's branch. - Thu Aug 8 14:12:32 2013 +0800
+commit654 - sp193 (ysai187 - *Re-added SPU reset code. CLEARSPU shouldn't be used and I was wrong about that. *Removed cache flush from the pad hooking code, using the uncached segment instead. This should reduce the impact IGR has on the EE. *Removed sync and ei instruction from the end of the IGR VBLANK_END INTC handler. Why does it have to be there and won't it be bad to change the processor state there? I never needed to use such instructions in any of my VBLANK interrupt handlers. :/ - Sun Jul 21 12:12:43 2013 +0800
+commit653 - sp193 (ysai187 - *Added sceCdPowerOff(). Games that power off the console should be able to do so now. *Modified the CD/DVD hardware interrupt handler to not acknowledge the power off interrupt event. The EE-side IGR code does that and has been missing the event. Invoking IGR via the power button should be working again. - Wed Jul 17 15:08:08 2013 +0800
+commit652 - sp193 (ysai187 - *Cleaned up IGR code. *Updated ATAD code to support a maximum block size of 65536 sectors for 48-bit LBA disks. - Wed Jul 17 13:12:54 2013 +0800
+commit651 - sp193 (ysai187 - Added power-off processing code. Games (mainly older one) that use it should no longer cause a deadlock. - Sat Jun 15 01:56:50 2013 +0800
+commit650 - sp193 (ysai187 - *Updated all DEV9 and ATAD module code. - Sat Jun 15 01:26:36 2013 +0800
+commit649 - sp193 (ysai187 - (AKuHAK): Updated OPL to support the updated LIBPNG port. - Sat Jun 15 00:52:08 2013 +0800
+commit648 - sp193 (ysai187 - Removed the integrated FreeType copy. Please update your FreeType library (From ps2sdk-ports)! - Sun Jun 2 20:44:40 2013 +0800
+commit647 - sp193 - *Removed the old Protokernel patch, since the PS2SDK now has a complete one. *Removed support for PS2LINK from within the CRT of the EE core. It was never used, and will never be used. - Thu Mar 21 00:11:48 2013 +0800
+commit646 - sp193 - *Removed the old Protokernel patch, since a full patch has been integrated into the PS2SDK. *Removed support for "loaders" within the CRT0 of the EE core. It will never be started from a thread, hence it's redundant. - Thu Mar 21 00:08:41 2013 +0800
+commit645 - doctorxyz - Added tag 0.9.1 for changeset 2ebb9bb56c19 - Mon Aug 13 06:00:01 2012 -0300
+commit644 - doctorxyz - Updated USBLD_VERSION to "0.9" - Mon Aug 13 05:57:32 2012 -0300
+commit643 - doctorxyz - Added tag 0.9 for changeset 830d78f67941 - Sat Jul 28 10:35:29 2012 -0300
+commit642 - doctorxyz - Updated CHANGELOG and DETAILED_CHANGELOG files - Sat Jul 28 10:35:22 2012 -0300
+commit641 - Hominem te esse - Disabling auto-refresh of game list by default, as it is causing bugs sometimes - Tue May 1 16:37:04 2012 +0200
+commit640 - Hominem te esse - mgh: fix for default HDD DMA mode, that wasn't correctly set - Thu Apr 26 22:46:24 2012 +0200
+commit639 - Hominem te esse - Suggestion from "mgh". - Mon Mar 26 22:40:28 2012 +0200
+commit638 - Hominem te esse - Fix a bug (in revision 426) which made "Mode 3 - Unhook Syscalls" un-effectivei ("Unhook Syscalls" was in fact activated by "Mode 7 - Reduced memory usage", which was setting both modes 3&7). - Sat Mar 24 22:08:24 2012 +0100
+commit637 - Hominem te esse - * fix for theme font handling (when switching back to the default theme, the language font wasn't re-applyied) * font code factorization - Sat Mar 24 00:21:03 2012 +0100
+commit636 - Hominem te esse - damn wide font ;) - Wed Mar 7 21:32:39 2012 +0100
+commit635 - Hominem te esse - Added hidden options to be able to define your own device delay before loading ART/config files. - Wed Mar 7 21:17:18 2012 +0100
+commit634 - Hominem te esse - layout adjustment - Wed Mar 7 20:54:36 2012 +0100
+commit633 - Hominem te esse - language files update - Tue Mar 6 19:31:33 2012 +0100
+commit632 - Hominem te esse - don't do HDD checks when no vmc configuref - Sun Mar 4 23:03:08 2012 +0100
+commit631 - Hominem te esse - fix for corrupted graphics when manipulating config files - Sun Mar 4 17:47:44 2012 +0100
+commit630 - Hominem te esse - SilverBull: apply a delay to CDVDMAN functions (initially for Shadow Heart 2) - Sun Mar 4 14:36:46 2012 +0100
+commit629 - Hominem te esse - adding i18n strings - Wed Feb 29 22:53:10 2012 +0100
+commit628 - Hominem te esse - Big up for Volca ... slowdown the busy icon - Mon Feb 27 21:18:00 2012 +0100
+commit627 - Hominem te esse - fix for wrapping artefact when display_mode=ALWAYS - Mon Feb 27 18:53:58 2012 +0100
+commit626 - Hominem te esse - remove useless code for compatibility mode 7 which is unused now. - Sun Feb 26 14:57:10 2012 +0100
+commit625 - Hominem te esse - fix for broken UL on ETH mode - Sun Feb 26 12:58:47 2012 +0100
+commit624 - Hominem te esse - make start/select button skinnable - Sat Feb 25 10:55:24 2012 +0100
+commit623 - Hominem te esse - make action buttons skinnable - Fri Feb 24 23:08:05 2012 +0100
+commit622 - Hominem te esse - small correction for gcc warning - Fri Feb 24 20:20:27 2012 +0100
+commit621 - Hominem te esse - * CRITICAL FIX for 4K disk. It was broken since the beginning for both UL and ISO (2 bugs, one when checking for the cluster size for UL, and one for UL/ISO when patching the usb_cdvdman_irx) * Fix for the ISO games filename extension that was required to be lowercase ".iso" (impact on Linux only). Now you can have any extension case you want. - Fri Feb 24 19:59:26 2012 +0100
+commit620 - Hominem te esse - Finalize the "list share" feature. Now you can list the share, select one from the list and OPL will connect it and display the games. - Mon Feb 20 23:22:33 2012 +0100
+commit619 - Hominem te esse - * fix a refresh bug introduced lately * maybe fix the HDD list not showing up at start - Sun Feb 19 17:44:06 2012 +0100
+commit618 - Hominem te esse - cosmetics again (prefixing every LOG by its location) - Sun Feb 19 16:32:35 2012 +0100
+commit617 - Hominem te esse - just some cosmetics - Sun Feb 19 15:46:15 2012 +0100
+commit616 - Hominem te esse - * don't display a share connection error when listing share * fix the VMC check, so we can run a game even if there is no OPL partition - Sun Feb 19 14:28:36 2012 +0100
+commit615 - hominem te esse - Hey Hominem ... don't commit shit you used for trying to reproduce some bug ;) - Sat Feb 18 11:43:45 2012 +0100
+commit614 - Hominem te esse - Adding ETHPrefix to fix the use of some box/NAS adding a sub path to the share - Sat Feb 18 11:16:58 2012 +0100
+commit613 - Hominem te esse - few changes to be able to refresh the menu from anywhere (should be used when selecting a share, after connecting to it, refresh the menu, but it doesn't work currently due to the info screen crashing ...) - Sat Feb 18 11:07:07 2012 +0100
+commit612 - Hominem te esse - * Add a feature to list network shares. Just let the sharename empty into network settings, and OPL will try to connect and list the shares (BUT then don't try to do anything with the share list, their are handled like games, but are not, so everything would crash) * change the PC IP/netmask/gateway to disable when the network module are loaded (as we can't change the PS2 IP after that) - Thu Feb 16 22:38:21 2012 +0100
+commit611 - Hominem te esse - * reverted some changes from rev500, finally crazyc was correct (when he skipped one vmc in error, but still wrote the structure in IRX but with flag as inactive) * fixed bug when checking VMC (if VMC0 was in error and not VMC1 you didn't got any message) * prepare stuff for eth prefix feature (name size at 64 to include the prefix) - Wed Feb 15 22:13:25 2012 +0100
+commit610 - Hominem te esse - load and use the internal LOGO before swapping theme (avoid flickering at startup) small fix with theme initialization (it is better to init textures before using them ;)) - Sun Feb 12 23:02:04 2012 +0100
+commit609 - Hominem te esse - NOTE: Concerning my comment in R606, I'm sorry Volca, the code wasn't "dangerous" and didn't write memory out of bounds (thanks to the check < MAX_GS_MODE) - Sat Feb 11 15:33:02 2012 +0100
+commit608 - Hominem te esse - fix small bug in alternate device mode, when loading config files (as we did a configEnd, we couldn't use the previously assigned config) - Fri Feb 10 18:41:41 2012 +0100
+commit607 - Hominem te esse - * fixed dangerous code (out of bounds memory writing in renderman) * clean lot's of stuff related to video mode * load vmode conf file only one time * removed useless vmode/vsync parameters (to applyConfig) and internal copies (renderman) - Fri Feb 10 00:19:28 2012 +0100
+commit606 - Hominem te esse - clarify the gui - Wed Feb 8 21:18:17 2012 +0100
+commit605 - Hominem te esse - Some changes in the way the network is "reloaded". - Tue Feb 7 23:06:20 2012 +0100
+commit604 - Hominem te esse - * Minor GUI changes (deferred error message display, small optim for main loop) * provide Error messages for network startup - Mon Feb 6 22:19:26 2012 +0100
+commit603 - Hominem te esse - Added "InfoHintText" element, to be able to put a small version of hints for the info screen. - Tue Jan 31 23:05:17 2012 +0100
+commit602 - Hominem te esse - Remove useless stuff (was thing for RTL transposition only, which will not be implemented after all as too complicated) - Tue Jan 31 22:18:03 2012 +0100
+commit601 - hominem te esse - Fix for space and punctuation characters. These one are weak/neutral and should not change the current rendering direction. - Tue Jan 31 21:49:25 2012 +0100
+commit600 - hominem te esse - Support for Right-to-Left scripting (Hebrew, Arabic, Syriac, Tifinar, ... languages) - Sat Jan 28 21:55:11 2012 +0100
+commit599 - Hominem te esse - merge (?) - Sat Jan 14 15:24:26 2012 +0100
+commit598 - Hominem te esse - Work around FOR PFS BUG with O_TRUNC Less flickering in info pane (forced attribute are displayed even without config, or when config is still loading) - Sat Jan 14 15:19:09 2012 +0100
+commit597 - Hominem te esse - Polishing things, full IO for loading/saving of config files, factorization, ... - Sat Jan 14 11:25:39 2012 +0100
+commit596 - Hominem te esse - automatically create the CFG folder - Sun Jan 8 13:59:22 2012 +0100
+commit595 - Hominem te esse - remove duplicate methods / factorization (need to ensure compatibility mode among other don't have regression) - Sun Jan 8 01:40:40 2012 +0100
+commit594 - Hominem te esse - Configuration related to DNAS/VMC/DMA/COMPAT are now saved in single per game files on each media. - Sat Jan 7 23:38:56 2012 +0100
+commit593 - Michaël Jimenez - l_oliveira: fix for SCPH-10000 with Sony Kernel update - Tue Oct 25 20:33:55 2011 +0200
+commit592 - Hominem te esse - fixed the alternate device mode. - Fri Oct 14 10:20:26 2011 +0200
+commit591 - Michaël Jimenez - fix for Kingdom Hearts 2: Final Mix(SLPM_666.75) gummi missions freezing - Mon Jun 20 18:09:10 2011 +0200
+commit590 - Michaël Jimenez - fix cdinited flag for SSX on Tour (broken in r585) - Thu Jun 9 17:05:57 2011 +0200
+commit589 - Michaël Jimenez - update to comply with the latest PS2SDK - Thu Jun 9 16:52:44 2011 +0200
+commit588 - sp193 - Fixed sceGetReadPos() to return the buffer offset in 2048-byte units (Updated dynamically). Fixes games like Castle Shikigami 2. - Wed May 4 16:40:35 2011 +0800
+commit587 - SP193 - Added new patch for Rugby League 2: World Cup Edition (PAL). - Sat Apr 30 22:29:07 2011 +0800
+commit586 - Michaël Jimenez - romz: added better cd tray emulation (fixes A2M games) - Fri Apr 29 17:48:50 2011 +0200
+commit585 - Hominem te esse - extracted code branching from ItemsList drawing and main drawing method - Wed Mar 9 23:39:07 2011 +0100
+commit584 - Hominem te esse - fix for the "alternate device mode" that was failing to re-read the configuration files from "mass" device - Sun Mar 6 01:42:13 2011 +0100
+commit583 - Hominem te esse - * use alignment for clipped/wrapped text * ItemsList can be "aligned" too now (but no real benefit, as then it requires the themer to define an explicit width/height) - Sun Mar 6 00:05:42 2011 +0100
+commit582 - Hominem te esse - ItemsList can now use clipping too. As a result, the "items" option for ItemsList has been removed. Now to limit the number of items being displayed, specify a "height" value. - Sat Mar 5 22:10:20 2011 +0100
+commit581 - Hominem te esse - * caching of last attribute value (for AttributeText/Image element), to not search the config file every frame * drawing text (font) do not use rmSetupQuad anymore, wasn't needed anyway (Also reduced branching for Pixmap/quad) * Image element have a new "scaled" option to define if the drawing of the Image should respect the screen scaling policy (for 4:3, or 16:9 adaptation). Background element use "scaled=0" by default to take the full screen width and height. * drawing text can used two mode for limiting the text size. When an element have a "width" or "height" defined, by default we use "clipping" (everything larger than width or height will not be drawn). With the "wrap=1" option for text element, you can change this default behavior to wrap the text instead. Finally if you don't define width/height, the full text wil be drawn, without any check. * Element width and height definition can use the string "DIM_INF" to mean "maximum/infinite" (bound to the max screenwidth/screenheight). This is to be used instead of putting the real max screen width/height (as "heigth=512"), as they may change depending of the use of NTSC/PAL. - Sat Mar 5 19:11:31 2011 +0100
+commit580 - Michaël Jimenez - cdvdfsv: implemented sceCdChangeThreadPriority export (as suggested by romz) - Mon Feb 28 10:32:09 2011 +0100
+commit579 - Michaël Jimenez - fix EE core makefiles (alt EE core broken in r546) - Mon Feb 28 09:56:24 2011 +0100
+commit578 - Izdubar Babylon - * minor addition to have more transitions * correction for the info page - Sat Feb 26 21:27:05 2011 +0100
+commit577 - Izdubar Babylon - Probable fix for the previous random crash (rev 572) at startup - Wed Feb 23 11:03:52 2011 +0100
+commit576 - Izdubar Babylon - * fix problem with semaphore * fix font of AttributeText/StaticText that were using gDefaultCol - Tue Feb 22 23:52:13 2011 +0100
+commit575 - volca - Merged changes - Tue Feb 22 21:45:42 2011 +0100
+commit574 - volca - * Added text block rendering function - Tue Feb 22 21:43:36 2011 +0100
+commit573 - Izdubar Babylon - * add a delay before loading per-game config file (same as Art, to not spam when navigating very fast) * corrected the mutual exclusion * corrected the init and re-init of submenu elements cache - Tue Feb 22 21:11:38 2011 +0100
+commit572 - volca - Merged changes - Tue Feb 22 20:20:19 2011 +0100
+commit571 - volca - * Fix for rendering problems caused by CLUT alpha setting change - Tue Feb 22 20:19:45 2011 +0100
+commit570 - Izdubar Babylon - use deferred IO to load config file (should be more safe, got sometimes corrupted file before) - Mon Feb 21 23:14:38 2011 +0100
+commit569 - volca - * Font rendering now uses clut - Mon Feb 21 22:41:46 2011 +0100
+commit568 - Izdubar Babylon - * hints now display either "Info" or "Run" depending if the presentation page is available in the theme AND the option is enabled in settings * theme are re-loaded only when needed (and same for the Art caches) - Mon Feb 21 00:25:03 2011 +0100
+commit567 - Izdubar Babylon - * add loading attributes from a per-game file * retrieve the size of a game (in MB) for USB and ETH * added options to the element type "AttributeText" - Sun Feb 20 22:48:39 2011 +0100
+commit566 - Izdubar Babylon - fix for config reading, "val" were truncated at 32 char (copy/paste typo) - Sat Feb 19 22:49:11 2011 +0100
+commit565 - Izdubar Babylon - * added new element type "StaticText" to display an hardcoded/static string to the screen * added media type for HDD * corrected indentation (damn CTRL+SHIFT+F ...) - Sat Feb 19 01:33:36 2011 +0100
+commit564 - Izdubar Babylon - * added information page (new option to enable it or not) * overlay, cache and static image can be shared between main/info page * code factorization for all image based elements * added AttributeImage type, and AttributeText type * add support for per-game config file (not used for the moment) - Fri Feb 18 20:18:17 2011 +0100
+commit563 - volca - First working version of the font atlasing. Probably still buggy so beware :D - Mon Feb 14 22:58:02 2011 +0100
+commit562 - Izdubar Babylon - small fixes - Sun Feb 13 01:43:02 2011 +0100
+commit561 - volca - * Fix for rendering artifacts on disabled vsync (the reason was we didn't wait for GS to finish before ending the frame) - Sat Feb 12 18:04:35 2011 +0100
+commit560 - volca - * Improvement for the config reader - it now handles python-like prefixes. Also added a safeguard for the max length of key and value in splitter - Sat Feb 12 16:22:24 2011 +0100
+commit559 - Izdubar Babylon - Erf first "merge" (I hope it works ...) - Sat Feb 12 11:56:55 2011 +0100
+commit558 - Izdubar Babylon - First step (almost) finished - Sat Feb 12 11:56:09 2011 +0100
+commit557 - Michaël Jimenez - romz: fix for cdvdman's sceCdSC() - Sun Feb 6 17:39:33 2011 +0100
+commit556 - Izdubar Babylon - step 2, loose coupling - Sun Feb 6 10:48:00 2011 +0100
+commit555 - Izdubar Babylon - first step of the theme/menu rendering rewrite - Fri Feb 4 14:19:11 2011 +0100
+commit554 - Izdubar Babylon - fix for "use_default=0" option in theme (entering the virtual keyboard was crashing, among other ...) - Tue Feb 1 08:42:07 2011 +0100
+commit553 - Izdubar Babylon - * fix a bug in color settings not applied to elements (needed to restart OPL, or cicle with another theme) * correct display of colors, depending of the current theme displayed (only the "default" theme can change colors) - Mon Jan 31 21:51:58 2011 +0100
+commit552 - Izdubar Babylon - fix for language fonts being reset-ed when changing theme - Sun Jan 30 22:23:20 2011 +0100
+commit551 - Izdubar Babylon - re work of virtual keyboard (needed to remove the non-latin characters), added focus on current selected chars - Sun Jan 30 20:57:10 2011 +0100
+commit550 - Izdubar Babylon - * saved some place in game settings (to add future GSM settings) * due to the above, needed to add a fixed width property (to keep multi columns aligned) * added "Dialog color" (ui) and "Selected color" in settings * added some effect to the "focused item" (lot's of complain for this one before), using theme colors - Sun Jan 30 17:57:54 2011 +0100
+commit549 - Izdubar Babylon - fix for broken hdldsrv (since r517/r521) - Fri Jan 28 11:07:45 2011 +0100
+commit548 - Michaël Jimenez - just some cosmetics to the main Makefile - Thu Jan 20 16:56:51 2011 +0100
+commit547 - Michaël Jimenez - just some cosmetics for the EE core - Thu Jan 20 15:32:05 2011 +0100
+commit546 - Michaël Jimenez - fix (hopefully) for DVD9 games - Wed Jan 19 15:07:45 2011 +0100
+commit545 - Michaël Jimenez - fix for Sonic Unleashed (broken in r515) - Wed Jan 19 09:19:30 2011 +0100
+commit544 - volca - Merged changes - Sun Jan 16 20:03:21 2011 +0100
+commit543 - volca - * Mode setting (PAL/NTSC/Auto) * Vsync On/Off switch - Sun Jan 16 19:51:10 2011 +0100
+commit542 - volca - * Implemented kerning - Sun Jan 16 19:49:53 2011 +0100
+commit541 - volca - * Longer first-press delay for pads - more comfy controls on max repeat speed - Sun Jan 16 19:28:44 2011 +0100
+commit540 - volca - * Added sclean make target for make clean without Freetype - Sun Jan 16 19:23:58 2011 +0100
+commit539 - Michaël Jimenez - EP: fix for POPWW (SLUS_210.22) - Sun Jan 16 12:13:12 2011 +0100
+commit538 - Michaël Jimenez - fix for the HD Pro (doesn't support idle timeout) - Sun Jan 16 12:03:57 2011 +0100
+commit537 - Michaël Jimenez - fix for white screen freezing in 'Tenchu: Wrath of Heaven' - Sun Jan 9 17:49:56 2011 +0100
+commit536 - Michaël Jimenez - fix for the BSOD at game launch on some PS3 (added timeout on wait SPU reset) - Sat Jan 8 15:10:07 2011 +0100
+commit535 - Michaël Jimenez - fix for POPWW (SLES_528.22) over SMB, HDD - Sat Jan 8 09:29:46 2011 +0100
+commit534 - Michaël Jimenez - fix for SSX on Tour - Fri Jan 7 15:11:50 2011 +0100
+commit533 - Izdubar Babylon - small fixes - Fri Jan 7 13:52:39 2011 +0100
+commit532 - Izdubar Babylon - short ELF name in App list (looks better for most themes) - Fri Jan 7 13:12:02 2011 +0100
+commit531 - Izdubar Babylon - Added option to specify the HDD spin down time out. - Wed Jan 5 22:04:17 2011 +0100
+commit530 - Michaël Jimenez - implemented hddSetIdleTimeout() - Wed Jan 5 17:04:27 2011 +0100
+commit529 - Michaël Jimenez - removed hdpro_checker IOP module (HD Pro is now detected directly from EE) - Tue Jan 4 18:13:31 2011 +0100
+commit528 - Michaël Jimenez - changes to be able to debug IOP core with HD Pro - Tue Jan 4 13:33:33 2011 +0100
+commit527 - Michaël Jimenez - added in-game code for HD Pro - Tue Jan 4 12:16:56 2011 +0100
+commit526 - Michaël Jimenez - added hdpro_atad IOP module (HD Pro users should have their games listed) - Tue Jan 4 09:09:45 2011 +0100
+commit525 - Michaël Jimenez - added hdpro_checker IOP module (detect if HD Pro Kit is present) - Mon Jan 3 21:14:55 2011 +0100
+commit524 - Michaël Jimenez - fix for Street Fighter Zero Fighters Generation (SLPM_664.09) by lee4, reverted Capcom Classics Collection fix - Sat Jan 1 10:04:43 2011 +0100
+commit523 - Michaël Jimenez - Fix for Capcom Classics Collection - Thu Dec 30 19:36:30 2010 +0100
+commit522 - Izdubar Babylon - fix for broken SMB (by r517) on some setup - Thu Dec 30 19:09:57 2010 +0100
+commit521 - volca - * Added theme support for multiple fonts (default_font, font0, font1... + _font=ID in the components) * fixed ttf allocation leak (from lang.c) - Thu Dec 30 12:41:14 2010 +0100
+commit520 - Izdubar Babylon - configurable IGR path (limited to 32 characters) - Thu Dec 30 00:34:02 2010 +0100
+commit519 - Michaël Jimenez - fix for game ID system (broken in r513) - Wed Dec 29 21:10:54 2010 +0100
+commit518 - Izdubar Babylon - saved 4k of IOP mem in cdvdman/SMB, direct write to buffer - Wed Dec 29 20:44:02 2010 +0100
+commit517 - volca - * Added support for multiple fonts (not used but there ;)) - Wed Dec 29 18:03:32 2010 +0100
+commit516 - Michaël Jimenez - fix for Capcom protected games (SFAA, VDC) - Wed Dec 29 15:28:31 2010 +0100
+commit515 - Michaël Jimenez - fix for games from 'Army Men' series - Fri Dec 24 16:56:55 2010 +0100
+commit514 - Michaël Jimenez - cdvdman: fix potential buffer overflow for long ISO filenames - Mon Dec 20 19:39:15 2010 +0100
+commit513 - Michaël Jimenez - enlarged cdvdman buffer for ISO name to 64 bytes - Mon Dec 20 17:07:51 2010 +0100
+commit512 - Izdubar Babylon - when creating a new VMC, the gEnableRenameDelete option should not be applied - Sun Dec 19 17:57:47 2010 +0100
+commit511 - Izdubar Babylon - * switch default background mode to "Art" * use alt_background_mode for Game Settings/VMC too - Sun Dec 19 17:27:55 2010 +0100
+commit510 - Izdubar Babylon - * fix USB fragmentation check of Game file parts (it should now works as expected) * fix some potential bugs in launching games * "ul.cfg" file is no more mandatory for the USB device * fix of the "USB prefix" feature, now it works really :) - Sun Dec 19 16:48:50 2010 +0100
+commit509 - Michaël Jimenez - fix for 10K patches freezing on some modchipped PS2 - Sun Dec 19 13:59:33 2010 +0100
+commit508 - Izdubar Babylon - * add configurable USB delay (3 is the default value currently used). If you have OPL stuck on yellow or orange screen (when using USB mode only), try increasing this value * you can now configure an USB prefix folder. This is useful for people wanting to use the same external USB device either connected on their NAS and accessed through SMB, or directly (in traveler mode) to the PS2. - Sat Dec 11 16:57:17 2010 +0100
+commit507 - Michaël Jimenez - fix for Super Dimensional Fortress Macross (SLPM_654.05) over HDD - Sat Dec 11 10:16:21 2010 +0100
+commit506 - Izdubar Babylon - final translations for release 0.8 - Thu Dec 9 20:37:29 2010 +0100
+commit505 - Michaël Jimenez - tagged r503 as release v0.8 - Wed Dec 8 12:58:24 2010 +0100
+commit504 - Michaël Jimenez - izdubar: added an About screen to the GUI - Wed Dec 8 12:56:57 2010 +0100
+commit503 - Izdubar Babylon - languages updates - Tue Dec 7 11:29:46 2010 +0100
+commit502 - Izdubar Babylon - work around for the infinite refresh on some NAS device - Mon Dec 6 08:52:19 2010 +0100
+commit501 - Michaël Jimenez - a few fixes so that OPL can comply with some Digitus NAS (with the help of Thinner), removed obsoletes language files and added 'Filipino' language file - Sat Dec 4 18:53:39 2010 +0100
+commit500 - Izdubar Babylon - update for Turkish language - Sun Nov 28 19:31:10 2010 +0100
+commit499 - Izdubar Babylon - fix for english and french translation - Sun Nov 28 13:28:01 2010 +0100
+commit498 - Izdubar Babylon - small fixes - Sun Nov 28 01:29:24 2010 +0100
+commit497 - Izdubar Babylon - Thanks to jimmi's help and ideas, things should now be fixed for alternate device start (and traditional mode too). - Sun Nov 28 01:10:54 2010 +0100
+commit496 - Michaël Jimenez - added ability to use '-use-early-debug' arg (for using ps2client netdump) - Sat Nov 27 15:10:04 2010 +0100
+commit495 - Izdubar Babylon - * devices started in alternate mode now have valid hints * when enabling/disabling "Rename & Delete option", hints are updated - Sat Nov 27 01:05:50 2010 +0100
+commit494 - Michaël Jimenez - genvmc: wait progress message update before to return from vmc_abort() call - Sun Nov 21 17:26:46 2010 +0100
+commit493 - Michaël Jimenez - genvmc: fixed IOP freezing on vmc_abort() call - Sun Nov 21 16:52:36 2010 +0100
+commit492 - Michaël Jimenez - added debug prints to genvmc module - Sun Nov 21 15:25:00 2010 +0100
+commit491 - Michaël Jimenez - modified sysReset() to allow genvmc to load properly - Sun Nov 21 15:02:05 2010 +0100
+commit490 - izdubar - * create an opl.icn into the OPL folder on MC, so the PS2 browser doesn't display it as corrupted data * hide the "check USB fragmentation" option as it is not working - Fri Nov 19 11:07:24 2010 +0100
+commit489 - izdubar - * IPCONFIG.DAT file now loaded from the alternate device too * small correction for the alternate device mode - Fri Nov 19 00:24:13 2010 +0100
+commit488 - izdubar - When no config for OPL is found: 1. if there is any MCs connected, then OPL will continue directly in "first start" mode 2. if no MCs inserted at all, OPL will scan for config on alternate devices until success (OR you can press cross or circle t abort attempt and continue without any config set) - Wed Nov 17 23:25:56 2010 +0100
+commit487 - izdubar - Fix in samba code: server buffer size could be set to 0 due to the type casting - Wed Nov 10 20:27:28 2010 +0100
+commit486 - izdubar - small fixes (USB delay, result return) - Sat Oct 30 20:22:45 2010 +0200
+commit485 - izdubar - * Applications configuration file is read from alternate device too * new configuration file to store the last played game * fix when deleting an apps - Sat Oct 30 19:40:47 2010 +0200
+commit484 - izdubar - Enable saving settings capability on USB or HDD. - Sat Oct 30 03:20:45 2010 +0200
+commit483 - izdubar - small changes - Fri Oct 15 23:57:44 2010 +0200
+commit482 - volca - * IO thread stabilization attempt (not sure if it helps, but it seems so) * Logo showup improvements - show logo a bit longer, do not render GUI while it covers whole screen * Lowering by a tiny bit the plasma resource hog, and making it more lazy to cover the screen tearing a bit * Rising the maximal iso title length (32 was really just to short) - don't be surprised if more titles show up now :) - Fri Oct 15 20:26:44 2010 +0200
+commit481 - izdubar - small bug with VMC settings - Wed Oct 6 19:47:22 2010 +0200
+commit480 - izdubar - add some error messages to warn user of various failing situations - Wed Oct 6 19:41:50 2010 +0200
+commit479 - izdubar - fix compat flag problem on HDD due to merge - Tue Oct 5 15:32:05 2010 +0200
+commit478 - izdubar - make alt background configurable too - Mon Oct 4 20:50:07 2010 +0200
+commit477 - izdubar - Start the pads before loading the config, as we may have to set the scrolling speed. - Mon Oct 4 20:05:11 2010 +0200
+commit476 - izdubar - few changes for SMB (in particular for device in "security share" mode - Mon Oct 4 19:11:24 2010 +0200
+commit475 - Michaël Jimenez - added FILEIO version check, to be sure - Mon Oct 4 17:23:39 2010 +0200
+commit474 - crazyc - fix hdd partition check - Mon Oct 4 10:20:37 2010 -0500
+commit473 - Michaël Jimenez - patch for FILEIO remove rpc handler - Mon Oct 4 16:52:40 2010 +0200
+commit472 - Michaël Jimenez - updated smblab - Mon Oct 4 12:48:31 2010 +0200
+commit471 - Michaël Jimenez - reviewed labs so they can compile - Mon Oct 4 12:03:13 2010 +0200
+commit470 - izdubar - only show VMC delete (and change size) button if "Rename/delete" operation are enabled in settings - Sun Oct 3 21:05:29 2010 +0200
+commit469 - izdubar - fioXXX operations on SMB makes strange things - Sun Oct 3 16:37:42 2010 +0200
+commit468 - izdubar - fioXXX operations on SMB make strange things ... - Sun Oct 3 16:37:08 2010 +0200
+commit467 - crazyc - merge vmc fork - Sun Oct 3 08:03:17 2010 -0500
+commit466 - izdubar - fix DNAS settings bug - Sun Oct 3 14:33:52 2010 +0200
+commit465 - izdubar - fix for invalid background when rendering guiMsgBox (deletion warning of VMC items) - Sun Oct 3 11:35:49 2010 +0200
+commit464 - izdubar - WARNING: uncertain change ! - Sun Oct 3 00:49:09 2010 +0200
+commit463 - izdubar - remember last focused item when reseting dialog - Sun Oct 3 00:28:10 2010 +0200
+commit462 - izdubar - I like to commit in two-phases ... - Sat Oct 2 11:21:02 2010 +0200
+commit461 - izdubar - fix for OK buttons - Sat Oct 2 11:19:48 2010 +0200
+commit460 - izdubar - Opps, disable VMC by default ... (as it is only GUI stuff, we don't want to confuse users ;)) - Sat Oct 2 00:38:50 2010 +0200
+commit459 - izdubar - Added VMC GUI (first shot) - Fri Oct 1 23:38:07 2010 +0200
+commit458 - Michaël Jimenez - moved IOP modules to more explicit subfolders - Thu Sep 30 17:28:59 2010 +0200
+commit457 - Michaël Jimenez - added mcman module and genvmclab - Mon Sep 27 20:33:56 2010 +0200
+commit456 - izdubar - save config files individually - Sun Sep 19 12:37:24 2010 +0200
+commit455 - izdubar - prepare stuff for VMC - Sun Sep 19 00:52:26 2010 +0200
+commit454 - izdubar - * removing settings for hdd was doing bad things * saving of settings file was not optimized ... - Sat Sep 18 23:04:37 2010 +0200
+commit453 - izdubar - * shutdown routine was free-ing stuff still used into the launch method ... * cleanUp of device only called if they are indeed started * hddSupport was still using old compat flag at some places * don't let the user leave the settings screen if there is no device at all started - Sat Sep 18 22:26:05 2010 +0200
+commit452 - izdubar - more corrections - Sat Sep 18 00:40:21 2010 +0200
+commit451 - izdubar - save config *before* shutting down the config files - Sat Sep 18 00:24:12 2010 +0200
+commit450 - izdubar - fixed a few bugs: - Fri Sep 17 22:43:08 2010 +0200
+commit449 - izdubar - * compatibility settings for HDD are now saved into the config files. * splitted settings into multiples config files - Fri Sep 17 21:35:50 2010 +0200
+commit448 - izdubar - fixed broken themes on MC - Mon Sep 13 22:11:29 2010 +0200
+commit447 - izdubar - should fix the invalid list positioning - Sun Sep 12 11:23:06 2010 +0200
+commit446 - izdubar - added file fragmentation test for USB games, code from Polo35 (VMC branch) - Sat Sep 11 23:45:42 2010 +0200
+commit445 - izdubar - splitted settings into "main settings" and "graphic settings" added setting to remember the last played game (and select it by default upon next OPL start) added setting to enable/disable dangerous options (delete/rename) added setting to check file fragmentation for USB game before launching -> NOT WORKING FOR THE MOMENT (not coded ;)) - Sat Sep 11 22:36:59 2010 +0200
+commit444 - izdubar - added "childproof" mode: - Wed Sep 8 23:58:07 2010 +0200
+commit443 - izdubar - add rename/delete functionality to Apps fix config list removal of last element - Wed Sep 8 22:44:13 2010 +0200
+commit442 - izdubar - added hint for "X Play" - Sat Sep 4 21:55:21 2010 +0200
+commit441 - Michaël Jimenez - added genvmc command-line tool for pc - Sat Sep 4 20:27:17 2010 +0200
+commit440 - Michaël Jimenez - update modload version check in MODLOAD hooking - Sat Sep 4 10:23:55 2010 +0200
+commit439 - izdubar - added rename and delete functionality for UL format (ul.cfg) - Fri Sep 3 23:22:33 2010 +0200
+commit438 - izdubar - only apply sorting, when autosort settings enabled - Fri Sep 3 20:43:36 2010 +0200
+commit437 - izdubar - fix update of HDD game list after restarting modules (when leaving HDLD server) - Fri Sep 3 19:55:34 2010 +0200
+commit436 - Michaël Jimenez - enable HDD rename/delete - Fri Sep 3 09:57:04 2010 +0200
+commit435 - Michaël Jimenez - fix again for those games resetting IOP with null arg - Fri Sep 3 09:07:57 2010 +0200
+commit434 - izdubar - Added "rename" and "delete" functionalities for games. - Thu Sep 2 23:07:32 2010 +0200
+commit433 - Michaël Jimenez - smbman: added debug prints ability - Thu Sep 2 19:01:13 2010 +0200
+commit432 - Michaël Jimenez - use MODLOAD hooking on IOP instead of patching LMB on EE - Thu Sep 2 16:07:15 2010 +0200
+commit431 - Michaël Jimenez - fix for alternative EE core build - Fri Aug 20 11:05:42 2010 +0200
+commit430 - Michaël Jimenez - fix: give some delay to ingame mass driver - Thu Aug 19 09:56:14 2010 +0200
+commit429 - Michaël Jimenez - EE core: get rid of libc dependency - Wed Aug 11 18:52:17 2010 +0200
+commit428 - Michaël Jimenez - IGR: use kernel's InitializeTLB instead of syscall - Sun Aug 8 20:52:36 2010 +0200
+commit427 - Michaël Jimenez - EE core: rewrote all syscall hooks in asm - Sat Aug 7 21:36:24 2010 +0200
+commit426 - Michaël Jimenez - EE core: a few tweaks to asm code - Thu Aug 5 22:28:01 2010 +0200
+commit425 - Michaël Jimenez - EE core: improved LoadExecPS2/SifSetDma hooks - Thu Aug 5 21:27:58 2010 +0200
+commit424 - izdubar - update spanish language file - Thu Aug 5 19:53:32 2010 +0200
+commit423 - Michaël Jimenez - added Italian language file - Wed Aug 4 20:05:27 2010 +0200
+commit422 - Michaël Jimenez - EE core: a few tweaks to asm code - Tue Aug 3 20:35:24 2010 +0200
+commit421 - Michaël Jimenez - EE core: improve LoadExecPS2 hooking (fixes Tecmo Hit Parade SLPS_204.01) - Tue Aug 3 17:03:25 2010 +0200
+commit420 - Michaël Jimenez - crazyc: add MC dump ability to genvmc - Mon Aug 2 21:42:12 2010 +0200
+commit419 - Michaël Jimenez - fix for Star Ocean 3 - Till the End of Time (broken in r395) - Mon Aug 2 16:31:25 2010 +0200
+commit418 - Michaël Jimenez - fix for V-Rally 3 PAL (SLES_507.25) - Sat Jul 31 21:31:30 2010 +0200
+commit417 - Michaël Jimenez - fix for Shaun Palmer's Pro Snowboarder US (SLUS_201.99) - Sat Jul 31 17:37:41 2010 +0200
+commit416 - izdubar - few i18n changes - Fri Jul 30 22:51:02 2010 +0200
+commit415 - izdubar - clean-up in GUI strings (removed old entries, added missing values) - Thu Jul 29 21:30:45 2010 +0200
+commit414 - Michaël Jimenez - fix for NRA Gun Club (SLUS_214.32) - Mon Jul 26 20:26:00 2010 +0200
+commit413 - Michaël Jimenez - improvements to genvmc module - Mon Jul 26 14:19:49 2010 +0200
+commit412 - Michaël Jimenez - added genvmc IOP module - Sun Jul 25 17:22:56 2010 +0200
+commit411 - Michaël Jimenez - fix attempt for Jak X - Sat Jul 24 10:09:38 2010 +0200
+commit410 - Michaël Jimenez - fix for those games rebooting IOP with null arg (fixes Bloody Roar 3) - Fri Jul 23 17:39:26 2010 +0200
+commit409 - Michaël Jimenez - fix for GTA 3 a-spec over SMB - Fri Jul 23 13:39:36 2010 +0200
+commit408 - Michaël Jimenez - cdvdfsv: name module like orginal one - cdvd_ee_driver - Fri Jul 23 10:40:53 2010 +0200
+commit407 - Michaël Jimenez - EE core: fix for Quake III Revolution - Thu Jul 22 18:25:23 2010 +0200
+commit406 - Michaël Jimenez - fix for Jak 3 - Thu Jul 22 08:49:21 2010 +0200
+commit405 - Michaël Jimenez - fix for Full Spectrum Warrior - Wed Jul 21 21:44:41 2010 +0200
+commit404 - Michaël Jimenez - fix for those having SMB slowdown/freeze issue on some setups - Wed Jul 21 18:52:43 2010 +0200
+commit403 - Michaël Jimenez - cdvdman: fix lseek fileIO (fixes Shadow of Ganymede) - Tue Jul 20 20:16:31 2010 +0200
+commit402 - Michaël Jimenez - HDD core fix: init filesystem before to return disc type (fixes Xyanide Resurrection) - Tue Jul 20 16:08:45 2010 +0200
+commit401 - izdubar - Added translation information for custom language - Tue Jul 20 15:29:15 2010 +0200
+commit400 - Michaël Jimenez - dlanor: fix for invisible cursor GUI glitch - Sun Jul 18 16:05:12 2010 +0200
+commit399 - Michaël Jimenez - fix for Viewtiful Joe - Sun Jul 18 15:58:03 2010 +0200
+commit398 - Michaël Jimenez - fix for EveryBody's Golf and other games - Sat Jul 17 17:26:26 2010 +0200
+commit397 - Michaël Jimenez - added feature to be able to disable sceSifStopModule/sceSifUnloadModule - Sat Jul 17 16:42:48 2010 +0200
+commit396 - Michaël Jimenez - hook SCE's SifLoadModuleBuffer to fake some modules to be loaded correctly through LoadModuleBuffer calls - Sat Jul 17 09:33:09 2010 +0200
+commit395 - Michaël Jimenez - fix for Kya: Dark Lineage PAL (SLES_514.73) - Thu Jul 15 15:06:51 2010 +0200
+commit394 - Michaël Jimenez - fix for V-Rally 3 US (SLUS_204.96) - Thu Jul 15 13:21:31 2010 +0200
+commit393 - Michaël Jimenez - fix for Kya: Dark Lineage US (SLUS_204.40) - Wed Jul 14 19:19:34 2010 +0200
+commit392 - Michaël Jimenez - changed the patches for Prince Of Persia: The Two Thrones - Wed Jul 14 19:15:35 2010 +0200
+commit391 - Michaël Jimenez - fix for Prince of Persia: The Two Thrones NTSC U (SLUS_212.87) - Tue Jul 13 12:35:52 2010 +0200
+commit390 - Michaël Jimenez - hdldsvr: use real HDD writes - Tue Jul 13 09:41:41 2010 +0200
+commit389 - Michaël Jimenez - udptty: redirect Kprintf output to tty - Mon Jul 12 20:50:43 2010 +0200
+commit388 - Michaël Jimenez - cdvdman: set cdstatus to CDVD_STAT_PAUSE in sceCdStStart/sceCdStResume - Sun Jul 11 16:42:07 2010 +0200
+commit387 - Michaël Jimenez - added EELOAD patches - Wed Jul 7 19:24:05 2010 +0200
+commit386 - Michaël Jimenez - fix for Suikoden IV (HDD) broken in r359 - Tue Jul 6 09:49:52 2010 +0200
+commit385 - Michaël Jimenez - fix for Prince of Persia: The Two Thrones PAL (SLES_537.77) - Mon Jul 5 19:01:47 2010 +0200
+commit384 - Michaël Jimenez - cdvdman: do not allocate IOP memory in cd callback handler (fixes Syphon Filter Logan's Shadow on HDD) - Sun Jul 4 18:30:17 2010 +0200
+commit383 - Michaël Jimenez - EE core: change stack pointer a bit earlier - Fri Jul 2 21:59:55 2010 +0200
+commit382 - Michaël Jimenez - EE core: use an intermediate stack during the IOP reset 'hook' code - Fri Jul 2 21:50:10 2010 +0200
+commit381 - Michaël Jimenez - use maximum priority for EE SMB password hashing thread - Fri Jul 2 19:30:42 2010 +0200
+commit380 - Michaël Jimenez - Fix for Suikoden V (in patch form) - Fri Jul 2 16:19:09 2010 +0200
+commit379 - Michaël Jimenez - fix for Max Payne EU version (SLES_503.25) - Thu Jul 1 21:08:36 2010 +0200
+commit378 - izdubar - * make arrow icons customizable * draw plasma background for every menu screen (IP settings, virtual keyboard, color selector, UI settings) - Wed Jun 30 23:44:26 2010 +0200
+commit377 - Michaël Jimenez - PS3 fix 2: use XLOADFILE when building EELOADCNF - Wed Jun 30 21:47:52 2010 +0200
+commit376 - Michaël Jimenez - PS3 fix 1: reinstated cddev module use in EE core - Wed Jun 30 21:21:18 2010 +0200
+commit375 - izdubar - * don't unmount pfs0 when we are launching an app that is on HDD * fix for cover when there is no '/' in the path * before launching the app, check we can open it (prevent freeze when missing elf, or device not started) - Wed Jun 30 21:00:04 2010 +0200
+commit374 - Michaël Jimenez - fix number 2 for Kingdom Hearts 2 gummi ship missions (should fix all regions) - Wed Jun 30 14:38:03 2010 +0200
+commit373 - Michaël Jimenez - fix for Kingdom Hearts 2 (SLUS_210.05) freeze on gummi ship missions - Wed Jun 30 11:01:15 2010 +0200
+commit372 - Michaël Jimenez - Apply Max Payne US patch on all 3 cores - Tue Jun 29 16:56:26 2010 +0200
+commit371 - Michaël Jimenez - SMSTCPIP: revert ARP_QUEUEING setting change (should fix broken Downhill Domination - SCUS_971.77 via SMB) - Tue Jun 29 16:45:45 2010 +0200
+commit370 - Michaël Jimenez - added compatibility mode 8 (should fix NFS Underground 2 - SLUS_210.65) - Mon Jun 28 19:39:40 2010 +0200
+commit369 - Michaël Jimenez - fix for the recent freezing using themes - Mon Jun 28 18:08:42 2010 +0200
+commit368 - Michaël Jimenez - changed smbauth & tcpip threads priorities (fixes Spiderman 3 and Genji) - Mon Jun 28 08:34:57 2010 +0200
+commit367 - Michaël Jimenez - link GUI SMB auth stuff to SMB core - Sun Jun 27 22:55:56 2010 +0200
+commit366 - volca - * startup logo implementation, with a placeholder Logo * SMB Auth (works for gui it seems) - Sun Jun 27 20:41:48 2010 +0200
+commit365 - Michaël Jimenez - SMB core: do not perform password hashing if SMB server uses plaintext passwords - Sun Jun 27 19:38:17 2010 +0200
+commit364 - Michaël Jimenez - Max Payne US version (SLUS_202.30) fix for SMB use - Sun Jun 27 18:53:00 2010 +0200
+commit363 - Michaël Jimenez - EE core: added a ResetSPU() in LoadExecPS2 hook - Sun Jun 27 18:51:33 2010 +0200
+commit362 - Michaël Jimenez - added User Security Level support to SMB core - Sat Jun 26 22:04:12 2010 +0200
+commit361 - Michaël Jimenez - cdvdman: change back SceCdTrayReq traycheck return value - Sat Jun 26 09:38:33 2010 +0200
+commit360 - Michaël Jimenez - SMB core: save more IOP memory to increase compatibility - Fri Jun 25 10:36:55 2010 +0200
+commit359 - Michaël Jimenez - removed cddev module use from EE core, removed cddev - Wed Jun 23 13:31:22 2010 +0200
+commit358 - izdubar - default to settings menu when no devices started or no config file found - Wed Jun 23 12:55:53 2010 +0200
+commit357 - izdubar - * re-enable game "test" functionality (from compatibility settings) * use "plasma" for drawing background in settings menu (theme background problem) - Wed Jun 23 12:06:48 2010 +0200
+commit356 - Michaël Jimenez - use ICO fix (r346) only in compatibility mode 7 - Wed Jun 23 09:54:52 2010 +0200
+commit355 - Michaël Jimenez - smbman: do not rely on EndOfSearch but rather SearchCount field - Tue Jun 22 22:31:11 2010 +0200
+commit354 - Michaël Jimenez - remove uneeded stuff from ps2link module - Mon Jun 21 12:43:50 2010 +0200
+commit353 - Michaël Jimenez - EE core: remove InitializeUserMemory() patch when removing kernel hooks - Mon Jun 21 11:02:31 2010 +0200
+commit352 - Michaël Jimenez - fix: do no longer use sbv_patch_user_mem_clear() to be compatible with faulty DMS4 modchip - Sun Jun 20 19:46:58 2010 +0200
+commit351 - Michaël Jimenez - ps2link module: corrected Makefile - Sun Jun 20 19:00:52 2010 +0200
+commit350 - Michaël Jimenez - reload ps2link module on 'make debug' rule - Sat Jun 19 11:52:19 2010 +0200
+commit349 - Michaël Jimenez - fix: HDD gamelist was deallocated too early in HDD game launch process - Sat Jun 19 11:08:28 2010 +0200
+commit348 - izdubar - * ISO support also "enabled" for USB (don't know what is the filesize limit, either 2Go or 4Go)   Same filename rules as for SMB, same folders CD/DVD to create in the USB device root directory. - Fri Jun 18 22:36:12 2010 +0200
+commit347 - Michaël Jimenez - cdvdfsv: remove a 2KB of wasted IOP mem (fixes ICO - SCUS_971.59 via SMB) - Fri Jun 18 22:08:30 2010 +0200
+commit346 - Michaël Jimenez - SMSTCPIP: adjust PBUF_POOL_SIZE for ingame use (fixes again Disgaea SLUS_206.66 broken since r283) - Thu Jun 17 12:14:37 2010 +0200
+commit345 - izdubar - added a new compatibilty mode: "reduce the buffers used by cdvdman/cdvdfsv" - Wed Jun 16 21:56:10 2010 +0200
+commit344 - Michaël Jimenez - added make_changelog.sh script and DETAILED_CHANGELOG file - Wed Jun 16 20:25:36 2010 +0200
+commit343 - Michaël Jimenez - cdvdman: check faulty filepath(more than one ';1') - fixes WWE Smackdown! Shut your mouth (SLUS_204.83) - Wed Jun 16 19:51:14 2010 +0200
+commit342 - Michaël Jimenez - use ioptrap module while debugging - Wed Jun 16 14:12:26 2010 +0200
+commit341 - Michaël Jimenez - fix for HDD games compat modes saving to another game when using sorted list - Mon Jun 14 20:30:37 2010 +0200
+commit340 - Michaël Jimenez - cdvdman fix: dread must return entry size (fixes Captain Tsubasa SLPS_256.91) - Sun Jun 13 17:37:48 2010 +0200
+commit339 - Michaël Jimenez - removed netlog module (now replaced by UDPtty) - Sun Jun 13 14:55:24 2010 +0200
+commit338 - Michaël Jimenez - make use of UDPtty for in-game debugging - Sun Jun 13 14:48:15 2010 +0200
+commit337 - Michaël Jimenez - 10K patch fix: only patch kernel if not already patched - Sat Jun 12 15:05:24 2010 +0200
+commit336 - Michaël Jimenez - fix for exiting kernel mode correctly while applying 10K patches - Sat Jun 12 13:03:30 2010 +0200
+commit335 - Michaël Jimenez - use more versatile code to get ROMVER info in 10K patches - Sat Jun 12 12:47:16 2010 +0200
+commit334 - Michaël Jimenez - remove debug from 10K patches - Fri Jun 11 23:42:36 2010 +0200
+commit333 - Michaël Jimenez - 10K fix 2: OPL now runs on original 10K kernel - Fri Jun 11 23:39:48 2010 +0200
+commit332 - Michaël Jimenez - loader: do a system restart in LoadExecPS2 hook as the real syscall does (reinitialize GS, INTC, TIMER, DMAC, VU0, VU1, VIF0, VIF1, GIF, IPU, FPU and ScratchPad - Wed Jun 9 21:13:38 2010 +0200
+commit331 - Michaël Jimenez - hdd.c: do not deallocate partion table when it's not allocated - Tue Jun 8 22:06:03 2010 +0200
+commit330 - Michaël Jimenez - free the HDL game list and HDD partition table in hddCleanup() - Tue Jun 8 20:07:04 2010 +0200
+commit329 - Michaël Jimenez - 10K fix 1: OPL now runs on patched 10K kernel - Tue Jun 8 12:07:01 2010 +0200
+commit328 - Michaël Jimenez - modified Disc ID stuff to no longer freeze on No disc/Invalid disc - Sun Jun 6 21:08:31 2010 +0200
+commit327 - Michaël Jimenez - fix to avoid warning on unused variable in hdd.c - Sun Jun 6 16:00:49 2010 +0200
+commit326 - Michaël Jimenez - modified and tested HDD deleting game code (real writes still deactivated) - Sun Jun 6 15:57:29 2010 +0200
+commit325 - Michaël Jimenez - use EE SIO debug in the loader - Sat Jun 5 14:53:15 2010 +0200
+commit324 - Michaël Jimenez - use EE SIO debug output in the GUI on 'make EESIO_debug' - Fri Jun 4 11:18:35 2010 +0200
+commit323 - Michaël Jimenez - cdvdman: be compatible with mass storage device having sector size of 4096 - Thu Jun 3 12:49:06 2010 +0200
+commit322 - Michaël Jimenez - usbhdfsd: added an ioctl to return mass storage device sectorsize - Thu Jun 3 11:26:33 2010 +0200
+commit321 - volca - * Fix for issue #29 (dia.c tooltip display) * Blinking/Fat lines fix in dialog display - Wed Jun 2 19:40:33 2010 +0200
+commit320 - volca - Put plasma speed back after the framerate optimization - Wed Jun 2 19:19:00 2010 +0200
+commit319 - Michaël Jimenez - cdvdman: be compatible with mass storage having sector size of 512, 1024, 2048 - Wed Jun 2 18:32:30 2010 +0200
+commit318 - volca - * separate background rendering (Issue #31) * added FPS meter in debug mode * small fix to logic of io blocking func * tweaks to VRAM allocation messages (flushes are normal, do not report, report only too large allocations that can't fit VRAM at all) * one pass ISO list population via linked list (should be a bit faster) * report memory allocation failures on some key places - Wed Jun 2 18:29:25 2010 +0200
+commit317 - Michaël Jimenez - usbhdfsd: removed unused code in fs_getFileStartSector() - Wed Jun 2 16:42:36 2010 +0200
+commit316 - Michaël Jimenez - cdvdman: fix for my previous code tweak breaking compat with SMB games in ul format - Wed Jun 2 15:38:01 2010 +0200
+commit315 - Michaël Jimenez - cdvdman: code tweaking for opening ISO file(s) - Wed Jun 2 15:19:27 2010 +0200
+commit314 - Michaël Jimenez - cdvdman: optimized code size for plain ISO support in cdvdman_ReadSect() - Wed Jun 2 13:05:27 2010 +0200
+commit313 - Michaël Jimenez - fix for theme choosen not saving - Mon May 31 20:12:26 2010 +0200
+commit312 - Michaël Jimenez - use LOG() rather than printf() - Mon May 31 12:03:14 2010 +0200
+commit311 - Michaël Jimenez - fix for issue #23 - Sun May 30 19:36:35 2010 +0200
+commit310 - Michaël Jimenez - make use of udptty in debug version - Sun May 30 17:25:10 2010 +0200
+commit309 - Michaël Jimenez - added udptty module - Sat May 29 20:34:44 2010 +0200
+commit308 - Michaël Jimenez - forgot system.h, now added - Sat May 29 18:03:54 2010 +0200
+commit307 - Michaël Jimenez - added system.h and sysLoadModuleBuffer to able to check for modules already loaded - Sat May 29 17:57:43 2010 +0200
+commit306 - Michaël Jimenez - added lanman module & lanlab - Sat May 29 16:00:14 2010 +0200
+commit305 - Michaël Jimenez - moved smblab & hdldsvrlab to labs folder - Sat May 29 13:39:14 2010 +0200
+commit304 - izdubar - small fix in game disc settings handling - Sat May 29 01:33:40 2010 +0200
+commit303 - volca - * stop io timer while io is blocked (seems not to affect the hdl server transfer rate though :( ) * Issue #25 (SMB blocking) maybe fixed - needs more testing * Issue #24 fix * Issue #22 fix * new functions to store/restore pad timings - Fri May 28 18:14:10 2010 +0200
+commit302 - izdubar - buffered write (for config file) - Fri May 28 16:54:37 2010 +0200
+commit301 - volca - Fixing issue #21 - Thu May 27 19:44:24 2010 +0200
+commit300 - volca - * Maybe a more resource friendly (but a bit awkward for now) hdld svr screen - Thu May 27 18:51:56 2010 +0200
+commit299 - Michaël Jimenez - smbman: reconnect, re-logon and re-open share on connection loss - Thu May 27 16:47:17 2010 +0200
+commit298 - Michaël Jimenez - smbman: removed connect/disconnect (now done by logon/logoff) - Thu May 27 15:13:17 2010 +0200
+commit297 - Michaël Jimenez - SMSMAP: do not wait forever for link established (wait around 10s otherwise fails to load) - Thu May 27 14:29:57 2010 +0200
+commit296 - Michaël Jimenez - added hdldsvrlab for testing purpose - Thu May 27 11:44:40 2010 +0200
+commit295 - izdubar - fix for SMB "file open" in APPEND mode - Thu May 27 11:33:26 2010 +0200
+commit294 - volca - Removing unzip, not used any more - Thu May 27 08:32:30 2010 +0200
+commit293 - izdubar - fix for themes listing in SMB mode - Wed May 26 23:01:04 2010 +0200
+commit292 - izdubar - Fix for missing Art in SMB mode - Wed May 26 22:27:36 2010 +0200
+commit291 - Michaël Jimenez - renamed hdl.c to hdd.c and hddFormat() to hddGetFormat() - Wed May 26 20:48:07 2010 +0200
+commit290 - volca - * Fork merge: Porting back the GUI repository changes - Wed May 26 20:01:23 2010 +0200
+commit289 - Michaël Jimenez - added hddFormat, hddDeleteHDLGame (untested) - Tue May 25 08:35:24 2010 +0200
+commit288 - Michaël Jimenez - fix for LoadHdldsvr() and UnloadHdldSvr() - Sun May 23 17:25:33 2010 +0200
+commit287 - Michaël Jimenez - added UnloadHdldSvr() - Sun May 23 16:08:35 2010 +0200
+commit286 - Michaël Jimenez - added LoadHdldSvr() to GUI (currently never called) - Sun May 23 09:45:54 2010 +0200
+commit285 - Michaël Jimenez - hdldsvr: use real writes (the module is not loaded by the GUI) - Sat May 22 18:18:32 2010 +0200
+commit284 - Michaël Jimenez - hdldsvr: added CMD_WRIT & CMD_WRIS, completed UDP thread part (only fake writes) - Sat May 22 11:41:45 2010 +0200
+commit283 - Michaël Jimenez - hdldsvr: added CMD_FLSH & CMD_POWX - Fri May 21 10:51:18 2010 +0200
+commit282 - Michaël Jimenez - hdldsvr: a fix in interpreting/replying command result - Fri May 21 10:11:22 2010 +0200
+commit281 - Michaël Jimenez - hdldsvr: added CMD_STAT & CMD_READ (hdl_dump able to attach and list games) - Fri May 21 10:07:45 2010 +0200
+commit280 - Michaël Jimenez - added hdldsvr IOP module skeleton - Thu May 20 20:13:19 2010 +0200
+commit279 - Michaël Jimenez - added a specific SMSTCPIP for ingame use, and re-enabled UDP in the normal one - Thu May 20 19:57:09 2010 +0200
+commit278 - Michaël Jimenez - Anti-freeze fix for NBSS Session KeepAlive in smbman and ingame SMB core - Wed May 19 21:20:43 2010 +0200
+commit277 - Michaël Jimenez - make use of new smbman fileXio functions - Tue May 18 20:28:56 2010 +0200
+commit276 - Michaël Jimenez - applied SMB connection speedup to ingame SMB core - Tue May 18 12:43:54 2010 +0200
+commit275 - Michaël Jimenez - smbman: finished chdir implementation - Tue May 18 12:00:32 2010 +0200
+commit274 - Michaël Jimenez - smbman: implemented dopen/dread/dclose/chdir (chdir is not complete) - Mon May 17 22:16:40 2010 +0200
+commit273 - Michaël Jimenez - smbman: implemented FindFirst2, FindNext2 requests, different tweaks to make connection faster - Mon May 17 17:11:56 2010 +0200
+commit272 - Michaël Jimenez - smbman: fixed a killer buffer overflow while generating DES keys - Mon May 17 12:37:30 2010 +0200
+commit271 - Michaël Jimenez - smbman: added mkdir IO function, make LogOn not retrying forever - Sun May 16 19:03:49 2010 +0200
+commit270 - Michaël Jimenez - smbman: added Rename request and his rename IO function - Sun May 16 17:43:06 2010 +0200
+commit269 - Michaël Jimenez - smbman: added Delete Directory request and his rmdir IO function - Sun May 16 16:59:25 2010 +0200
+commit268 - Michaël Jimenez - smbman: added Delete request and his remove IO function - Sun May 16 16:35:31 2010 +0200
+commit267 - Michaël Jimenez - smbman: added poll() to not lock forever using lwip_recv - Sun May 16 14:01:51 2010 +0200
+commit266 - Michaël Jimenez - smbman: fix for closing previously created tcp connection before opening it (in the same module instance) - Sun May 16 13:36:20 2010 +0200
+commit265 - Michaël Jimenez - smbman: added timer to echo the SMB server every 3 sec while not doing IO - Sun May 16 13:21:34 2010 +0200
+commit264 - Michaël Jimenez - smbman: added QueryDiskInfo request and his devctl function - Sat May 15 17:15:58 2010 +0200
+commit263 - Michaël Jimenez - smbman: added file IO getstat support - Sat May 15 16:05:06 2010 +0200
+commit262 - Michaël Jimenez - smbman: a few tweaks to the packet structs - Fri May 14 14:04:09 2010 +0200
+commit261 - Michaël Jimenez - smbman: added QueryPathInformation Trans2 request - Fri May 14 13:32:58 2010 +0200
+commit260 - Michaël Jimenez - smbman: modified smb_ReadAndX and smb_WriteAndX to support large files (>4GB) - Fri May 14 10:17:05 2010 +0200
+commit259 - Michaël Jimenez - smbman: added generic lseek64 support (needs PS2SDK lseek64 fix to work) - Thu May 13 22:40:36 2010 +0200
+commit258 - Michaël Jimenez - smbman: reviewed devctl functions - Thu May 13 16:14:45 2010 +0200
+commit257 - Michaël Jimenez - smbman: reviewed AddPassword function - Thu May 13 11:48:13 2010 +0200
+commit256 - izdubar - * added method for managing passwords, re-enable smb_NTCreateAndX, small fix when read only mode requested * minor change in writeIPConfig (leading 0 caused HDLD_SRV to ignore the IPCONFIG.DAT) - Wed May 12 22:33:19 2010 +0200
+commit255 - Michaël Jimenez - added smblab to test smbman functions - Wed May 12 20:43:27 2010 +0200
+commit254 - Michaël Jimenez - smbman: finished smb_NetShareEnum(), added smb_Echo(), refined devctls - Wed May 12 17:52:40 2010 +0200
+commit253 - Michaël Jimenez - tagged r245 as release 0.7 - Tue May 11 20:56:56 2010 +0200
+commit252 - Michaël Jimenez - smbman: fixed fatal error for compiling in smb_NetShareEnum() - Tue May 11 20:53:03 2010 +0200
+commit251 - Michaël Jimenez - added a few commands to smbman (TreeDisconnect, LogOffAndX, NetShareEnum) - Tue May 11 20:48:45 2010 +0200
+commit250 - volca - Porting back the opl2iso into the main repository - Sun May 9 19:17:26 2010 +0200
+commit249 - Michaël Jimenez - added write support to smbman - Sun May 9 17:06:37 2010 +0200
+commit248 - Michaël Jimenez - added NTLMv1 authentification ability to smbman - Sat May 8 22:49:44 2010 +0200
+commit247 - Michaël Jimenez - added user security level to smbman, currently supports plaintext/encrypted passwords and LanMan authentification - Sat May 8 18:59:02 2010 +0200
+commit246 - Michaël Jimenez - updated version number to 0.7 and changelog, credits - Tue May 4 17:13:11 2010 +0200
+commit245 - Michaël Jimenez - izdubar: fix for 18K - Tue May 4 16:37:28 2010 +0200
+commit244 - polo35 - IGR2 Fix 5. -Added pad frame checking in IGR Intc to make sure pad buffer is still alive.  When a game call padPortClose (or pad2Deletesocket) pad frame stop increasing.  In this case tell to syshook to re-install padOpen hook. (SOCOM3) -Install padOpen hook when a thread with init_prio < 5 and current_prio == 0 is created. (YAKUZA) - Tue Mar 30 11:53:11 2010 +0200
+commit243 - polo35 - IGR2 Fix 4. -Use Hook_ExecPS2 and Hook_CreateThread to install IGR.  This might solve pink-green flicker problem, and increase IGR compatibility. -Modify Find_pattern_with_mask function to compare 32bits at a time instead of 8bits.  No more search mistake, and increase IGR installation speed. -Modify thread priority management when IGR is call.  IGR thread is created with prio=127, (lowest) to not interfere with other threads.  When IGR is call, all thread are suspended, and prio are set to 127.  Then, IGR thread is woken-up, and prio is set to 0. (highest) -Add padOpen function check before calling it.  Some game execute ELFs, so old padOpen function can remain in memory.  This check ensure function is still available before calling it. -Add ability to patch padOpen function called with a simple Jump (J) instead of a JumpAndLink (JAL). (Armored Core: Nine Breacker) -Add ability to patch padOpen instuction code.  Some game use an address table to call functions. (Ratchet & Clank: Size Matter) -Add libpad2 2.7.0.0 pattern. (Legacy of Kain Defiance) - Tue Mar 23 13:27:19 2010 +0100
+commit242 - Michaël Jimenez - corrected polish translation by Berion - Mon Mar 15 10:06:28 2010 +0100
+commit241 - Michaël Jimenez - Added an embedded Elf loader to the GUI (actually used on Exit to Elf) - Sat Mar 13 20:29:29 2010 +0100
+commit240 - polo35 - IGR2 fix 3. Add libpad 2.1.0.0 pattern. (Fix for Baulder's Gate: Dark Alliance, Gauntlet: Dark Legacy, Spyhunter, ...) - Sat Mar 6 18:17:59 2010 +0100
+commit239 - volca - Pad repeat pre-delay (double the repeat delay for now). Izdubar: Search for usb partition again on refresh if appropriate - Thu Mar 4 19:09:04 2010 +0100
+commit238 - Michaël Jimenez - Renamed iso2usbld to iso2opl, fix for running iso2opl on Big Endian systems - Wed Mar 3 19:47:29 2010 +0100
+commit237 - polo35 - IGR2 fix 2. -Switch to VBlank End interrupt instead of VBlank Start.  Registering a VBlank Start interrupt is incompatible with $ceGsVSync function from $ony basic graphic library. :D -Create IGR thread with initial priority set to 0. ( highest prio, same as kernel ) -Suspend all threads and disable all interrupts when power button or combo is press. ( make sure only IGR thread will wakeup ) -Remove unneeded deletion of old IGR thread and interrupt. ( cause a "INTC() does not exist" ) - Tue Mar 2 23:55:57 2010 +0100
+commit236 - Michaël Jimenez - Gilgamesh88: fix read buffer double increment bug in smbman.c - Tue Mar 2 11:36:07 2010 +0100
+commit235 - polo35 - IRG2 first fix. ;) Suspend all thread which currently return run state when power button or combo is press. This way we make sure IGR thread will really wakeup. ( Ratchet & Clank 2 ) - Mon Mar 1 23:48:20 2010 +0100
+commit234 - Michaël Jimenez - smbman, usbhdfsd: just cosmetics, fixed indents and leading/trailing whitespaces - Mon Mar 1 20:05:55 2010 +0100
+commit233 - Michaël Jimenez - eesync/imgdrv: just cosmetics - Mon Mar 1 11:31:27 2010 +0100
+commit232 - Michaël Jimenez - just cosmetics: fixed indents, removed leading/trailing whitespaces - Mon Mar 1 09:54:14 2010 +0100
+commit231 - volca - Fix: be sure HDD is actually used and selected before storing - Mon Mar 1 08:53:18 2010 +0100
+commit230 - volca - HDD settings only stored on save, not test (untested) - Mon Mar 1 08:34:45 2010 +0100
+commit229 - volca - merging branches - Sun Feb 28 21:39:54 2010 +0100
+commit228 - volca - Two more fixes by Izdubar - Sun Feb 28 21:39:13 2010 +0100
+commit227 - polo35 - Rewrote completly IGR. - Sun Feb 28 21:30:38 2010 +0100
+commit226 - Michaël Jimenez - dev9: just cosmetics, fixed indents and leading/trailing whitespaces - Sun Feb 28 20:43:27 2010 +0100
+commit225 - Michaël Jimenez - cddev, discID: just cosmetics, fixed indents and leading/trailing whitespaces - Sun Feb 28 20:32:54 2010 +0100
+commit224 - Michaël Jimenez - cdvdfsv: just cosmetics, fixed indents and leading/trailing whitespaces - Sun Feb 28 20:18:56 2010 +0100
+commit223 - Michaël Jimenez - cdvdman: just cosmetics, fixed indents and leading/trailing whitespaces - Sun Feb 28 17:06:08 2010 +0100
+commit222 - volca - A couple of fixes: * Waiting for pad does not block on disconnected * initialize the max_games variables! * disable_debug config storage removed by accident, so readded Thanks Izdubar for the report - Fri Feb 26 08:58:19 2010 +0100
+commit221 - volca - * this slipped through - default delay should be 7 - Thu Feb 25 18:53:06 2010 +0100
+commit220 - volca - * Cummulative patch by gilgamesh - consistency improvements * Splitting the usbld.h a bit * Moved the dialog code to dia.h/dia.c * gfx.c now uses lower case names for function (for consistency) * pad.c now enables the use of up to 4 controllers - Thu Feb 25 18:49:47 2010 +0100
+commit219 - volca - New coloured icons by Gilgamesh88 - Thu Feb 25 18:46:47 2010 +0100
+commit218 - root - Added PCMCIA support (auto-detected, should work with 18K atm) - Mon Feb 22 09:10:51 2010 +0100
+commit217 - Michaël Jimenez - Fix again to the sed command in all modules Rules.make files causing 'unrecognized -mcpu=r3000 option' on some dev environments - Sun Feb 21 13:39:36 2010 +0100
+commit216 - polo35 - Working IGR fix for NFS Underground2 this time. :D IGR special fix for Xenosaga3 when returning to OPL. - Tue Feb 16 20:40:56 2010 +0100
+commit215 - Michaël Jimenez - Removed PS2ETH and GSKIT vars definition from Makefile - Tue Feb 16 20:16:19 2010 +0100
+commit214 - Michaël Jimenez - Corrected misuse of ps2-packer in Makefile, sorry for those who'll need to move it - Tue Feb 16 16:02:03 2010 +0100
+commit213 - polo35 - IGR fix 2. Fix stack pointer place under user memory. ( NFS Underground2 ) - Tue Feb 16 15:24:30 2010 +0100
+commit212 - Michaël Jimenez - Modified sed in Rules.make files to fix unrecognized option -mcpu=r3000 when using fr_FR.UTF-8 as LANG env var on some Linux distro - Tue Feb 16 11:40:27 2010 +0100
+commit211 - polo35 - Add "Disable Debug Colors" setting. Does what the name says. ;) - Mon Feb 15 19:45:22 2010 +0100
+commit210 - ifcaro - zipped theme support (very slow) theme support in mc0 mc1 and mass themes directory is now OPL in place of USBLD - Sun Feb 14 22:38:46 2010 +0100
+commit209 - polo35 - Fix a bug when setting compatibility in multiple device. Thanks to Vsub for report and Gilgamesh88 for code. - Sun Feb 14 20:50:03 2010 +0100
+commit208 - polo35 - IGR fixs: Search scePadRead in 0 size ELF program segment. (NightShade) ScratchPad Ram use for stack pointer. (NFS) Restore Translation Look-Aside Buffer (TLB), and stop performance counter. (GT4) - Sun Feb 14 12:36:19 2010 +0100
+commit207 - volca - A fix for the pink freezes when using custom lang file - Fri Jan 29 17:30:57 2010 +0100
+commit206 - volca - Adding the ability to load language localisation files - Thu Jan 28 19:04:00 2010 +0100
+commit205 - polo35 - Optimization of scePadRead hooking time. First scan elf loaded segments when starting game. ( t_loadElf function ) If not found scan whole memory after iop reset. ( New_Reset_Iop function ) Add Dev9 shutdown function. Use with Poweroff combo, and return to browser. - Tue Jan 26 18:32:04 2010 +0100
+commit204 - polo35 - Revert to sbv patch use with igr too. I forgot that old PS2 failed to load a module from a buffer without sbv patches. :D - Sun Jan 24 19:12:07 2010 +0100
+commit203 - polo35 - Revert to Sbv patches use for old game compatibility. Thanks Jimmikaelkael for report. - Sun Jan 24 10:20:58 2010 +0100
+commit202 - polo35 - Add a poweroff combo trick. R1 + L1 + R2 + L2 + Start + Select -> Return to home. R1 + L1 + R2 + L2 + R3 + L3 -> Poweroff PS2. - Sat Jan 23 23:34:44 2010 +0100
+commit201 - polo35 - Add compat mode 6 to disable IGR. ( In compatibility settings ) Use OPNPS2LD exit path with IGR ( Browser, mc0:/BOOT/BOOT.ELF, mc0:/APPS/BOOT.ELF ) Return to browser is worse then other. :( - Sat Jan 23 14:59:52 2010 +0100
+commit200 - polo35 - Loader size optimization. Get rid of sbv patch. Don't needed and take lot of place. ;) Revert linkfile & linkfile.alt to ps2sdk one ( with section modified to match OPNPS2LD ) instead of old HDP one. - Sat Jan 23 14:41:15 2010 +0100
+commit199 - polo35 - Sorry .s file don't want to be push. - Thu Jan 21 22:02:25 2010 +0100
+commit198 - polo35 - Loader size optimization. Add a modified crt0 file from ps2sdk to get rid of libc initialization. - Thu Jan 21 21:08:09 2010 +0100
+commit197 - volca - home & end for HDD games - Thu Jan 21 18:59:25 2010 +0100
+commit196 - volca - some more pointer handling fixes - Thu Jan 21 17:24:15 2010 +0100
+commit195 - volca - pagestart handling fixes - Thu Jan 21 17:17:07 2010 +0100
+commit194 - volca - Merging branches - Thu Jan 21 15:21:42 2010 +0100
+commit193 - volca - * Selection in static mode now not centered (HDLoader like) * Automatic sorting implemented * page up/down now via L1/R1 * garbage screen after start fix * next line in dialog not working on dialog end fix * scroll speed not applied after start fix * misleading "theme" settings item renamed to "Settings" - Thu Jan 21 15:19:56 2010 +0100
+commit192 - Michaël Jimenez - SMSMAP: wait link status forever (hopefully it fixes freeze on 1 bug) - Thu Jan 21 14:58:32 2010 +0100
+commit191 - polo35 - Fix sound loop bug when using in game reset. - Thu Jan 21 00:06:19 2010 +0100
+commit190 - polo35 - In Game Reset first shot. ( Disabled for the moment ) Thanks Misfire and Jimmikaelkael for PS2RD and great scePadRead hooking fonction. Optimize loader size by removing lot of useless linked function references. - Tue Jan 19 23:16:15 2010 +0100
+commit189 - Michaël Jimenez - get rid of kernel mem usage for patches code and let it handled by the loader - Fri Jan 15 13:26:36 2010 +0100
+commit188 - Michaël Jimenez - Added some generic patching mode for some games - Thu Jan 14 14:31:08 2010 +0100
+commit187 - Michaël Jimenez - cosmetic changes again to patches table code - Wed Jan 13 20:26:43 2010 +0100
+commit186 - Michaël Jimenez - Added patch for Armored Core Nine Breaker NTSC US via USB - Wed Jan 13 16:53:31 2010 +0100
+commit185 - Michaël Jimenez - Added value check to the game patching process - Wed Jan 13 10:41:07 2010 +0100
+commit184 - Michaël Jimenez - Loader now uses game patches (actually Disgaea PAL USB/SMB fix) - Tue Jan 12 22:25:22 2010 +0100
+commit183 - Michaël Jimenez - Enabled game patches table before to launch the loader - Tue Jan 12 19:09:12 2010 +0100
+commit182 - Michaël Jimenez - Added game patches table code - Tue Jan 12 18:53:03 2010 +0100
+commit181 - volca - Slower Dialog scrolling. Also a speed handling fix. - Tue Jan 12 18:32:17 2010 +0100
+commit180 - volca - HDD autostart option added. - Tue Jan 12 17:50:00 2010 +0100
+commit179 - Michaël Jimenez - some cosmetic changes to PS3 network fix - Tue Jan 12 13:33:16 2010 +0100
+commit178 - Michaël Jimenez - fix to SMSMAP to be able to use network on PS3 - Tue Jan 12 12:45:43 2010 +0100
+commit177 - Michaël Jimenez - adjusted DMA modes implementation (functional now) - Sat Jan 9 13:43:03 2010 +0100
+commit176 - ifcaro - Added DMA mode in UI - Sat Jan 9 01:24:28 2010 +0100
+commit175 - Michaël Jimenez - v12/v13 HDD detect fix: information given by dlanor - Fri Jan 8 14:33:15 2010 +0100
+commit174 - Michaël Jimenez - modified and tested HDD write OK (for compat modes), still disabled - Thu Jan 7 11:51:47 2010 +0100
+commit173 - Michaël Jimenez - totally ignore native HDL compatibilty modes - Wed Jan 6 22:21:32 2010 +0100
+commit172 - Michaël Jimenez - fix for lack of file opened check in smbman - Wed Jan 6 21:27:09 2010 +0100
+commit171 - Michaël Jimenez - fix for modchip freezing (maybe not all modchips) - Wed Jan 6 20:28:31 2010 +0100
+commit170 - volca - Untested: * added sorting for HDD (via select) * hddCheck returns zero on success, inverted the hddfound (thanks yoshi314) - Wed Jan 6 08:52:00 2010 +0100
+commit169 - volca - fixing bug in hdd usage gui selection - Tue Jan 5 22:38:32 2010 +0100
+commit168 - volca - a copy-paste warning fix - Tue Jan 5 22:13:53 2010 +0100
+commit167 - volca - First shot of HDD integration into GUI. Compat modes very rough. Untested! - Tue Jan 5 20:42:05 2010 +0100
+commit166 - ifcaro - added dutch language - Tue Jan 5 17:13:56 2010 +0100
+commit165 - Michaël Jimenez - changes to redundant code in system.c, changes to HDD compat modes handling - Mon Jan 4 19:48:35 2010 +0100
+commit164 - Michaël Jimenez - changes for SOCOM 3 Online playing - Mon Jan 4 14:50:46 2010 +0100
+commit163 - Michaël Jimenez - added poweroff support (currently disabled) - Mon Jan 4 11:35:12 2010 +0100
+commit162 - Michaël Jimenez - updated CREDITS file - Sun Jan 3 18:48:26 2010 +0100
+commit161 - Michaël Jimenez - HDL code: fix potential overflow while changing game name - Sun Jan 3 15:59:19 2010 +0100
+commit160 - Michaël Jimenez - changes to HDL code (added ability to save compat flags and game name) - Sun Jan 3 15:44:10 2010 +0100
+commit159 - Michaël Jimenez - added ps2hdd module, adjusted code to support 48-bit LBA HDD and set Transfer Mode - Sun Jan 3 14:39:45 2010 +0100
+commit158 - Michaël Jimenez - added atad module - Sun Jan 3 11:16:39 2010 +0100
+commit157 - Michaël Jimenez - fix to cdvdman so that HDD core is able to detect network adapter - Sun Jan 3 11:04:27 2010 +0100
+commit156 - Michaël Jimenez - changes again to HDD code - Sat Jan 2 20:57:22 2010 +0100
+commit155 - Michaël Jimenez - changes to HDD code - Sat Jan 2 20:34:34 2010 +0100
+commit154 - Michaël Jimenez - added HDL layer to GUI (currently disabled) - Sat Jan 2 14:50:04 2010 +0100
+commit153 - volca - Game ID GUI and injection implementation (for DNAS) - Sat Jan 2 12:40:45 2010 +0100
+commit152 - Michaël Jimenez - changes to hdl header struct - Fri Jan 1 20:18:19 2010 +0100
+commit151 - Michaël Jimenez - added code for internal HDD support (HDL format) to cdvdman - Fri Jan 1 15:42:27 2010 +0100
+commit150 - Michaël Jimenez - fixes to SMB code for NAS devices not supporting Unicode strings - Thu Dec 31 09:25:44 2009 +0100
+commit149 - Michaël Jimenez - fixed bug in cdvdfsv never returning CDVD_READY_READY state for blocking mode - Mon Dec 28 21:27:32 2009 +0100
+commit148 - Michaël Jimenez - changes to be able to use a valid disc ID on online games - Sun Dec 27 17:33:49 2009 +0100
+commit147 - volca - Adding the ability to choose the default menu (USB, NET, HDD games). - Sun Dec 27 17:18:04 2009 +0100
+commit146 - volca - Network startup forced to be synchronous (Solution for bug #16, hopefully) - Sun Dec 27 17:00:13 2009 +0100
+commit145 - volca - Better randomization of the port value (And even more hacky). Improves network startup delays significantly here - Sun Dec 27 14:29:14 2009 +0100
+commit144 - Michaël Jimenez - tagged r142 to release 0.6 - Wed Dec 23 20:15:44 2009 +0100
+commit143 - ifcaro - Updated version number - Wed Dec 23 19:15:48 2009 +0100
+commit142 - volca - Hacky SMB speedup: "Randomize" the source port value to avoid port reusal. - Wed Dec 23 13:20:55 2009 +0100
+commit141 - Michaël Jimenez - updated CHANGELOG/CREDTIS/README files - Wed Dec 23 10:45:48 2009 +0100
+commit140 - ifcaro - Added configurable exit button - Tue Dec 22 22:25:22 2009 +0100
+commit139 - ifcaro - Changed UI color controls - Tue Dec 22 19:47:30 2009 +0100
+commit138 - Michaël Jimenez - fixed long reconnection time (yellow screen) - Tue Dec 22 17:33:33 2009 +0100
+commit137 - ifcaro - Added support for multiple partitions - Tue Dec 22 16:54:22 2009 +0100
+commit136 - volca - Fixing linux samba compatibility (White screen removal fix) - Tue Dec 22 14:16:20 2009 +0100
+commit135 - ifcaro - Changed modes text - Tue Dec 22 13:14:19 2009 +0100
+commit134 - Michaël Jimenez - changes to SMSUTILS so it doesn't use PS2SDKSRC env var to build - Mon Dec 21 18:52:28 2009 +0100
+commit133 - Michaël Jimenez - new core merging step3: adapted EE core to new IOP core - Mon Dec 21 16:51:23 2009 +0100
+commit132 - Michaël Jimenez - new core merging step2: added new modules - Mon Dec 21 15:36:12 2009 +0100
+commit131 - Michaël Jimenez - new core merging step1: deleted modules - Mon Dec 21 15:26:46 2009 +0100
+commit130 - volca - Implemented sorting (via select) Page up/down modifier (L1) Home/End (L2/R2) - Wed Dec 2 13:11:06 2009 +0100
+commit129 - volca - Adding two new icons Adding colour selection (a bit rough) Reworked the colour selection to use default and theme introduced values fix for issue #14 Reworked the game list to use one routine and arrays instead of linked lists - Wed Dec 2 10:52:36 2009 +0100
+commit128 - Michaël Jimenez - tagged r126 to release 0.5 - Sun Nov 29 19:58:33 2009 +0100
+commit127 - ifcaro - * Added languages * Changed version number to 0.5 - Sun Nov 29 16:28:09 2009 +0100
+commit126 - volca - Czech welcome message update - Mon Nov 23 16:46:23 2009 +0100
+commit125 - Michaël Jimenez - added ioctl cmd to usbhdfsd to retrieve physical file sector - Sun Nov 22 11:59:09 2009 +0100
+commit124 - Michaël Jimenez - added sifman module, currently unused - Sun Nov 15 20:10:27 2009 +0100
+commit123 - Michaël Jimenez - reduced buffers again in isofs/smbman - Sat Nov 14 16:54:05 2009 +0100
+commit122 - Michaël Jimenez - try to use IPCONFIG.DAT from mc in slot 2 - Fri Nov 13 18:55:53 2009 +0100
+commit121 - Michaël Jimenez - chaanged some modules rules.make to build properly on my Ubuntu environment - Fri Nov 13 17:10:40 2009 +0100
+commit120 - Michaël Jimenez - changes to lwipopts.h to reduce SMSTCPIP mem usage - Fri Nov 13 14:42:11 2009 +0100
+commit119 - Michaël Jimenez - reduced IOP mem usage for isofs/smbman modules - Fri Nov 13 09:43:26 2009 +0100
+commit118 - volca - Correcting hints - Fri Nov 13 09:37:27 2009 +0100
+commit117 - volca - Adding UI component hint feature. Hints on Compat settings now - Thu Nov 12 20:51:39 2009 +0100
+commit116 - Michaël Jimenez - enlighted mass driver mem usage for mode 2 - Thu Nov 12 20:31:08 2009 +0100
+commit115 - Michaël Jimenez - implemented mode 2: have lower mem usage in SMSTCPIP/smbman modules - Thu Nov 12 19:26:35 2009 +0100
+commit114 - Michaël Jimenez - Enabled SMSMAP/SMSTCPIP IOP modules - Thu Nov 12 16:08:21 2009 +0100
+commit113 - Michaël Jimenez - Fixed pink screen, and bugs in IOP reboot - Thu Nov 12 14:47:47 2009 +0100
+commit112 - Michaël Jimenez - reverted loader changes: stupid idea to choose g_buf address at runtime - Wed Nov 11 22:26:12 2009 +0100
+commit111 - Michaël Jimenez - added compat mode 1, inverted modes 4 & 5 - Wed Nov 11 21:28:57 2009 +0100
+commit110 - Michaël Jimenez - added compat mode 4 & 5 - Wed Nov 11 21:08:01 2009 +0100
+commit109 - Michaël Jimenez - added compat mode 3 - Wed Nov 11 20:47:49 2009 +0100
+commit108 - volca - Moving the compat mask to third argument - Wed Nov 11 16:21:25 2009 +0100
+commit107 - volca - FIX: Temporary fix - Second pink freeze for some games - This helps another bit - Wed Nov 11 15:50:07 2009 +0100
+commit106 - volca - Virt. keyboard now uses button icons - Wed Nov 11 14:15:09 2009 +0100
+commit105 - volca - FIX: This removes the freeze on second pink for some games (on my machine) - Wed Nov 11 10:54:19 2009 +0100
+commit104 - volca - Renaming to lower case - caused Error opening with case sensitive linux filesystem - Wed Nov 11 10:14:12 2009 +0100
+commit103 - volca - Adding select and start button icons by JNABK - Wed Nov 11 10:09:52 2009 +0100
+commit102 - volca - FIX: Compat settings now seem to propagate well. Copy-paste introduced bug fixed - Wed Nov 11 09:51:39 2009 +0100
+commit101 - volca - set IP changed flag to ensure IP settings get saved - Wed Nov 11 06:50:21 2009 +0100
+commit100 - volca - Merging changes - Tue Nov 10 22:08:55 2009 +0100
+commit99 - volca - * Pass in the compat settings in the same string * Commenting out the compat modes for now as they freeze here (feel free to test by uncommenting) - Tue Nov 10 22:07:31 2009 +0100
+commit98 - ifcaro - fix: saving config if SYS-CONF doesn't exists - Tue Nov 10 19:50:50 2009 +0100
+commit97 - volca - Compat settings count now 5, propagation to loader.c implemented - Tue Nov 10 19:16:23 2009 +0100
+commit96 - Michaël Jimenez - changes to SMSTCPIP/include/lwipopts.h - Tue Nov 10 12:04:33 2009 +0100
+commit95 - Michaël Jimenez - added missing smap_opt.s, updated CREDITS file - Tue Nov 10 11:34:52 2009 +0100
+commit94 - Michaël Jimenez - add SMSMAP/SMSTCIP modules, currently not used - Tue Nov 10 11:23:26 2009 +0100
+commit93 - Michaël Jimenez - added stuff to build an alternate loader (suitable for Sonic Unleashed) - Tue Nov 10 10:25:24 2009 +0100
+commit92 - volca - FIX: Config loading was removed. Putting it back - Tue Nov 10 09:07:25 2009 +0100
+commit91 - volca - FIX: Error codes are <0, not <=0. This could affect loading if file handle had value 0 - Tue Nov 10 09:06:29 2009 +0100
+commit90 - Michaël Jimenez - reverted netlog loading accidentally committed - Mon Nov 9 20:32:32 2009 +0100
+commit89 - Michaël Jimenez - fix for freezing multi-elf games - Mon Nov 9 20:29:58 2009 +0100
+commit88 - volca - Adding missing icons - Sun Nov 8 21:12:15 2009 +0100
+commit87 - volca - FIX: Issue 10 (share name overflow) FIX: Enum UI component data overlap FIX: Theme listing did not free * Improved the UI. Added hint display capability, new icons for buttons, new config screen * Theme now loads theme.cfg file (bgcolor and textcolor variables) * Removed old IP config * Some other small tweaks - Sun Nov 8 20:04:14 2009 +0100
+commit86 - ifcaro - Show icons at background in config dialogs - Sun Nov 8 02:29:23 2009 +0100
+commit85 - ifcaro - Changed name, updated spanish translation, and now info txt shows in selected language - Sun Nov 8 02:13:54 2009 +0100
+commit84 - Michaël Jimenez - added missing ioman_add header file for dev9 module - Fri Nov 6 21:02:33 2009 +0100
+commit83 - Michaël Jimenez - enlighted dev9 module and added dev9x device driver - Fri Nov 6 20:57:03 2009 +0100
+commit82 - Michaël Jimenez - renamed GetSyscall to GetSycallHandler and use syscallnr header - Fri Nov 6 16:25:36 2009 +0100
+commit81 - volca - FIX: The remaining ip config fields renumbered. That should be it - Fri Nov 6 08:48:56 2009 +0100
+commit80 - volca - Fix: IP config screen had all the settings moved by one (renumbered the dialog but not the value injection) - Fri Nov 6 08:09:20 2009 +0100
+commit79 - volca - Fix for the recent error with media and parts reading. - Thu Nov 5 12:39:02 2009 +0100
+commit78 - Michaël Jimenez - reverting back isofs to rev71 - Wed Nov 4 18:12:29 2009 +0100
+commit77 - Michaël Jimenez - reverted cdvdman & isofs to rev70 - Wed Nov 4 17:18:48 2009 +0100
+commit76 - volca - Reverting this (commit by accident) - Tue Nov 3 21:42:15 2009 +0100
+commit75 - volca - * New compat mode ui (via triangle) - currently without function * Comfigurable share name via Ifcaro's keyboard * Name and Image zero padding to stop string overflows * other small fixes/changes - Tue Nov 3 21:39:13 2009 +0100
+commit74 - Michaël Jimenez - added SIF and SIF RPC init calls to cdvdman - Tue Nov 3 18:50:05 2009 +0100
+commit73 - Michaël Jimenez - few changes to cdvdman and commented unneeded code in smbman - Tue Nov 3 18:34:03 2009 +0100
+commit72 - Michaël Jimenez - fix for those games opening files with other flag than O_RDONLY - Mon Nov 2 18:09:42 2009 +0100
+commit71 - ifcaro - fix: smaller elf at second make all - Mon Nov 2 13:28:11 2009 +0100
+commit70 - Michaël Jimenez - fix for some games freezing while searching for a non-existent file - Mon Nov 2 12:09:40 2009 +0100
+commit69 - ifcaro - Added ugly virtual keyboard - Sun Nov 1 23:21:19 2009 +0100
+commit68 - volca - Merging changes - Sun Nov 1 20:25:52 2009 +0100
+commit67 - volca - New data driven dialog code. Needs color, enum and string inputs to be complete. IP config rewritten to use it. - Sun Nov 1 20:25:10 2009 +0100
+commit66 - Michaël Jimenez - remove pink screen when a IOP reset hook has finished (set_reg_hook reaches 0) - Sun Nov 1 16:18:15 2009 +0100
+commit65 - Michaël Jimenez - fix for white screens: bad gamename crc32 calculation - Sun Nov 1 11:50:30 2009 +0100
+commit64 - volca - Small file adressing fix - Sat Oct 31 19:06:23 2009 +0100
+commit63 - volca - Merged changes - Sat Oct 31 12:22:29 2009 +0100
+commit62 - volca - Some input system rewrites, scrolling after dialog fix, settings only saved on save settings subitem now - Sat Oct 31 12:18:09 2009 +0100
+commit61 - Michaël Jimenez - usbhdfsd: removed use of PS2SDKSRC env var - Sat Oct 31 12:08:12 2009 +0100
+commit60 - volca - Network UI improvements: Port and autostart settings, network loading feedback - Sat Oct 31 09:11:53 2009 +0100
+commit59 - volca - Config handling improved - now remembers the loaded config and stores to the same location Config handling moved to main.c from gfx.c - code organization - Sat Oct 31 07:09:53 2009 +0100
+commit58 - Michaël Jimenez - iso2usbld: only use long long and not __int64 - Fri Oct 30 22:50:27 2009 +0100
+commit57 - Michaël Jimenez - iso2usbld: added commented use of open/read/write/lsee64/close - Fri Oct 30 21:00:58 2009 +0100
+commit56 - Michaël Jimenez - build iso2usbld on make pc_tools - Fri Oct 30 11:37:17 2009 +0100
+commit55 - volca - Adding the missing network icons, sorry everyone! - Fri Oct 30 08:05:09 2009 +0100
+commit54 - volca - Adding network icons by JNABK Czech translation improvements Start network text for better orientation - Thu Oct 29 20:25:46 2009 +0100
+commit53 - Michaël Jimenez - just corrected a comment - Thu Oct 29 17:02:08 2009 +0100
+commit52 - Michaël Jimenez - fix once again to avoid breaking compatibility - Thu Oct 29 16:58:07 2009 +0100
+commit51 - Michaël Jimenez - another fix to fake module load to avoid breaking compatibility - Thu Oct 29 14:07:59 2009 +0100
+commit50 - Michaël Jimenez - fix for faking some modules load correctly - Thu Oct 29 13:16:09 2009 +0100
+commit49 - Michaël Jimenez - fix for multi-elf games freezing on pink - Wed Oct 28 20:22:14 2009 +0100
+commit48 - Michaël Jimenez - fixes for iso2usbld to handle large ISO (>4Gb) - Wed Oct 28 18:29:11 2009 +0100
+commit47 - Michaël Jimenez - renamed PUBLIC share to PS2SMB - Wed Oct 28 16:48:15 2009 +0100
+commit46 - Michaël Jimenez - modified iso2usbld CFLAGS - Wed Oct 28 13:49:58 2009 +0100
+commit45 - Michaël Jimenez - create USBLD folder on mass if not existing - Wed Oct 28 12:34:45 2009 +0100
+commit44 - Michaël Jimenez - apply IP settings to loader/modules - Wed Oct 28 12:00:29 2009 +0100
+commit43 - ifcaro - Added IP configuration screen - Tue Oct 27 21:58:29 2009 +0100
+commit42 - Michaël Jimenez - different fixes, one very important for iso2usbld - Tue Oct 27 20:58:24 2009 +0100
+commit41 - ifcaro - Updated CHANGELOG, README and CREDITS - Tue Oct 27 16:13:35 2009 +0100
+commit40 - ifcaro - Added missing license headers - Mon Oct 26 20:27:06 2009 +0100
+commit39 - Michaël Jimenez - added support to network games trought SMB protocol - Mon Oct 26 18:52:16 2009 +0100
+commit38 - Michaël Jimenez - just acouple changes for isofs patch & cdvdman - Sat Oct 24 20:03:21 2009 +0200
+commit37 - Michaël Jimenez - allow isofs to handle up to 8 parts - Sat Oct 24 17:56:28 2009 +0200
+commit36 - Michaël Jimenez - added .hgtags - Sat Oct 24 16:14:24 2009 +0200
+commit35 - Michaël Jimenez - added missing readonly makefile for mass_driver - Sat Oct 24 16:12:02 2009 +0200
+commit34 - Michaël Jimenez - disabled write support for ingame mass_driver - Sat Oct 24 16:09:31 2009 +0200
+commit33 - Michaël Jimenez - added LICENSE, README, CREDITS and CHANGELOG - Fri Oct 23 10:20:06 2009 +0200
+commit32 - Michaël Jimenez - New_Iop_Reset: switched to reset with EELOADCNF - Thu Oct 22 20:27:52 2009 +0200
+commit31 - ifcaro - Now searchs for USBD.IRX in MC. If not exists load embedded usbd.irx for each platform - Sun Oct 18 20:26:50 2009 +0200
+commit30 - ifcaro - static mode now fit with JNABK templates also in PAL mode - Sun Oct 18 00:48:15 2009 +0200
+commit29 - ifcaro - Fix: Welcome text showing extra text - Sat Oct 17 22:54:56 2009 +0200
+commit28 - ifcaro - fix for PS3 with software emulation - Sat Oct 17 22:43:30 2009 +0200
+commit27 - ifcaro - Added spanish translation - Sat Oct 17 20:44:42 2009 +0200
+commit26 - volca - Oops. These slipped through. Reverting - Sat Oct 17 16:32:20 2009 +0200
+commit25 - volca - Adding save icon - Sat Oct 17 16:30:30 2009 +0200
+commit24 - volca - Adding language support - Sat Oct 17 16:29:49 2009 +0200
+commit23 - volca - * rewritten the config file handling (to use key=val lines) * potential fix for the hang problem while starting - Tue Oct 13 21:56:57 2009 +0200
+commit22 - volca - * cleaning up the code a bit - all menu construction now in main, etc. * icon positioning fixes * second background option (for static menu) added * added new icons (Done by JNABK) * Menu type selection now a menu item insted of select key event - Tue Oct 13 17:55:35 2009 +0200
+commit21 - Michaël Jimenez - isofs: fixed bug in skipmod_check() - Tue Oct 6 08:52:56 2009 +0200
+commit20 - Michaël Jimenez - modified isofs: allow it to fake some module load from cdrom - Mon Oct 5 21:01:36 2009 +0200
+commit19 - ifcaro - fix for 8+3 elf's filename - Sun Oct 4 20:44:48 2009 +0200
+commit18 - ifcaro - Added messages of what is doing makefile - Sun Oct 4 20:43:49 2009 +0200
+commit17 - ifcaro - fix: cdvdman.c:1708: warning: unused variable `netlog_modname' - Sun Oct 4 19:38:27 2009 +0200
+commit16 - Michaël Jimenez - loader: modified Patch_Img into Patch_Mod using g_buf - Sun Oct 4 16:57:37 2009 +0200
+commit15 - Michaël Jimenez - loader now loads at e8000 and use g_buf at 88000 - Sun Oct 4 15:45:04 2009 +0200
+commit14 - Michaël Jimenez - modified cdvdman: added stream and other fixes - Sun Oct 4 15:31:56 2009 +0200
+commit13 - Michaël Jimenez - modified isofs to handle media type - Sun Oct 4 15:13:06 2009 +0200
+commit12 - Michaël Jimenez - moved IOP reset to LoadExecPS2 replacement - Sun Oct 4 14:56:59 2009 +0200
+commit11 - Michaël Jimenez - added debug over ethernet - Sun Oct 4 14:40:10 2009 +0200
+commit10 - ifcaro - Updated interface - Sun Oct 4 02:34:51 2009 +0200
+commit9 - ifcaro - Updated interface with dynamic menu - Fri Oct 2 18:40:33 2009 +0200
+commit8 - Michaël Jimenez - a few fixes so that it can compile - Tue Sep 29 09:39:20 2009 +0200
+commit7 - Michaël Jimenez - iso2usbld: fixes for linux build - Sun Sep 27 21:55:27 2009 +0200
+commit6 - Michaël Jimenez - iso2usbld: fixed those deprecated type casts - Sun Sep 27 21:20:14 2009 +0200
+commit5 - Michaël Jimenez - bugfix for iso2usbld - Sun Sep 27 19:00:50 2009 +0200
+commit4 - Michaël Jimenez - modified .hignore - Sun Sep 27 17:42:30 2009 +0200
+commit3 - ifcaro - added open usb loader sources - Sun Sep 27 17:36:34 2009 +0200
+commit2 - Michaël Jimenez - added iso2usbld - Sun Sep 27 16:28:14 2009 +0200
+commit1 - Michaël Jimenez - added .hgignore - Sun Sep 27 16:20:30 2009 +0200

--- a/include/opl.h
+++ b/include/opl.h
@@ -38,7 +38,6 @@
 // Last Played Auto Start
 #include <time.h>
 
-#define OPL_VERSION "0.9.4 WIP"
 #define OPL_IS_DEV_BUILD 1 //Define if this build is a development build.
 
 //IO type IDs

--- a/lng_pack.sh
+++ b/lng_pack.sh
@@ -4,7 +4,7 @@
 # Set variables
 _dir=$(pwd)
 _bdir="/tmp/opl_lng"
-_rev=$(cat ${_dir}/DETAILED_CHANGELOG | head -11 | tail -n 1 | cut -d " " -f 1 | tr -d "rev" | tr -d "commit")
+_rev=$(cat ${_dir}/Makefile | grep "REVISION =" | head -1 | cut -d " " -f 3)
 
 # Print a list
 printf "$(ls ${_dir}/lng/ | cut -c 6- | rev | cut -c 5- | rev)" > /tmp/opl_lng_list

--- a/make_changelog.sh
+++ b/make_changelog.sh
@@ -25,7 +25,7 @@ then
 fi
 
 # Store author, commit and date on temp file
-git log --pretty=format:"%cn - %s - %cd" > /tmp/commit_summary
+git log --pretty=format:"%an - %s - %cd" > /tmp/commit_summary
 if ! [ "${?}" == "0" ]
 then
  echo "Git command failed, exiting..."


### PR DESCRIPTION
OPL: Update versioning to new scheme
It basically changed version to makefile header because
its more easy to find and detect what OPL Version is,
and also because old method is just hardcoded in one line
and not show revision, and no way to change it without
dirty the code

Makefile:
- first of all, cleanup
- add Git Revision to version, make it easy to find if is
  Official or Unofficial releases, since we can store hash
  commit in a Thread, also it add "-dirty", if no .git found or
  if it is a edited/wip repo
- reworked ifeq logic
- add "make release" to prevent editions before official release, also
  no one use partial edition
- versioning is on .ELF now
- add "make oplversion" to show current OPL Version

TravisCI:
- change versioning to new version scheme
- changed to "make clean" and "make release"
- building of LANGS zip and DETAILED CHANGELOG is made after
  "make" command to prevent addition of "-dirty" to version
- add if to opl_git and opl_extraversion in case of it is "blank"

Others:
- change lng_pack to new version scheme
- fix make_changelog author corruption
- regenerate DETAILED_CHANGELOG
