### PR TITLE
Fix for HDD deinit, avoid linking to thread and TLB patches and updated IOP reboot code.

### DIFF
--- a/ee_core/Makefile
+++ b/ee_core/Makefile
@@ -16,9 +16,10 @@ EE_OBJS_DIR = obj/
 GSMCORE_EE_OBJS = gsm_engine.o gsm_api.o
 IGSCORE_EE_OBJS = igs_api.o
 CHEATCORE_EE_OBJS = cheat_engine.o cheat_api.o
+KERNEL_OBJS = iWakeupThread.o #iWakeupThread is used by SIFRPC. This prevents the thread patch from libkernel from being linked to.
 
 EE_OBJS = main.o syshook.o iopmgr.o modmgr.o util.o patches.o patches_asm.o \
-	  padhook.o spu.o tlb.o asm.o crt0.o
+	  padhook.o spu.o tlb.o asm.o crt0.o $(KERNEL_OBJS)
 MAPFILE = ee_core.map
 
 EE_INCS := -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -Iinclude -I.
@@ -102,5 +103,8 @@ clean:
 clean_all:
 	rm -f -r $(EE_OBJS_DIR) $(EE_BIN) $(MAPFILE)
 
+$(KERNEL_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)kernel_custom.S
+	@mkdir -p $(EE_OBJS_DIR)
+	$(EE_CC) $(EE_CFLAGS) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
 
 include $(PS2SDK)/samples/Makefile.pref

--- a/ee_core/include/iopmgr.h
+++ b/ee_core/include/iopmgr.h
@@ -10,18 +10,6 @@
 #ifndef IOPMGR_H
 #define IOPMGR_H
 
-#define RESET_ARG_MAX 79
-
-struct _iop_reset_pkt
-{
-    struct t_SifCmdHeader header;
-    int arglen;
-    int mode;
-    char arg[RESET_ARG_MAX + 1];
-} ALIGNED(16);
-
-void InitSIF0(void);
-void SyncSIF0(void);
 int New_Reset_Iop(const char *arg, int arglen);
 int Reset_Iop(const char *arg, int flag);
 

--- a/ee_core/include/syscallnr_custom.h
+++ b/ee_core/include/syscallnr_custom.h
@@ -1,0 +1,9 @@
+#ifndef _SYSCALLNR_H_
+#define _SYSCALLNR_H_
+
+/*
+ * This file contains the system call numbers, similar to asm/unistd.h on Linux.
+ */
+#define __NR_iWakeupThread		(-0x34)
+
+#endif /* _SYSCALLNR_H_ */

--- a/ee_core/src/asm.S
+++ b/ee_core/src/asm.S
@@ -217,7 +217,7 @@ _LoadExecPS2:
 	daddu	$a1, $zero, $zero
 	daddu	$a2, $zero, $zero
 	daddu	$a3, $zero, $zero
-	addiu	$v1, $zero, __NR_ExecPS2
+	addiu	$v1, $zero, __NR__ExecPS2
 	syscall
 	nop
 

--- a/ee_core/src/iopmgr.c
+++ b/ee_core/src/iopmgr.c
@@ -127,7 +127,7 @@ int New_Reset_Iop(const char *arg, int arglen)
     }
 #endif
     // Reseting IOP.
-    while (!Reset_Iop(NULL, 0)) {
+    while (!Reset_Iop("", 0)) {
         ;
     }
     while (!SifIopSync()) {
@@ -188,8 +188,9 @@ int New_Reset_Iop(const char *arg, int arglen)
 /*----------------------------------------------------------------------------------------*/
 int Reset_Iop(const char *arg, int mode)
 {
-    struct _iop_reset_pkt reset_pkt; /* Implicitly aligned. */
+    static SifCmdResetData_t reset_pkt __attribute__((aligned(64)));
     struct t_SifDmaTransfer dmat;
+    int arglen;
 
     _iop_reboot_count++; // increment reboot counter to allow RPC clients to detect unbinding!
 
@@ -205,18 +206,13 @@ int Reset_Iop(const char *arg, int mode)
 				That caused SifSetDChain() to be run ASAP, which re-enables SIF0.
 				I don't find that a good workaround because it may result in a timing problem.	*/
 
-    memset(&reset_pkt, 0, sizeof reset_pkt);
+    for(arglen = 0; arg[arglen] != '\0'; arglen++)
+        reset_pkt.arg[arglen] = arg[arglen];
 
-    reset_pkt.header.size = sizeof reset_pkt;
+    reset_pkt.header.psize = sizeof reset_pkt;	//dsize is not initialized (and not processed, even on the IOP).
     reset_pkt.header.cid = SIF_CMD_RESET_CMD;
-
+    reset_pkt.arglen = arglen;
     reset_pkt.mode = mode;
-    if (arg != NULL) {
-        strncpy(reset_pkt.arg, arg, RESET_ARG_MAX);
-        reset_pkt.arg[RESET_ARG_MAX] = '\0';
-
-        reset_pkt.arglen = strlen(reset_pkt.arg) + 1;
-    }
 
     dmat.src = &reset_pkt;
     dmat.dest = (void *)SifGetReg(SIF_SYSREG_SUBADDR);

--- a/ee_core/src/kernel_custom.S
+++ b/ee_core/src/kernel_custom.S
@@ -1,0 +1,91 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (C)2001, Gustavo Scotti (gustavo@scotti.com)
+# (c) 2003 Marcus R. Brown (mrbrown@0xd6.org)
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * EE Kernel functions
+ */
+
+#include "syscallnr_custom.h"
+
+	.text
+	.p2align 3
+
+#ifdef USE_KMODE
+#define SYSCALL(name) 		\
+	.set	push;		\
+	.set	noreorder;	\
+	.text;			\
+	.align 4;		\
+	.globl	name;		\
+	.type	name,@function;	\
+	.ent	name,0;		\
+name:	j	__syscall;	\
+	li	$3, __NR_##name;\
+	nop;			\
+	.end	name;		\
+	.size	name,.-name;	\
+	.set	pop;
+#else
+#define SYSCALL(name) 		\
+	.set	push;		\
+	.set	noreorder;	\
+	.text;			\
+	.align 4;		\
+	.globl	name;		\
+	.type	name,@function;	\
+	.ent	name,0;		\
+name:	li	$3, __NR_##name;\
+	syscall;		\
+	jr	$31;		\
+	nop;			\
+	.end	name;		\
+	.size	name,.-name;	\
+	.set	pop;
+#endif
+
+#ifdef F___syscall
+.set	push
+.set	noreorder
+.text
+.align	4
+.globl	__syscall
+.type	__syscall,@function
+.ent	__syscall,0
+__syscall:
+        mfc0        $2, $12
+        andi        $2, $2, 0x18
+        beqz        $2, _kMode
+        slt         $2, $3, $0
+        syscall
+        jr          $31
+        nop
+_kMode:
+        subu        $26, $0, $3
+        movn        $3, $26, $2
+        sll         $3, $3, 2
+        lui         $26, 0x8000
+        lhu         $2, 0x02F0($26)
+        sll         $2, $2, 16
+        lh          $26, 0x02F8($26)
+        add         $2, $26
+        addu        $3, $2
+        lw          $26, 0x00($3)
+        jr          $26
+        nop
+.end	__syscall
+.size	__syscall,.-__syscall
+.set	pop
+#endif
+
+#ifdef F_iWakeupThread
+SYSCALL(iWakeupThread)
+#endif

--- a/ee_core/src/main.c
+++ b/ee_core/src/main.c
@@ -154,9 +154,9 @@ int main(int argc, char **argv)
         char *argvs[1];
         argvs[0] = ElfPath;
         argvs[1] = NULL;
-        LoadExecPS2("rom0:PS2LOGO", 1, argvs);
+        _LoadExecPS2("rom0:PS2LOGO", 1, argvs);
     } else {
-        LoadExecPS2(ElfPath, 0, NULL);
+        _LoadExecPS2(ElfPath, 0, NULL);
     }
 
     if (!DisableDebug)

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -134,7 +134,7 @@ static void t_loadElf(void)
             GS_BGCOLOUR = 0x0080FF; // Orange
 
         // Execute BOOT.ELF
-        ExecPS2((void *)elf.epc, (void *)elf.gp, 1, argv);
+        _ExecPS2((void *)elf.epc, (void *)elf.gp, 1, argv);
     }
 
     if (!DisableDebug) {
@@ -143,7 +143,7 @@ static void t_loadElf(void)
     }
 
     // Return to PS2 Browser
-    Exit(0);
+    _Exit(0);
 }
 
 // Poweroff PlayStation 2
@@ -277,10 +277,10 @@ static void IGR_Thread(void *arg)
 
         // Execute home loader
         if (ExitPath[0] != '\0')
-            ExecPS2(t_loadElf, &_gp, 0, NULL);
+            _ExecPS2(t_loadElf, &_gp, 0, NULL);
 
         // Return to PS2 Browser
-        Exit(0);
+        _Exit(0);
     }
 
     // If combo is R3 + L3 or Reset failed, Poweroff PS2

--- a/ee_core/src/syshook.c
+++ b/ee_core/src/syshook.c
@@ -133,7 +133,7 @@ void t_loadElf(void)
         disable_padOpen_hook = 0;
 
         DPRINTF("t_loadElf: executing...\n");
-        ExecPS2((void *)elf.epc, (void *)elf.gp, g_argc, g_argv);
+        _ExecPS2((void *)elf.epc, (void *)elf.gp, g_argc, g_argv);
     }
 
     DPRINTF(" failed\n");
@@ -155,16 +155,16 @@ void Install_Kernel_Hooks(void)
     Old_SifSetReg = GetSyscallHandler(__NR_SifSetReg);
     SetSyscall(__NR_SifSetReg, &Hook_SifSetReg);
 
-    Old_LoadExecPS2 = GetSyscallHandler(__NR_LoadExecPS2);
-    SetSyscall(__NR_LoadExecPS2, &Hook_LoadExecPS2);
+    Old_LoadExecPS2 = GetSyscallHandler(__NR__LoadExecPS2);
+    SetSyscall(__NR__LoadExecPS2, &Hook_LoadExecPS2);
 
     // If IGR is enabled hook ExecPS2 & CreateThread syscalls
     if (!(g_compat_mask & COMPAT_MODE_6)) {
         Old_CreateThread = GetSyscallHandler(__NR_CreateThread);
         SetSyscall(__NR_CreateThread, &Hook_CreateThread);
 
-        Old_ExecPS2 = GetSyscallHandler(__NR_ExecPS2);
-        SetSyscall(__NR_ExecPS2, &Hook_ExecPS2);
+        Old_ExecPS2 = GetSyscallHandler(__NR__ExecPS2);
+        SetSyscall(__NR__ExecPS2, &Hook_ExecPS2);
     }
 }
 
@@ -176,11 +176,11 @@ void Remove_Kernel_Hooks(void)
 {
     SetSyscall(__NR_SifSetDma, Old_SifSetDma);
     SetSyscall(__NR_SifSetReg, Old_SifSetReg);
-    SetSyscall(__NR_LoadExecPS2, Old_LoadExecPS2);
+    SetSyscall(__NR__LoadExecPS2, Old_LoadExecPS2);
 
     // If IGR is enabled unhook ExecPS2 & CreateThread syscalls
     if (!(g_compat_mask & COMPAT_MODE_6)) {
         SetSyscall(__NR_CreateThread, Old_CreateThread);
-        SetSyscall(__NR_ExecPS2, Old_ExecPS2);
+        SetSyscall(__NR__ExecPS2, Old_ExecPS2);
     }
 }

--- a/elfldr/Makefile
+++ b/elfldr/Makefile
@@ -1,5 +1,6 @@
 EE_BIN = elfldr.elf
-EE_OBJS = elfldr.o crt0.o
+KERNEL_OBJS = iWakeupThread.o #iWakeupThread is used by SIFRPC. This prevents the thread patch from libkernel from being linked to.
+EE_OBJS = elfldr.o crt0.o $(KERNEL_OBJS)
 
 EE_INCS := -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I.
 EE_CFLAGS := -D_EE -O2 -mgpopt -G8192 -Wall $(EE_INCS)
@@ -16,10 +17,12 @@ EE_LIBS += -lkernel
 $(EE_BIN) : $(EE_OBJS)
 	$(EE_CC) $(EE_CFLAGS) $(EE_LDFLAGS) -o $(EE_BIN) $(EE_OBJS) $(EE_LIBS) -Xlinker -Map -Xlinker elfldr.map
 
-
 all: $(EE_BIN)
 
 clean:
 	rm -f $(EE_BIN) $(EE_OBJS) elfldr.map
+
+$(KERNEL_OBJS:%=$(EE_OBJS_DIR)%): $(EE_SRC_DIR)kernel_custom.S
+	$(EE_CC) $(EE_CFLAGS) -DF_$(*:$(EE_OBJS_DIR)%=%) $< -c -o $@
 
 include $(PS2SDK)/samples/Makefile.pref

--- a/elfldr/elfldr.c
+++ b/elfldr/elfldr.c
@@ -20,7 +20,7 @@ static inline void BootError(char *filename)
     argv[0] = "BootError";
     argv[1] = filename;
 
-    ExecOSD(2, argv);
+    _ExecOSD(2, argv);
 }
 
 static inline void InitializeUserMemory(unsigned int start, unsigned int end)
@@ -66,7 +66,6 @@ int main(int argc, char *argv[])
         while (!SifIopSync()) {
         };
 
-        //Sync with the SIF library on the IOP, or it may crash the IOP kernel during the next reset (Depending on the how the next program initializes the IOP).
         SifInitRpc(0);
         //Load modules.
         SifLoadFileInit();
@@ -76,7 +75,7 @@ int main(int argc, char *argv[])
         SifLoadFileExit();
         SifExitRpc();
 
-        ExecPS2((void *)exd.epc, (void *)exd.gp, argc, argv);
+        _ExecPS2((void *)exd.epc, (void *)exd.gp, argc, argv);
     } else {
         SifExitRpc();
     }

--- a/elfldr/elfldr.c
+++ b/elfldr/elfldr.c
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
 
     if (result == 0 && exd.epc != 0) {
         //Final IOP reset, to fill the IOP with the default modules.
-        while (!SifIopReset(NULL, 0)) {
+        while (!SifIopReset("", 0)) {
         };
 
         FlushCache(0);

--- a/elfldr/kernel_custom.S
+++ b/elfldr/kernel_custom.S
@@ -1,0 +1,91 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (C)2001, Gustavo Scotti (gustavo@scotti.com)
+# (c) 2003 Marcus R. Brown (mrbrown@0xd6.org)
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+*/
+
+/**
+ * @file
+ * EE Kernel functions
+ */
+
+#include "syscallnr_custom.h"
+
+	.text
+	.p2align 3
+
+#ifdef USE_KMODE
+#define SYSCALL(name) 		\
+	.set	push;		\
+	.set	noreorder;	\
+	.text;			\
+	.align 4;		\
+	.globl	name;		\
+	.type	name,@function;	\
+	.ent	name,0;		\
+name:	j	__syscall;	\
+	li	$3, __NR_##name;\
+	nop;			\
+	.end	name;		\
+	.size	name,.-name;	\
+	.set	pop;
+#else
+#define SYSCALL(name) 		\
+	.set	push;		\
+	.set	noreorder;	\
+	.text;			\
+	.align 4;		\
+	.globl	name;		\
+	.type	name,@function;	\
+	.ent	name,0;		\
+name:	li	$3, __NR_##name;\
+	syscall;		\
+	jr	$31;		\
+	nop;			\
+	.end	name;		\
+	.size	name,.-name;	\
+	.set	pop;
+#endif
+
+#ifdef F___syscall
+.set	push
+.set	noreorder
+.text
+.align	4
+.globl	__syscall
+.type	__syscall,@function
+.ent	__syscall,0
+__syscall:
+        mfc0        $2, $12
+        andi        $2, $2, 0x18
+        beqz        $2, _kMode
+        slt         $2, $3, $0
+        syscall
+        jr          $31
+        nop
+_kMode:
+        subu        $26, $0, $3
+        movn        $3, $26, $2
+        sll         $3, $3, 2
+        lui         $26, 0x8000
+        lhu         $2, 0x02F0($26)
+        sll         $2, $2, 16
+        lh          $26, 0x02F8($26)
+        add         $2, $26
+        addu        $3, $2
+        lw          $26, 0x00($3)
+        jr          $26
+        nop
+.end	__syscall
+.size	__syscall,.-__syscall
+.set	pop
+#endif
+
+#ifdef F_iWakeupThread
+SYSCALL(iWakeupThread)
+#endif

--- a/elfldr/syscallnr_custom.h
+++ b/elfldr/syscallnr_custom.h
@@ -1,0 +1,9 @@
+#ifndef _SYSCALLNR_H_
+#define _SYSCALLNR_H_
+
+/*
+ * This file contains the system call numbers, similar to asm/unistd.h on Linux.
+ */
+#define __NR_iWakeupThread		(-0x34)
+
+#endif /* _SYSCALLNR_H_ */

--- a/labs/genvmclab/genvmclab.c
+++ b/labs/genvmclab/genvmclab.c
@@ -99,7 +99,7 @@ int main(int argc, char *argv[2])
 
     DPRINTF("IOP Reset... ");
 
-    while (!SifIopReset("rom0:UDNL rom0:EELOADCNF", 0))
+    while (!SifIopReset("", 0))
         ;
     while (!SifIopSync())
         ;

--- a/labs/hdldsvrlab/hdldsvrlab.c
+++ b/labs/hdldsvrlab/hdldsvrlab.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[2])
 
     scr_printf("\t IOP Reset... ");
 
-    while (!SifIopReset("rom0:UDNL rom0:EELOADCNF", 0))
+    while (!SifIopReset("", 0))
         ;
     while (!SifIopSync())
         ;

--- a/labs/smblab/smblab.c
+++ b/labs/smblab/smblab.c
@@ -137,7 +137,7 @@ int main(int argc, char *argv[2])
 
     DPRINTF("IOP Reset... ");
 
-    while (!SifIopReset("rom0:UDNL rom0:EELOADCNF", 0))
+    while (!SifIopReset("", 0))
         ;
     while (!SifIopSync())
         ;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -476,6 +476,8 @@ static void hddCleanUp(int exception)
 
         if ((exception & UNMOUNT_EXCEPTION) == 0)
             fileXioUmount(hddPrefix);
+
+      fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
     }
 
     hddModulesLoaded = 0;

--- a/src/system.c
+++ b/src/system.c
@@ -247,7 +247,7 @@ void sysReset(int modload_mask)
     while (!SifIopReset("rom0:UDNL", 0))
         ;
 #else
-    while (!SifIopReset(NULL, 0))
+    while (!SifIopReset("", 0))
         ;
 #endif
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author.

## Pull Request description

Updated to support recent changes to the PS2SDK:
* Close all files upon deinit of HDD support.
* Added a iWakeupThread object to EE core and ELFLDR to avoid linking to the thread patch.
* Changed all calls to Exit, LoadExecPS2, ExecPS2 and ExecOSD to _Exit, _LoadExecPS2, _ExecPS2 and _ExecOSD respectively, to continue calling these syscalls directly.
* Changed references to _NR_ExecPS2 and _NR_LoadExecPS2 to _NR__ExecPS2 and _NR__LoadExecPS2 respectively.
* Updated IOP reboot code to support the corrected SIFCMD header structure.