### PR TITLE
Fix for HDD size calculation, new poweroff processing mechanism, fixed PBUF allocation for Ethernet ARP request, new option for SMSTCPIP to save more RAM. 

### DIFF
--- a/modules/network/SMSTCPIP/etharp.c
+++ b/modules/network/SMSTCPIP/etharp.c
@@ -759,7 +759,10 @@ err_t etharp_query(struct netif *netif, struct ip_addr *ipaddr, struct pbuf *q)
     if (perform_arp_request) {
         struct pbuf *p;
         /* allocate a pbuf for the outgoing ARP request packet */
-        p = pbuf_alloc(PBUF_LINK, sizeof(struct etharp_hdr), PBUF_RAM);
+        /* SP193: the original used PBUF_LINK, but doesn't reveal the Ethernet header with pbuf_header().
+		So other than causing alignment problems when the frame is sent to linkoutput(),
+		I guess it could possibly write beyond the end of the PBUF. */
+        p = pbuf_alloc(PBUF_RAW, sizeof(struct etharp_hdr), PBUF_RAM);
         /* could allocate pbuf? */
         if (p != NULL) {
             u8_t j;

--- a/modules/network/SMSTCPIP/include/arch/sys_arch.h
+++ b/modules/network/SMSTCPIP/include/arch/sys_arch.h
@@ -8,4 +8,15 @@ typedef int sys_thread_t;
 
 #define SYS_MBOX_NULL NULL
 #define SYS_SEM_NULL 0
+
+#if MEM_LIBC_MALLOC
+void *ps2ip_mem_malloc(int size);
+void ps2ip_mem_free(void *rmem);
+void *ps2ip_mem_realloc(void *rmem, int newsize);
+
+#define mem_clib_free       ps2ip_mem_free
+#define mem_clib_malloc     ps2ip_mem_malloc
+#define mem_clib_realloc    ps2ip_mem_realloc
+#endif
+
 #endif /* __SYS_ARCH_H__ */

--- a/modules/network/SMSTCPIP/include/lwip/opt.h
+++ b/modules/network/SMSTCPIP/include/lwip/opt.h
@@ -53,6 +53,15 @@
 #define NO_SYS 0
 #endif
 /* ---------- Memory options ---------- */
+/**
+ * MEM_LIBC_MALLOC==1: Use malloc/free/realloc provided by your C-library
+ * instead of the lwip internal allocator. Can save code size if you
+ * already use it.
+ */
+#if !defined MEM_LIBC_MALLOC
+#define MEM_LIBC_MALLOC 0
+#endif
+
 /* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
    lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
    byte alignment -> define MEM_ALIGNMENT to 2. */

--- a/modules/network/SMSTCPIP/include/lwipopts.h
+++ b/modules/network/SMSTCPIP/include/lwipopts.h
@@ -3,6 +3,13 @@
 
 #define LWIP_CALLBACK_API 1
 /* ---------- Memory options ---------- */
+/**
+ * MEM_LIBC_MALLOC==1: Use malloc/free/realloc provided by your C-library
+ * instead of the lwip internal allocator. Can save code size if you
+ * already use it.
+ */
+#define MEM_LIBC_MALLOC 1
+
 /* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
    lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
    byte alignment -> define MEM_ALIGNMENT to 2. */

--- a/modules/network/SMSTCPIP/mem.c
+++ b/modules/network/SMSTCPIP/mem.c
@@ -51,6 +51,79 @@
 
 #include "smsutils.h"
 
+#if MEM_LIBC_MALLOC
+/** mem_init is not used when using C library malloc().
+ */
+void
+mem_init(void)
+{
+}
+
+/* lwIP heap implemented using C library malloc() */
+
+/* in case C library malloc() needs extra protection,
+ * allow these defines to be overridden.
+ */
+#ifndef mem_clib_free
+#define mem_clib_free free
+#endif
+#ifndef mem_clib_malloc
+#define mem_clib_malloc malloc
+#endif
+#ifndef mem_clib_realloc
+#define mem_clib_realloc realloc
+#endif
+
+/**
+ * Allocate a block of memory with a minimum of 'size' bytes.
+ *
+ * @param size is the minimum size of the requested block in bytes.
+ * @return pointer to allocated memory or NULL if no free memory was found.
+ *
+ * Note that the returned value must always be aligned (as defined by MEM_ALIGNMENT).
+ */
+void *
+mem_malloc(mem_size_t size)
+{
+    void* ret = mem_clib_malloc(size);
+    if (ret == NULL) {
+#if MEM_STATS
+        ++lwip_stats.mem.err;
+#endif /* MEM_STATS */
+    } else {
+      LWIP_ASSERT("malloc() must return aligned memory", LWIP_MEM_ALIGN(ret) == ret);
+    }
+    return ret;
+}
+
+/** Put memory back on the heap
+ *
+ * @param rmem is the pointer as returned by a previous call to mem_malloc()
+ */
+void
+mem_free(void *rmem)
+{
+    LWIP_ASSERT("rmem != NULL", (rmem != NULL));
+    LWIP_ASSERT("rmem == MEM_ALIGN(rmem)", (rmem == LWIP_MEM_ALIGN(rmem)));
+    mem_clib_free(rmem);
+}
+
+void *
+mem_realloc(void *rmem, mem_size_t newsize)
+{
+    void* ret = mem_clib_realloc(rmem, newsize);
+    if (ret == NULL) {
+#if MEM_STATS
+        ++lwip_stats.mem.err;
+#endif /* MEM_STATS */
+    } else {
+      LWIP_ASSERT("realloc() must return aligned memory", LWIP_MEM_ALIGN(ret) == ret);
+    }
+    return ret;
+}
+
+#else
+
 struct mem
 {
     mem_size_t next, prev;
@@ -177,18 +250,6 @@ void mem_free(void *rmem)
     plug_holes(mem);
     SYS_ARCH_UNPROTECT(old_level);
 }
-void *
-mem_reallocm(void *rmem, mem_size_t newsize)
-{
-    void *nmem;
-    nmem = mem_malloc(newsize);
-    if (nmem == NULL) {
-        return mem_realloc(rmem, newsize);
-    }
-    mips_memcpy(nmem, rmem, newsize);
-    mem_free(rmem);
-    return nmem;
-}
 
 void *
 mem_realloc(void *rmem, mem_size_t newsize)
@@ -242,6 +303,7 @@ mem_realloc(void *rmem, mem_size_t newsize)
     SYS_ARCH_UNPROTECT(old_level);
     return rmem;
 }
+
 void *
 mem_malloc(mem_size_t size)
 {
@@ -314,4 +376,19 @@ mem_malloc(mem_size_t size)
 #endif /* MEM_STATS */
     SYS_ARCH_UNPROTECT(old_level);
     return NULL;
+}
+
+#endif	/* MEM_LIBC_MALLOC */
+
+void *
+mem_reallocm(void *rmem, mem_size_t newsize)
+{
+    void *nmem;
+    nmem = mem_malloc(newsize);
+    if (nmem == NULL) {
+        return mem_realloc(rmem, newsize);
+    }
+    mips_memcpy(nmem, rmem, newsize);
+    mem_free(rmem);
+    return nmem;
 }

--- a/modules/network/smap-ingame/xfer.c
+++ b/modules/network/smap-ingame/xfer.c
@@ -29,7 +29,7 @@ static inline int CopyToFIFOWithDMA(volatile u8 *smap_regbase, void *buffer, int
     int NumBlocks;
     int result;
 
-    if (((unsigned int)buffer & 3) == 0 && (NumBlocks = length >> 7) > 0) {
+    if ((NumBlocks = length >> 7) > 0) {
         if (dev9DmaTransfer(1, buffer, NumBlocks << 16 | 0x20, DMAC_FROM_MEM) >= 0) {
             result = NumBlocks << 7;
         } else
@@ -205,14 +205,10 @@ int SMAPSendPacket(const void *data, unsigned int length)
             "beqz    $at, 3f\n\t"
             "andi    %1, %1, 0xF\n\t"
             "4:\n\t"
-            "lwr     $t0,  0(%0)\n\t"
-            "lwl     $t0,  3(%0)\n\t"
-            "lwr     $t1,  4(%0)\n\t"
-            "lwl     $t1,  7(%0)\n\t"
-            "lwr     $t2,  8(%0)\n\t"
-            "lwl     $t2, 11(%0)\n\t"
-            "lwr     $t3, 12(%0)\n\t"
-            "lwl     $t3, 15(%0)\n\t"
+            "lw      $t0,  0(%0)\n\t"
+            "lw      $t1,  4(%0)\n\t"
+            "lw      $t2,  8(%0)\n\t"
+            "lw      $t3, 12(%0)\n\t"
             "addiu   $at, $at, -1\n\t"
             "sw      $t0, 4352($v1)\n\t"
             "sw      $t1, 4352($v1)\n\t"
@@ -224,8 +220,7 @@ int SMAPSendPacket(const void *data, unsigned int length)
             "beqz    %1, 1f\n\t"
             "nop\n\t"
             "2:\n\t"
-            "lwr     $v0, 0(%0)\n\t"
-            "lwl     $v0, 3(%0)\n\t"
+            "lw      $v0, 0(%0)\n\t"
             "addiu   %1, %1, -4\n\t"
             "sw      $v0, 4352($v1)\n\t"
             "bnez    %1, 2b\n\t"

--- a/src/hdd.c
+++ b/src/hdd.c
@@ -212,7 +212,7 @@ int hddGetHDLGamelist(hdl_games_list_t *game_list)
                     pGameEntry->lba = dirent.stat.private_5 + (HDL_GAME_DATA_OFFSET + 4096) / 512;
                 }
 
-                pGameEntry->size += (dirent.stat.hisize << 21) | (dirent.stat.size >> 11); //size in bytes / 2048
+                pGameEntry->size += (dirent.stat.size / 4); //size in sectors * (512 / 2048)
             }
         }
 

--- a/src/system.c
+++ b/src/system.c
@@ -323,6 +323,8 @@ void sysReset(int modload_mask)
 
 void sysPowerOff(void)
 {
+    deinit(NO_EXCEPTION);
+    fileXioDevctl("dev9x:", DDIOC_OFF, NULL, 0, NULL, 0);
     poweroffShutdown();
 }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author.

## Pull Request description

45e99f0 - Fixed HDD partition size calculation. Originally, our HDD.IRX module used to return the partition size in bytes. Eventually, that got changed to fit the official documentation, which returns in 512-byte sectors.
8cadeb4 - Corrected bug in PBUF allocation for Ethernet ARP requests and changed the SMAP output function to always assume that outgoing PBUFs are always aligned (for performance). Previously, the outgoing PBUFs were occasionally unaligned because of this glitch.
4a9a5a7 - As of the recent PS2SDK commit, poweroff no longer automatically switches off DEV9 as a safety measure. OPL will now deinitialize the GUI before switching off DEV9, before finally switching off the PS2.
13d1347 - Our SMSTCPIP module is based on an ancient version of LWIP, which always uses its own memory heap allocator (even though SYSMEM can fill that requirement). This patch adds and enables a new option (MEM_LIBC_MALLOC), which functions like the official version from the newer versions of LWIP.