### PR TITLE
Update dialogs.c - completing X and Y Offset implementation in GUI

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -412,12 +412,12 @@ struct UIItem diaUIConfig[] = {
     {UI_ENUM, UICFG_VMODE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"X-Offset", -1}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_HINT_XOFFSET}}},
     {UI_SPACER},
     {UI_INT, UICFG_XOFF, 1, 1, -1, 0, 0, {.intvalue = {0, 0, -300, 300}}},
     {UI_BREAK},
 
-    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Y-Offset", -1}}},
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_HINT_YOFFSET}}},
     {UI_SPACER},
     {UI_INT, UICFG_YOFF, 1, 1, -1, 0, 0, {.intvalue = {0, 0, -300, 300}}},
     {UI_BREAK},


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author.

## Pull Request description

This allows X and Y Offset strings not to be hardcoded anymore in the GUI. X and Y Offset will use the same string as X and Y Offset (Hint text) from GSM menu (no change need in lang files).