### PR TITLE
Update pademu

### DIFF
--- a/ee_core/include/ee_core.h
+++ b/ee_core/include/ee_core.h
@@ -80,7 +80,6 @@ int EnableCheatOp;
 #ifdef PADEMU
 int EnablePadEmuOp;
 int PadEmuSettings;
-int pademu_reset();
 #endif
 
 int DisableDebug;

--- a/ee_core/src/iopmgr.c
+++ b/ee_core/src/iopmgr.c
@@ -121,11 +121,6 @@ int New_Reset_Iop(const char *arg, int arglen)
 
     iop_reboot_count++;
 
-#ifdef PADEMU
-    if (iop_reboot_count >= 3 && EnablePadEmuOp) {
-        pademu_reset();
-    }
-#endif
     // Reseting IOP.
     while (!Reset_Iop(NULL, 0)) {
         ;

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -183,10 +183,6 @@ static void IGR_Thread(void *arg)
         if (!DisableDebug)
             GS_BGCOLOUR = 0xFFFFFF; // White
 
-#ifdef PADEMU
-        if (EnablePadEmuOp)
-            pademu_reset();
-#endif
         // Re-Init RPC & CMD
         SifInitRpc(0);
 
@@ -628,23 +624,4 @@ int Install_PadOpen_Hook(u32 mem_start, u32 mem_end, int mode)
 
     return patched;
 }
-#ifdef PADEMU
 
-#define PADEMU_RESET 1
-#define PADEMU_BIND_RPC_ID 0x18E3878D
-
-static SifRpcClientData_t pademu;
-
-int pademu_reset()
-{
-    pademu.server = NULL;
-
-    do {
-        if (SifBindRpc(&pademu, PADEMU_BIND_RPC_ID, 0) < 0)
-            return -1;
-        nopdelay();
-    } while (!pademu.server);
-
-    return SifCallRpc(&pademu, PADEMU_RESET, 0, NULL, 0, NULL, 0, NULL, NULL);
-}
-#endif

--- a/modules/debug/udptty-ingame/imports.lst
+++ b/modules/debug/udptty-ingame/imports.lst
@@ -36,7 +36,7 @@ I_strncmp
 sysclib_IMPORTS_end
 
 sysmem_IMPORTS_start
-I_Kprintf_set
+I_KprintfSet
 sysmem_IMPORTS_end
 
 ps2ip_IMPORTS_start

--- a/modules/debug/udptty-ingame/udptty.c
+++ b/modules/debug/udptty-ingame/udptty.c
@@ -181,7 +181,7 @@ void kprtty_init(void)
     thid = CreateThread(&thp);
     StartThread(thid, (void *)kpa);
 
-    Kprintf_set((kprintf_handler_func_t *)Kprintf_Handler, (u32)kpa);
+    KprintfSet((KprintfHandler_t *)Kprintf_Handler, (u32*)kpa);
 }
 #endif
 

--- a/modules/debug/udptty/imports.lst
+++ b/modules/debug/udptty/imports.lst
@@ -36,7 +36,7 @@ I_strncmp
 sysclib_IMPORTS_end
 
 sysmem_IMPORTS_start
-I_Kprintf_set
+I_KprintfSet
 sysmem_IMPORTS_end
 
 ps2ip_IMPORTS_start

--- a/modules/debug/udptty/udptty.c
+++ b/modules/debug/udptty/udptty.c
@@ -181,7 +181,7 @@ void kprtty_init(void)
     thid = CreateThread(&thp);
     StartThread(thid, (void *)kpa);
 
-    Kprintf_set((kprintf_handler_func_t *)Kprintf_Handler, (u32)kpa);
+    KprintfSet((KprintfHandler_t *)Kprintf_Handler, (u32*)kpa);
 }
 #endif
 

--- a/modules/ds3bt/ee/libds3bt.c
+++ b/modules/ds3bt/ee/libds3bt.c
@@ -25,7 +25,7 @@ int ds3bt_init()
 
     do {
         if (SifBindRpc(&ds3bt, DS3BT_BIND_RPC_ID, 0) < 0)
-            return -1;
+            return 0;
 
         nopdelay();
     } while (!ds3bt.server);
@@ -38,7 +38,7 @@ int ds3bt_init()
 int ds3bt_reinit_ports(u8 ports)
 {
     if (!ds3bt_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = ports;
     return SifCallRpc(&ds3bt, DS3BT_INIT, 0, rpcbuf, 1, NULL, 0, NULL, NULL);
@@ -47,7 +47,7 @@ int ds3bt_reinit_ports(u8 ports)
 int ds3bt_init_charging()
 {
     if (!ds3bt_inited)
-        return -1;
+        return 0;
 
     return SifCallRpc(&ds3bt, DS3BT_INIT_CHARGING, 0, NULL, 0, NULL, 0, NULL, NULL);
 }
@@ -55,7 +55,7 @@ int ds3bt_init_charging()
 int ds3bt_get_status(int port)
 {
     if (!ds3bt_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = port;
 
@@ -69,7 +69,7 @@ int ds3bt_get_bdaddr(u8 *bdaddr)
     int i, ret;
 
     if (!ds3bt_inited)
-        return -1;
+        return 0;
 
     ret = SifCallRpc(&ds3bt, DS3BT_GET_BDADDR, 0, NULL, 0, rpcbuf, 6, NULL, NULL);
 
@@ -82,7 +82,7 @@ int ds3bt_get_bdaddr(u8 *bdaddr)
 int ds3bt_set_rumble(int port, u8 lrum, u8 rrum)
 {
     if (!ds3bt_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = port;
     rpcbuf[1] = lrum;
@@ -94,7 +94,7 @@ int ds3bt_set_rumble(int port, u8 lrum, u8 rrum)
 int ds3bt_set_led(int port, u8 led)
 {
     if (!ds3bt_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = port;
     rpcbuf[1] = led;
@@ -107,7 +107,7 @@ int ds3bt_get_data(int port, u8 *data)
     int ret;
 
     if (!ds3bt_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = port;
 
@@ -121,7 +121,7 @@ int ds3bt_get_data(int port, u8 *data)
 int ds3bt_reset()
 {
     if (!ds3bt_inited)
-        return -1;
+        return 0;
 
     return SifCallRpc(&ds3bt, DS3BT_RESET, 0, NULL, 0, NULL, 0, NULL, NULL);
 }

--- a/modules/ds3bt/ee/libds3bt.c
+++ b/modules/ds3bt/ee/libds3bt.c
@@ -41,7 +41,7 @@ int ds3bt_reinit_ports(u8 ports)
         return 0;
 
     rpcbuf[0] = ports;
-    return SifCallRpc(&ds3bt, DS3BT_INIT, 0, rpcbuf, 1, NULL, 0, NULL, NULL);
+    return (SifCallRpc(&ds3bt, DS3BT_INIT, 0, rpcbuf, 1, NULL, 0, NULL, NULL) == 0);
 }
 
 int ds3bt_init_charging()
@@ -49,7 +49,7 @@ int ds3bt_init_charging()
     if (!ds3bt_inited)
         return 0;
 
-    return SifCallRpc(&ds3bt, DS3BT_INIT_CHARGING, 0, NULL, 0, NULL, 0, NULL, NULL);
+    return (SifCallRpc(&ds3bt, DS3BT_INIT_CHARGING, 0, NULL, 0, NULL, 0, NULL, NULL) == 0);
 }
 
 int ds3bt_get_status(int port)
@@ -71,7 +71,7 @@ int ds3bt_get_bdaddr(u8 *bdaddr)
     if (!ds3bt_inited)
         return 0;
 
-    ret = SifCallRpc(&ds3bt, DS3BT_GET_BDADDR, 0, NULL, 0, rpcbuf, 6, NULL, NULL);
+    ret = (SifCallRpc(&ds3bt, DS3BT_GET_BDADDR, 0, NULL, 0, rpcbuf, 6, NULL, NULL) == 0);
 
     for (i = 0; i < 6; i++)
         bdaddr[i] = rpcbuf[i];
@@ -88,7 +88,7 @@ int ds3bt_set_rumble(int port, u8 lrum, u8 rrum)
     rpcbuf[1] = lrum;
     rpcbuf[2] = rrum;
 
-    return SifCallRpc(&ds3bt, DS3BT_SET_RUMBLE, 0, rpcbuf, 3, NULL, 0, NULL, NULL);
+    return (SifCallRpc(&ds3bt, DS3BT_SET_RUMBLE, 0, rpcbuf, 3, NULL, 0, NULL, NULL) == 0);
 }
 
 int ds3bt_set_led(int port, u8 led)
@@ -99,7 +99,7 @@ int ds3bt_set_led(int port, u8 led)
     rpcbuf[0] = port;
     rpcbuf[1] = led;
 
-    return SifCallRpc(&ds3bt, DS3BT_SET_LED, 0, rpcbuf, 2, NULL, 0, NULL, NULL);
+    return (SifCallRpc(&ds3bt, DS3BT_SET_LED, 0, rpcbuf, 2, NULL, 0, NULL, NULL) == 0);
 }
 
 int ds3bt_get_data(int port, u8 *data)
@@ -111,7 +111,7 @@ int ds3bt_get_data(int port, u8 *data)
 
     rpcbuf[0] = port;
 
-    ret = SifCallRpc(&ds3bt, DS3BT_GET_DATA, 0, rpcbuf, 1, rpcbuf, 18, NULL, NULL);
+    ret = (SifCallRpc(&ds3bt, DS3BT_GET_DATA, 0, rpcbuf, 1, rpcbuf, 18, NULL, NULL) == 0);
 
     memcpy(data, rpcbuf, 18);
 
@@ -123,5 +123,5 @@ int ds3bt_reset()
     if (!ds3bt_inited)
         return 0;
 
-    return SifCallRpc(&ds3bt, DS3BT_RESET, 0, NULL, 0, NULL, 0, NULL, NULL);
+    return (SifCallRpc(&ds3bt, DS3BT_RESET, 0, NULL, 0, NULL, 0, NULL, NULL) == 0);
 }

--- a/modules/ds3usb/ee/libds3usb.c
+++ b/modules/ds3usb/ee/libds3usb.c
@@ -41,7 +41,7 @@ int ds3usb_reinit_ports(u8 ports)
         return 0;
 
     rpcbuf[0] = ports;
-    return SifCallRpc(&ds3usb, DS3USB_INIT, 0, rpcbuf, 1, NULL, 0, NULL, NULL);
+    return (SifCallRpc(&ds3usb, DS3USB_INIT, 0, rpcbuf, 1, NULL, 0, NULL, NULL) == 0);
 }
 
 int ds3usb_get_status(int port)
@@ -65,7 +65,7 @@ int ds3usb_get_bdaddr(int port, u8 *bdaddr)
 
     rpcbuf[0] = port;
 
-    ret = SifCallRpc(&ds3usb, DS3USB_GET_BDADDR, 0, rpcbuf, 1, rpcbuf, 6, NULL, NULL);
+    ret = (SifCallRpc(&ds3usb, DS3USB_GET_BDADDR, 0, rpcbuf, 1, rpcbuf, 6, NULL, NULL) == 0);
 
     for (i = 0; i < 6; i++)
         bdaddr[i] = rpcbuf[i];
@@ -85,7 +85,7 @@ int ds3usb_set_bdaddr(int port, u8 *bdaddr)
     for (i = 0; i < 6; i++)
         rpcbuf[i + 1] = bdaddr[i];
 
-    return SifCallRpc(&ds3usb, DS3USB_SET_BDADDR, 0, rpcbuf, 7, NULL, 0, NULL, NULL);
+    return (SifCallRpc(&ds3usb, DS3USB_SET_BDADDR, 0, rpcbuf, 7, NULL, 0, NULL, NULL) == 0);
 }
 
 int ds3usb_set_rumble(int port, u8 lrum, u8 rrum)
@@ -97,7 +97,7 @@ int ds3usb_set_rumble(int port, u8 lrum, u8 rrum)
     rpcbuf[1] = lrum;
     rpcbuf[2] = rrum;
 
-    return SifCallRpc(&ds3usb, DS3USB_SET_RUMBLE, 0, rpcbuf, 3, NULL, 0, NULL, NULL);
+    return (SifCallRpc(&ds3usb, DS3USB_SET_RUMBLE, 0, rpcbuf, 3, NULL, 0, NULL, NULL) == 0);
 }
 
 int ds3usb_set_led(int port, u8 led)
@@ -108,7 +108,7 @@ int ds3usb_set_led(int port, u8 led)
     rpcbuf[0] = port;
     rpcbuf[1] = led;
 
-    return SifCallRpc(&ds3usb, DS3USB_SET_LED, 0, rpcbuf, 2, NULL, 0, NULL, NULL);
+    return (SifCallRpc(&ds3usb, DS3USB_SET_LED, 0, rpcbuf, 2, NULL, 0, NULL, NULL) == 0);
 }
 
 int ds3usb_get_data(int port, u8 *data)
@@ -120,7 +120,7 @@ int ds3usb_get_data(int port, u8 *data)
 
     rpcbuf[0] = port;
 
-    ret = SifCallRpc(&ds3usb, DS3USB_GET_DATA, 0, rpcbuf, 1, rpcbuf, 18, NULL, NULL);
+    ret = (SifCallRpc(&ds3usb, DS3USB_GET_DATA, 0, rpcbuf, 1, rpcbuf, 18, NULL, NULL) == 0);
 
     memcpy(data, rpcbuf, 18);
 
@@ -132,5 +132,5 @@ int ds3usb_reset()
     if (!ds3usb_inited)
         return 0;
 
-    return SifCallRpc(&ds3usb, DS3USB_RESET, 0, NULL, 0, NULL, 0, NULL, NULL);
+    return (SifCallRpc(&ds3usb, DS3USB_RESET, 0, NULL, 0, NULL, 0, NULL, NULL) == 0);
 }

--- a/modules/ds3usb/ee/libds3usb.c
+++ b/modules/ds3usb/ee/libds3usb.c
@@ -25,7 +25,7 @@ int ds3usb_init()
 
     do {
         if (SifBindRpc(&ds3usb, DS3USB_BIND_RPC_ID, 0) < 0)
-            return -1;
+            return 0;
 
         nopdelay();
     } while (!ds3usb.server);
@@ -38,7 +38,7 @@ int ds3usb_init()
 int ds3usb_reinit_ports(u8 ports)
 {
     if (!ds3usb_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = ports;
     return SifCallRpc(&ds3usb, DS3USB_INIT, 0, rpcbuf, 1, NULL, 0, NULL, NULL);
@@ -47,7 +47,7 @@ int ds3usb_reinit_ports(u8 ports)
 int ds3usb_get_status(int port)
 {
     if (!ds3usb_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = port;
 
@@ -61,7 +61,7 @@ int ds3usb_get_bdaddr(int port, u8 *bdaddr)
     int i, ret;
 
     if (!ds3usb_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = port;
 
@@ -78,7 +78,7 @@ int ds3usb_set_bdaddr(int port, u8 *bdaddr)
     int i;
 
     if (!ds3usb_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = port;
 
@@ -91,7 +91,7 @@ int ds3usb_set_bdaddr(int port, u8 *bdaddr)
 int ds3usb_set_rumble(int port, u8 lrum, u8 rrum)
 {
     if (!ds3usb_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = port;
     rpcbuf[1] = lrum;
@@ -103,7 +103,7 @@ int ds3usb_set_rumble(int port, u8 lrum, u8 rrum)
 int ds3usb_set_led(int port, u8 led)
 {
     if (!ds3usb_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = port;
     rpcbuf[1] = led;
@@ -116,7 +116,7 @@ int ds3usb_get_data(int port, u8 *data)
     int ret;
 
     if (!ds3usb_inited)
-        return -1;
+        return 0;
 
     rpcbuf[0] = port;
 
@@ -130,7 +130,7 @@ int ds3usb_get_data(int port, u8 *data)
 int ds3usb_reset()
 {
     if (!ds3usb_inited)
-        return -1;
+        return 0;
 
     return SifCallRpc(&ds3usb, DS3USB_RESET, 0, NULL, 0, NULL, 0, NULL, NULL);
 }

--- a/modules/mcemu/mcemu.c
+++ b/modules/mcemu/mcemu.c
@@ -89,7 +89,7 @@ void StartNow(void *param)
 #ifdef PADEMU
     exp = GetExportTable("pademu", 0x101);
     if (exp != NULL) {
-        pademu_hookSio2man = GetExportEntry(exp, 0);
+        pademu_hookSio2man = GetExportEntry(exp, 4);
     } else {
         pademu_hookSio2man = no_pademu;
     }

--- a/modules/pademu/Makefile
+++ b/modules/pademu/Makefile
@@ -15,7 +15,7 @@ endif
 
 IOP_OBJS := $(IOP_OBJS:%=$(IOP_OBJNAME)%)
 
-IOP_CFLAGS += -Wall -fno-builtin
+IOP_CFLAGS += -Wall -fno-builtin -DUSE_SMSUTILS
 IOP_LDFLAGS += -s
 
 all: $(IOP_BIN)

--- a/modules/pademu/Makefile
+++ b/modules/pademu/Makefile
@@ -8,7 +8,7 @@ IOP_OBJS += ds3usb.o
 endif
 ifeq ($(USE_BT),1)
 IOP_BIN = bt_pademu.irx
-IOP_CFLAGS += -DBT
+IOP_CFLAGS += -DBT -DUSE_THREAD
 IOP_OBJNAME = bt.
 IOP_OBJS += ds3bt.o
 endif

--- a/modules/pademu/ds3bt.c
+++ b/modules/pademu/ds3bt.c
@@ -1466,7 +1466,10 @@ static void update_thread(void *param)
 
         UsbBulkTransfer(bt_dev.inEndp, l2cap_buf, MAX_BUFFER_SIZE, l2cap_event_cb, (void *)update_port);
 
+        WaitSema(bt_dev.l2cap_sema);
+
         SignalSema(bt_dev.hci_sema);
+        SignalSema(bt_dev.l2cap_sema);
 
         SignalSema(update_sema);
     }

--- a/modules/pademu/ds3bt.h
+++ b/modules/pademu/ds3bt.h
@@ -267,7 +267,7 @@ enum eBUF_SIZE {
 int ds3bt_init(uint8_t pads);
 int ds3bt_get_status(int port);
 void ds3bt_reset();
-void ds3bt_get_data(char *dst, int size, int port);
+int ds3bt_get_data(char *dst, int size, int mode_lock, int port);
 void ds3bt_set_rumble(uint8_t lrum, uint8_t rrum, int port);
 
 #endif

--- a/modules/pademu/ds3bt.h
+++ b/modules/pademu/ds3bt.h
@@ -267,7 +267,8 @@ enum eBUF_SIZE {
 int ds3bt_init(uint8_t pads);
 int ds3bt_get_status(int port);
 void ds3bt_reset();
-int ds3bt_get_data(char *dst, int size, int mode_lock, int port);
+int ds3bt_get_data(char *dst, int size, int port);
 void ds3bt_set_rumble(uint8_t lrum, uint8_t rrum, int port);
+void ds3bt_set_mode(int mode, int lock, int port);
 
 #endif

--- a/modules/pademu/ds3usb.c
+++ b/modules/pademu/ds3usb.c
@@ -37,6 +37,14 @@ static uint8_t output_01_report[] =
         0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00};
 
+static uint8_t led_patterns[][2] =
+{
+    { 0x1C, 0x02 },
+    { 0x1A, 0x04 },
+    { 0x16, 0x08 },
+    { 0x0E, 0x10 }, 
+};
+
 static uint8_t usb_buf[MAX_BUFFER_SIZE] __attribute((aligned(4))) = {0};
 
 int usb_probe(int devId);
@@ -66,6 +74,7 @@ typedef struct _usb_ds3
     uint8_t oldrrumble;
     uint8_t data[18];
     uint8_t enabled;
+    uint8_t analog_btn;
 } ds3usb_device;
 
 ds3usb_device ds3pad[MAX_PADS];
@@ -178,6 +187,9 @@ int usb_disconnect(int devId)
 
 static void usb_release(int pad)
 {
+    if (ds3pad[pad].sema >= 0)
+        WaitSema(ds3pad[pad].sema);
+    
     if (ds3pad[pad].eventEndp >= 0)
         UsbCloseEndpoint(ds3pad[pad].eventEndp);
 
@@ -193,7 +205,8 @@ static void usb_release(int pad)
 static void usb_data_cb(int resultCode, int bytes, void *arg)
 {
     int pad = (int)arg;
-
+    
+    PollSema(ds3pad[pad].sema);
     //DPRINTF("usb_data_cb: res %d, bytes %d, arg %p \n", resultCode, bytes, arg);
 
     if (!resultCode)
@@ -264,10 +277,18 @@ static void readReport(uint8_t *data, int pad)
         ds3pad[pad].data[16] = data[DATA_START + PressureL2]; //L2
         ds3pad[pad].data[17] = data[DATA_START + PressureR2]; //R2
 
-        if (data[DATA_START + PSButtonState]) //display battery level
-            ds3pad[pad].oldled = ~(1 << data[DATA_START + Power]) & 0x1E;
+        if (data[DATA_START + PSButtonState]) { //display battery level
+            if(data[DATA_START + ButtonStateL] == 0x01) { //PS + SELECT
+                if(ds3pad[pad].analog_btn < 2) //unlocked mode 
+                    ds3pad[pad].analog_btn = !ds3pad[pad].analog_btn;
+
+                ds3pad[pad].oldled = led_patterns[pad][(ds3pad[pad].analog_btn & 1)];
+            }
+            else
+                ds3pad[pad].oldled = ~(1 << data[DATA_START + Power]) & 0x1E;
+        }
         else
-            ds3pad[pad].oldled = (pad + 1) << 1;
+            ds3pad[pad].oldled = led_patterns[pad][(ds3pad[pad].analog_btn & 1)];
 
         if (data[DATA_START + Power] == 0xEE) //charging
             ds3pad[pad].oldled |= 0x80;
@@ -309,7 +330,12 @@ static uint8_t LED(uint8_t led, int pad)
 
 static uint8_t Rumble(uint8_t lrum, uint8_t rrum, int pad)
 {
-    return LEDRumble(ds3pad[pad].oldled, lrum, rrum, pad);
+    uint8_t ret;
+
+    ret = LEDRumble(ds3pad[pad].oldled, lrum, rrum, pad);
+    WaitSema(ds3pad[pad].sema);
+
+    return ret;
 }
 
 void ds3usb_set_rumble(uint8_t lrum, uint8_t rrum, int port)
@@ -318,22 +344,28 @@ void ds3usb_set_rumble(uint8_t lrum, uint8_t rrum, int port)
 
     Rumble(lrum, rrum, port);
 
-    WaitSema(ds3pad[port].sema);
-
     SignalSema(ds3pad[port].sema);
 }
 
-void ds3usb_get_data(char *dst, int size, int port)
+int ds3usb_get_data(char *dst, int size, int mode_lock, int port)
 {
+    int ret;
+    
     WaitSema(ds3pad[port].sema);
+
+    if(mode_lock)
+        ds3pad[port].analog_btn = mode_lock;
 
     UsbInterruptTransfer(ds3pad[port].eventEndp, usb_buf, MAX_BUFFER_SIZE, usb_data_cb, (void *)port);
 
     WaitSema(ds3pad[port].sema);
 
     mips_memcpy(dst, ds3pad[port].data, size);
+    ret = ds3pad[port].analog_btn & 1;
 
     SignalSema(ds3pad[port].sema);
+
+    return ret;
 }
 
 void ds3usb_reset()
@@ -346,7 +378,18 @@ void ds3usb_reset()
 
 int ds3usb_get_status(int port)
 {
-    return ds3pad[port].status;
+    int status;
+
+    if (ds3pad[port].sema >= 0) {
+        WaitSema(ds3pad[port].sema);
+        status = ds3pad[port].status;
+        SignalSema(ds3pad[port].sema);
+    }
+    else {
+        return ds3pad[port].status;
+    }
+    
+    return status;
 }
 
 int ds3usb_init(uint8_t pads)
@@ -367,6 +410,7 @@ int ds3usb_init(uint8_t pads)
 
         ds3pad[pad].data[0] = 0xFF;
         ds3pad[pad].data[1] = 0xFF;
+        ds3pad[pad].analog_btn = 0;
 
         mips_memset(&ds3pad[pad].data[2], 0x7F, 4);
         mips_memset(&ds3pad[pad].data[6], 0x00, 12);

--- a/modules/pademu/ds3usb.h
+++ b/modules/pademu/ds3usb.h
@@ -110,7 +110,8 @@ enum eBUF_SIZE {
 int ds3usb_init(uint8_t pads);
 int ds3usb_get_status(int port);
 void ds3usb_reset();
-int ds3usb_get_data(char *dst, int size, int mode_lock, int port);
+int ds3usb_get_data(char *dst, int size, int port);
 void ds3usb_set_rumble(uint8_t lrum, uint8_t rrum, int port);
+void ds3usb_set_mode(int mode, int lock, int port);
 
 #endif

--- a/modules/pademu/ds3usb.h
+++ b/modules/pademu/ds3usb.h
@@ -110,7 +110,7 @@ enum eBUF_SIZE {
 int ds3usb_init(uint8_t pads);
 int ds3usb_get_status(int port);
 void ds3usb_reset();
-void ds3usb_get_data(char *dst, int size, int port);
+int ds3usb_get_data(char *dst, int size, int mode_lock, int port);
 void ds3usb_set_rumble(uint8_t lrum, uint8_t rrum, int port);
 
 #endif

--- a/modules/pademu/exports.tab
+++ b/modules/pademu/exports.tab
@@ -1,4 +1,10 @@
 
 DECLARE_EXPORT_TABLE(pademu, 1, 1)
+	DECLARE_EXPORT(_start)
+	DECLARE_EXPORT(_retonly)
+	DECLARE_EXPORT(_exit)
+	DECLARE_EXPORT(_retonly)
 	DECLARE_EXPORT(pademu_hookSio2man)
 END_EXPORT_TABLE
+
+void _retonly() {}

--- a/modules/pademu/imports.lst
+++ b/modules/pademu/imports.lst
@@ -1,12 +1,8 @@
-
-#include "ioman_mod.h"
-
-sifcmd_IMPORTS_start
-I_sceSifInitRpc
-I_sceSifSetRpcQueue
-I_sceSifRegisterRpc
-I_sceSifRpcLoop
-sifcmd_IMPORTS_end
+loadcore_IMPORTS_start
+I_RegisterLibraryEntries
+I_GetLoadcoreInternalData
+I_QueryLibraryEntryTable
+loadcore_IMPORTS_end
 
 stdio_IMPORTS_start
 I_printf
@@ -26,19 +22,14 @@ I_CreateThread
 I_DeleteThread
 I_DelayThread
 I_GetThreadId
+I_SleepThread
+I_WakeupThread
 thbase_IMPORTS_end
 
 intrman_IMPORTS_start
 I_CpuSuspendIntr
 I_CpuResumeIntr
 intrman_IMPORTS_end
-
-sifman_IMPORTS_start
-I_sceSifCheckInit
-I_sceSifInit
-I_sceSifSetDma
-I_sceSifDmaStat
-sifman_IMPORTS_end
 
 usbd_IMPORTS_start
 I_UsbGetDeviceStaticDescriptor
@@ -50,25 +41,11 @@ I_UsbTransfer
 I_UsbRegisterDriver
 usbd_IMPORTS_end
 
-vblank_IMPORTS_start
-I_WaitVblankStart
-I_RegisterVblankHandler
-vblank_IMPORTS_end
+sysclib_IMPORTS_start
+I_strncmp
+sysclib_IMPORTS_end
 
 smsutils_IMPORTS_start
 I_mips_memset
 I_mips_memcpy
 smsutils_IMPORTS_end
-
-sysclib_IMPORTS_start
-I_prnt
-I_strncmp
-I_strncpy
-sysclib_IMPORTS_end
-
-loadcore_IMPORTS_start
-I_GetLoadcoreInternalData
-I_QueryLibraryEntryTable
-I_FlushIcache
-I_FlushDcache
-loadcore_IMPORTS_end

--- a/modules/pademu/imports.lst
+++ b/modules/pademu/imports.lst
@@ -24,6 +24,7 @@ I_DelayThread
 I_GetThreadId
 I_SleepThread
 I_WakeupThread
+I_TerminateThread
 thbase_IMPORTS_end
 
 intrman_IMPORTS_start
@@ -43,9 +44,15 @@ usbd_IMPORTS_end
 
 sysclib_IMPORTS_start
 I_strncmp
+#ifndef USE_SMSUTILS
+I_memset
+I_memcpy
+#endif
 sysclib_IMPORTS_end
 
+#ifdef USE_SMSUTILS
 smsutils_IMPORTS_start
 I_mips_memset
 I_mips_memcpy
 smsutils_IMPORTS_end
+#endif

--- a/modules/pademu/pademu.c
+++ b/modules/pademu/pademu.c
@@ -101,16 +101,18 @@ int _start(int argc, char *argv[])
     }
 #endif
 
-    pademu_setup(enable, vibration);
+    if (RegisterLibraryEntries(&_exp_pademu) != 0) {
+        return MODULE_NO_RESIDENT_END;
+    }
 
-    RegisterLibraryEntries(&_exp_pademu);
+    pademu_setup(enable, vibration);
 
     return MODULE_RESIDENT_END;
 }
 
 void _exit(int mode)
 {
-	PAD_RESET();
+    PAD_RESET();
 }
 
 int install_sio2hook()
@@ -238,7 +240,7 @@ void pademu_setup(uint8_t ports, uint8_t vib)
         pad[i].mask[3] = 0x00;
         
         pad[i].lrum = 2;
-    	pad[i].rrum = 2;
+        pad[i].rrum = 2;
     }
 }
 
@@ -312,8 +314,8 @@ void pademu_cmd(int port, uint8_t *in, uint8_t *out, uint8_t out_size)
     mips_memset(out, 0x00, out_size);
 
     if (!(PAD_GET_STATUS(port) & PAD_STATE_RUNNING)) {
-    	pad[port].lrum = 2;
-    	pad[port].rrum = 2;
+        pad[port].lrum = 2;
+        pad[port].rrum = 2;
         return;
     }
 

--- a/modules/pademu/sys_utils.h
+++ b/modules/pademu/sys_utils.h
@@ -16,6 +16,7 @@ typedef struct
     void **exports;
 } modinfo_t;
 
+#ifdef USE_SMSUTILS
 /* SMS Utils Imports */
 #define smsutils_IMPORTS_start DECLARE_IMPORT_TABLE(smsutils, 1, 1)
 
@@ -26,5 +27,9 @@ void mips_memset(void *, int, unsigned);
 #define I_mips_memset DECLARE_IMPORT(5, mips_memset)
 
 #define smsutils_IMPORTS_end END_IMPORT_TABLE
+#else
+#define mips_memset memset
+#define mips_memcpy memcpy
+#endif
 
 #endif /* __MCEMU_UTILS_H */

--- a/src/gui.c
+++ b/src/gui.c
@@ -695,10 +695,10 @@ static int guiPadEmuUpdater(int modified)
 
     if (PadEmuMode) {
         if (ds3bt_get_status(0) & DS3BT_STATE_USB_CONFIGURED) {
-        	if (dg_discon) {
-        		dgmacset = 0;
-        		dg_discon = 0;
-			}
+            if (dg_discon) {
+                dgmacset = 0;
+                dg_discon = 0;
+            }
             if (!dgmacset) {
                 if (!ds3bt_get_bdaddr(dg_mac)) {
                     dgmacset = 1;
@@ -708,10 +708,10 @@ static int guiPadEmuUpdater(int modified)
                 }
             }
         } else {
-        	dg_discon = 1;
-		}
+            dg_discon = 1;
+        }
 
-		if (!dgmacset) {
+        if (!dgmacset) {
             diaSetLabel(diaPadEmuConfig, PADCFG_USBDG_MAC, _l(_STR_NOT_CONNECTED));
         }
 
@@ -737,7 +737,7 @@ static void guiShowPadEmuConfig(void)
 {
     const char *PadEmuModes[] = {_l(_STR_DS3USB_MODE), _l(_STR_DS3BT_MODE), NULL};
     int PadPort;
-	
+
     diaSetEnum(diaPadEmuConfig, PADCFG_PADEMU_MODE, PadEmuModes);
 
     diaSetInt(diaPadEmuConfig, PADCFG_PADEMU_MODE, PadEmuSettings & 0xFF);

--- a/src/gui.c
+++ b/src/gui.c
@@ -630,13 +630,13 @@ void guiShowCheatConfig(void)
 #endif
 
 #ifdef PADEMU
-
 static u8 ds3_mac[6];
 static u8 dg_mac[6];
 static char ds3_str[18];
 static char dg_str[18];
 static int ds3macset = 0;
 static int dgmacset = 0;
+static int dg_discon = 0;
 
 static int PadEmuSettings = 0;
 
@@ -695,6 +695,10 @@ static int guiPadEmuUpdater(int modified)
 
     if (PadEmuMode) {
         if (ds3bt_get_status(0) & DS3BT_STATE_USB_CONFIGURED) {
+        	if (dg_discon) {
+        		dgmacset = 0;
+        		dg_discon = 0;
+			}
             if (!dgmacset) {
                 if (!ds3bt_get_bdaddr(dg_mac)) {
                     dgmacset = 1;
@@ -704,8 +708,11 @@ static int guiPadEmuUpdater(int modified)
                 }
             }
         } else {
+        	dg_discon = 1;
+		}
+
+		if (!dgmacset) {
             diaSetLabel(diaPadEmuConfig, PADCFG_USBDG_MAC, _l(_STR_NOT_CONNECTED));
-            dgmacset = 0;
         }
 
         if (ds3usb_get_status(0) & DS3USB_STATE_RUNNING) {
@@ -758,7 +765,6 @@ static void guiShowPadEmuConfig(void)
             break;
     }
 }
-
 #endif
 
 static int netConfigUpdater(int modified)

--- a/src/gui.c
+++ b/src/gui.c
@@ -700,7 +700,7 @@ static int guiPadEmuUpdater(int modified)
                 dg_discon = 0;
             }
             if (!dgmacset) {
-                if (!ds3bt_get_bdaddr(dg_mac)) {
+                if (ds3bt_get_bdaddr(dg_mac)) {
                     dgmacset = 1;
                     diaSetLabel(diaPadEmuConfig, PADCFG_USBDG_MAC, bdaddr_to_str(dg_mac, dg_str));
                 } else {
@@ -717,7 +717,7 @@ static int guiPadEmuUpdater(int modified)
 
         if (ds3usb_get_status(0) & DS3USB_STATE_RUNNING) {
             if (!ds3macset) {
-                if (!ds3usb_get_bdaddr(0, ds3_mac)) {
+                if (ds3usb_get_bdaddr(0, ds3_mac)) {
                     ds3macset = 1;
                     diaSetLabel(diaPadEmuConfig, PADCFG_PAD_MAC, bdaddr_to_str(ds3_mac, ds3_str));
                 } else {
@@ -755,7 +755,7 @@ static void guiShowPadEmuConfig(void)
         if (result == PADCFG_PAIR) {
             if (ds3macset && dgmacset) {
                 if (ds3usb_get_status(0) & DS3USB_STATE_RUNNING) {
-                    if (!ds3usb_set_bdaddr(0, dg_mac))
+                    if (ds3usb_set_bdaddr(0, dg_mac))
                         ds3macset = 0;
                 }
             }

--- a/src/pad.c
+++ b/src/pad.c
@@ -193,12 +193,12 @@ static int readPad(struct pad_data_t *pad)
     newpdata = 0xffff ^ pad->buttons.btns;
 
     if (ds3bt_get_status(pad->port) & DS3BT_STATE_RUNNING) {
-        ret = !ds3bt_get_data(pad->port, (u8 *)&pad->buttons.btns);
+        ret = ds3bt_get_data(pad->port, (u8 *)&pad->buttons.btns);
         newpdata |= 0xffff ^ pad->buttons.btns;
     }
 
     if (ds3usb_get_status(pad->port) & DS3USB_STATE_RUNNING) {
-        ret = !ds3usb_get_data(pad->port, (u8 *)&pad->buttons.btns);
+        ret = ds3usb_get_data(pad->port, (u8 *)&pad->buttons.btns);
         newpdata |= 0xffff ^ pad->buttons.btns;
     }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author.

## Pull Request description
- use module export table to reset ds3 (remove pademu rpc in ee_core)
- use thread to read data/set vibration in ds3bt module (can be disabled in Makefile)
- emulating analog button (changing pad mode by pressing PS+SELECT buttons)
- option to compile pademu modules without using sms_utils (remove -DUSE_SMSUTILS in Makefile) to make them usable in others apps
- in gui: saving bt adapter mac address, now pairing DS3 is posible without connected bt adapter