### PR TITLE
Alpha + Font improved

### DIFF
--- a/src/atlas.c
+++ b/src/atlas.c
@@ -1,7 +1,7 @@
 /*
   Copyright 2010, Volca
   Licenced under Academic Free License version 3.0
-  Review OpenUsbLd README & LICENSE files for further details.  
+  Review OpenUsbLd README & LICENSE files for further details.
 */
 
 #include <stdio.h>
@@ -167,7 +167,7 @@ struct atlas_allocation_t *atlasPlace(atlas_t *atlas, size_t width, size_t heigh
     if (!surface)
         return NULL;
 
-    struct atlas_allocation_t *al = allocPlace(atlas->allocation, width, height);
+    struct atlas_allocation_t *al = allocPlace(atlas->allocation, width+1, height+1);
 
     if (!al)
         return NULL;

--- a/src/dia.c
+++ b/src/dia.c
@@ -39,10 +39,12 @@ static int screenHeight;
 
 static void diaDrawBoundingBox(int x, int y, int w, int h, int focus)
 {
-    if (focus)
-        rmDrawRect(x - 5, y, w + 10, h + 10, gTheme->selTextColor & gColFocus);
-    else
-        rmDrawRect(x - 5, y, w + 10, h + 10, gTheme->textColor & gColFocus);
+    u64 color = focus ? gTheme->selTextColor : gTheme->textColor;
+
+    color |= GS_SETREG_RGBA(0, 0, 0, 0xFF);
+    color &= gColFocus;
+
+    rmDrawRect(x - 5, y, w + 10, h + 10, color);
 }
 
 int diaShowKeyb(char *text, int maxLen, int hide_text)
@@ -257,7 +259,7 @@ static int diaShowColSel(unsigned char *r, unsigned char *g, unsigned char *b)
         rmDrawRect(0, 0, screenWidth, screenHeight, gColDarker);
 
         // "Color selection"
-        fntRenderString(gTheme->fonts[0], 50, 50, ALIGN_NONE, 0, 0, _l(_STR_COLOR_SELECTION), GS_SETREG_RGBA(0x060, 0x060, 0x060, 0x060));
+        fntRenderString(gTheme->fonts[0], 50, 50, ALIGN_NONE, 0, 0, _l(_STR_COLOR_SELECTION), GS_SETREG_RGBA(0x60, 0x60, 0x60, 0x80));
 
         // 3 bars representing the colors...
         size_t co;
@@ -273,9 +275,9 @@ static int diaShowColSel(unsigned char *r, unsigned char *g, unsigned char *b)
             u64 dcol = GS_SETREG_RGBA(cc[0], cc[1], cc[2], 0x80);
 
             if (selc == co)
-                rmDrawRect(x, y, 200, 20, GS_SETREG_RGBA(0x060, 0x060, 0x060, 0x60));
+                rmDrawRect(x, y, 200, 20, GS_SETREG_RGBA(0x60, 0x60, 0x60, 0x80));
             else
-                rmDrawRect(x, y, 200, 20, GS_SETREG_RGBA(0x020, 0x020, 0x020, 0x60));
+                rmDrawRect(x, y, 200, 20, GS_SETREG_RGBA(0x20, 0x20, 0x20, 0x80));
 
             rmDrawRect(x + 2, y + 2, 190.0f * (cc[co] * 100 / 255) / 100, 16, dcol);
         }
@@ -286,7 +288,7 @@ static int diaShowColSel(unsigned char *r, unsigned char *g, unsigned char *b)
         x = 300;
         y = 75;
 
-        rmDrawRect(x, y, 70, 70, GS_SETREG_RGBA(0x060, 0x060, 0x060, 0x60));
+        rmDrawRect(x, y, 70, 70, GS_SETREG_RGBA(0x60, 0x60, 0x60, 0x80));
         rmDrawRect(x + 5, y + 5, 60, 60, dcol);
 
         guiDrawIconAndText(gSelectButton == KEY_CIRCLE ? CIRCLE_ICON : CROSS_ICON, _STR_OK, gTheme->fonts[0], 420, 417, gTheme->selTextColor);

--- a/src/dia.c
+++ b/src/dia.c
@@ -94,8 +94,7 @@ int diaShowKeyb(char *text, int maxLen, int hide_text)
         fntRenderString(gTheme->fonts[0], 50, 120, ALIGN_NONE, 0, 0, hide_text ? mask_buffer : text, gTheme->textColor);
 
         // separating line for simpler orientation
-        rmDrawLine(25, 138, 615, 138, gColWhite);
-        rmDrawLine(25, 139, 615, 139, gColWhite);
+        rmDrawRect(25, 138, 590, 2, gColWhite);
 
         for (j = 0; j < KEYB_HEIGHT; j++) {
             for (i = 0; i < KEYB_WIDTH; i++) {
@@ -415,8 +414,7 @@ static void diaRenderItem(int x, int y, struct UIItem *item, int selected, int h
             ypos &= ~1;
 
             // two lines for lesser eye strain :)
-            rmDrawLine(x, ypos, x + UI_BREAK_LEN, ypos, gColWhite);
-            rmDrawLine(x, ypos + 1, x + UI_BREAK_LEN, ypos + 1, gColWhite);
+            rmDrawRect(x, ypos, UI_BREAK_LEN, 2, gColWhite);
             break;
         }
 

--- a/src/dia.c
+++ b/src/dia.c
@@ -72,6 +72,8 @@ int diaShowKeyb(char *text, int maxLen, int hide_text)
     cmdicons[2] = thmGetTexture(START_ICON);
     cmdicons[3] = thmGetTexture(SELECT_ICON);
 
+    rmGetScreenExtents(&screenWidth, &screenHeight);
+
     if (hide_text) {
         if ((mask_buffer = malloc(maxLen)) != NULL) {
             memset(mask_buffer, '*', len);

--- a/src/fntsys.c
+++ b/src/fntsys.c
@@ -178,9 +178,9 @@ static void fntPrepareCLUT()
     size_t i;
     u32 *clut = fontClut.Clut;
     for (i = 0; i < 256; ++i) {
-        u8 alpha = i > 0x080 ? 0x080 : i;
+        u8 alpha = (i*128)/255;
 
-        *clut = alpha << 24 | i << 16 | i << 8 | i;
+        *clut = GS_SETREG_RGBA(0xFF, 0xFF, 0xFF, alpha);
         clut++;
     }
 }

--- a/src/gui.c
+++ b/src/gui.c
@@ -1504,26 +1504,23 @@ static void guiDrawBusy()
     if (gTheme->loadingIcon) {
         GSTEXTURE *texture = thmGetTexture(LOAD0_ICON + (guiFrameId >> 1) % gTheme->loadingIconCount);
         if (texture && texture->Mem) {
-            u64 mycolor = GS_SETREG_RGBA(0x080, 0x080, 0x080, bfadeout);
+            u64 mycolor = GS_SETREG_RGBA(0x80, 0x80, 0x80, bfadeout);
             rmDrawPixmap(texture, gTheme->loadingIcon->posX, gTheme->loadingIcon->posY, gTheme->loadingIcon->aligned, gTheme->loadingIcon->width, gTheme->loadingIcon->height, gTheme->loadingIcon->scaled, mycolor);
         }
     }
 }
 
-static int wfadeout = 0x0150;
+static int wfadeout = 0x80;
 static void guiRenderGreeting()
 {
-    int fade = wfadeout > 0xFF ? 0xFF : wfadeout;
-    u64 mycolor = GS_SETREG_RGBA(0x10, 0x10, 0x10, fade >> 1);
+    u64 mycolor = GS_SETREG_RGBA(0x00, 0x00, 0x00, wfadeout);
     rmDrawRect(0, 0, screenWidth, screenHeight, mycolor);
 
     GSTEXTURE *logo = thmGetTexture(LOGO_PICTURE);
     if (logo) {
-        mycolor = GS_SETREG_RGBA(0x080, 0x080, 0x080, fade >> 1);
+        mycolor = GS_SETREG_RGBA(0x80, 0x80, 0x80, wfadeout);
         rmDrawPixmap(logo, screenWidth >> 1, gTheme->usedHeight >> 1, ALIGN_CENTER, logo->Width, logo->Height, SCALING_RATIO, mycolor);
     }
-
-    return;
 }
 
 static float mix(float a, float b, float t)
@@ -1701,13 +1698,13 @@ void guiDrawBGPlasma()
 
     for (y = pery; y < ymax; y++) {
         for (x = 0; x < PLASMA_W; x++) {
-            u32 fper = guiCalcPerlin((float)(2 * x) / PLASMA_W, (float)(2 * y) / PLASMA_H, perz) * 0x080 + 0x080;
+            u32 fper = guiCalcPerlin((float)(2 * x) / PLASMA_W, (float)(2 * y) / PLASMA_H, perz) * 0x80 + 0x80;
 
             *buf = GS_SETREG_RGBA(
                 (u32)(fper * curbgColor[0]) >> 8,
                 (u32)(fper * curbgColor[1]) >> 8,
                 (u32)(fper * curbgColor[2]) >> 8,
-                0x080);
+                0x80);
 
             ++buf;
         }
@@ -1741,7 +1738,7 @@ static void guiDrawOverlays()
         else
             bfadeout = 0x0;
     } else {
-        if (bfadeout < 0x080)
+        if (bfadeout < 0x80)
             bfadeout += 0x08;
     }
 
@@ -1757,7 +1754,7 @@ static void guiDrawOverlays()
     else
         snprintf(fps, sizeof(fps), "%3d ms ----- FPS", time_render);
 
-    fntRenderString(gTheme->fonts[0], screenWidth - 90, 30, ALIGN_CENTER, 0, 0, fps, GS_SETREG_RGBA(0x060, 0x060, 0x060, 0x060));
+    fntRenderString(gTheme->fonts[0], screenWidth - 90, 30, ALIGN_CENTER, 0, 0, fps, GS_SETREG_RGBA(0x60, 0x60, 0x60, 0x80));
 #endif
 
     // Last Played Auto Start
@@ -1768,7 +1765,7 @@ static void guiDrawOverlays()
             CronCurrent = clock() / CLOCKS_PER_SEC;
             RemainSecs = gAutoStartLastPlayed - (CronCurrent - CronStart);
             snprintf(strAutoStartInNSecs, sizeof(strAutoStartInNSecs), _l(_STR_AUTO_START_IN_N_SECS), RemainSecs);
-            fntRenderString(gTheme->fonts[0], screenWidth / 2, screenHeight / 2, ALIGN_CENTER, 0, 0, strAutoStartInNSecs, GS_SETREG_RGBA(0x060, 0x060, 0x060, 0x060));
+            fntRenderString(gTheme->fonts[0], screenWidth / 2, screenHeight / 2, ALIGN_CENTER, 0, 0, strAutoStartInNSecs, GS_SETREG_RGBA(0x60, 0x60, 0x60, 0x80));
         }
     }
 
@@ -1827,7 +1824,7 @@ void guiIntroLoop(void)
 
         guiReadPads();
 
-        if (wfadeout < 0x0FF)
+        if (wfadeout < 0x80)
             guiShow();
 
         if (gInitComplete)

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -459,7 +459,6 @@ void rmDrawPixmap(GSTEXTURE *txt, int x, int y, short aligned, int w, int h, sho
 void rmDrawOverlayPixmap(GSTEXTURE *overlay, int x, int y, short aligned, int w, int h, short scaled, u64 color,
                          GSTEXTURE *inlay, int ulx, int uly, int urx, int ury, int blx, int bly, int brx, int bry)
 {
-
     rm_quad_t quad;
     rmSetupQuad(overlay, x, y, aligned, w, h, scaled, color, &quad);
 
@@ -483,7 +482,7 @@ void rmDrawOverlayPixmap(GSTEXTURE *overlay, int x, int y, short aligned, int w,
 void rmDrawRect(int x, int y, int w, int h, u64 color)
 {
     gsGlobal->PrimAlphaEnable = GS_SETTING_ON;
-    gsKit_prim_quad(gsGlobal, x + transX, shiftY(y) + transY, x + w + transX, shiftY(y) + transY, x + transX, shiftY(y) + h + transY, x + w + transX, shiftY(y) + h + transY, order, color);
+    gsKit_prim_sprite(gsGlobal, x + transX, shiftY(y) + transY, x + w + transX, shiftY(y) + h + transY, order, color);
     order++;
 }
 

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -57,12 +57,12 @@ static float aspectHeight;
 static float transX = 0;
 static float transY = 0;
 
-const u64 gColWhite = GS_SETREG_RGBA(0xFF, 0xFF, 0xFF, 0x00);
-const u64 gColBlack = GS_SETREG_RGBA(0x00, 0x00, 0x00, 0x00);
-const u64 gColDarker = GS_SETREG_RGBA(0x00, 0x00, 0x00, 0x60);
-const u64 gColFocus = GS_SETREG_RGBA(0xFF, 0xFF, 0xFF, 0x50);
+const u64 gColWhite = GS_SETREG_RGBA(0xFF, 0xFF, 0xFF, 0x80);   // Alpha 0x80 -> solid white
+const u64 gColBlack = GS_SETREG_RGBA(0x00, 0x00, 0x00, 0x80);   // Alpha 0x80 -> solid black
+const u64 gColDarker = GS_SETREG_RGBA(0x00, 0x00, 0x00, 0x60);  // Alpha 0x60 -> transparent overlay color
+const u64 gColFocus = GS_SETREG_RGBA(0xFF, 0xFF, 0xFF, 0x50);   // Alpha 0x50 -> transparent overlay color
 
-const u64 gDefaultCol = GS_SETREG_RGBA(0x80, 0x80, 0x80, 0x80);
+const u64 gDefaultCol = GS_SETREG_RGBA(0x80, 0x80, 0x80, 0x80); // Special color for texture multiplication
 const u64 gDefaultAlpha = GS_SETREG_ALPHA(0, 1, 0, 1, 0);
 
 static float shiftYVal;
@@ -356,6 +356,7 @@ int rmSetMode(int force)
         gsKit_mode_switch(gsGlobal, GS_ONESHOT);
 
         gsKit_set_test(gsGlobal, GS_ZTEST_OFF);
+        gsKit_set_primalpha(gsGlobal, gDefaultAlpha, 0);
 
         // reset the contents of the screen to avoid garbage being displayed
         gsKit_clear(gsGlobal, gColBlack);
@@ -435,9 +436,10 @@ void rmDrawQuad(rm_quad_t *q)
     if (!rmPrepareTexture(q->txt)) // won't render if not ready!
         return;
 
-    if ((q->txt->PSM == GS_PSM_CT32) || (q->txt->Clut && q->txt->ClutPSM == GS_PSM_CT32)) {
-        gsKit_set_primalpha(gsGlobal, gDefaultAlpha, 0);
-    }
+    if ((q->txt->PSM == GS_PSM_CT32) || (q->txt->Clut && q->txt->ClutPSM == GS_PSM_CT32))
+        gsGlobal->PrimAlphaEnable = GS_SETTING_ON;
+    else
+        gsGlobal->PrimAlphaEnable = GS_SETTING_OFF;
 
     gsKit_prim_sprite_texture(gsGlobal, q->txt,
                               q->ul.x + transX, q->ul.y + transY,
@@ -445,8 +447,6 @@ void rmDrawQuad(rm_quad_t *q)
                               q->br.x + transX, q->br.y + transY,
                               q->br.u - 0.375f, q->br.v + 0.375f, order, q->color);
     order++;
-
-    gsKit_set_primalpha(gsGlobal, GS_BLEND_BACK2FRONT, 0);
 }
 
 void rmDrawPixmap(GSTEXTURE *txt, int x, int y, short aligned, int w, int h, short scaled, u64 color)
@@ -466,30 +466,32 @@ void rmDrawOverlayPixmap(GSTEXTURE *overlay, int x, int y, short aligned, int w,
     if (!rmPrepareTexture(inlay))
         return;
 
-    if (inlay->PSM == GS_PSM_CT32)
-        gsKit_set_primalpha(gsGlobal, gDefaultAlpha, 0);
+    if ((inlay->PSM == GS_PSM_CT32) || (inlay->Clut && inlay->ClutPSM == GS_PSM_CT32))
+        gsGlobal->PrimAlphaEnable = GS_SETTING_ON;
+    else
+        gsGlobal->PrimAlphaEnable = GS_SETTING_OFF;
 
     gsKit_prim_quad_texture(gsGlobal, inlay, quad.ul.x + transX + aspectWidth * ulx, quad.ul.y + transY + uly, 0.5f, 0.5f,
                             quad.ul.x + transX + aspectWidth * urx, quad.ul.y + transY + ury, inlay->Width - 0.375f, 0.5f,
                             quad.ul.x + transX + aspectWidth * blx, quad.ul.y + transY + bly, 0.5f, inlay->Height - 0.375f,
                             quad.ul.x + transX + aspectWidth * brx, quad.ul.y + transY + bry, inlay->Width - 0.375f, inlay->Height - 0.375f, order, gDefaultCol);
     order++;
-    gsKit_set_primalpha(gsGlobal, GS_BLEND_BACK2FRONT, 0);
 
     rmDrawQuad(&quad);
 }
 
 void rmDrawRect(int x, int y, int w, int h, u64 color)
 {
-    gsKit_set_primalpha(gsGlobal, GS_SETREG_ALPHA(0, 1, 0, 1, 0), 0);
+    gsGlobal->PrimAlphaEnable = GS_SETTING_ON;
     gsKit_prim_quad(gsGlobal, x + transX, shiftY(y) + transY, x + w + transX, shiftY(y) + transY, x + transX, shiftY(y) + h + transY, x + w + transX, shiftY(y) + h + transY, order, color);
     order++;
-    gsKit_set_primalpha(gsGlobal, GS_BLEND_BACK2FRONT, 0);
 }
 
 void rmDrawLine(int x, int y, int x1, int y1, u64 color)
 {
+    gsGlobal->PrimAlphaEnable = GS_SETTING_ON;
     gsKit_prim_line(gsGlobal, x + transX, shiftY(y) + transY, x1 + transX, shiftY(y1) + transY, order, color);
+    order++;
 }
 
 void rmSetDisplayOffset(int x, int y)

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -278,7 +278,6 @@ void rmEndFrame(void)
                            gsGlobal->Width / 64, gsGlobal->PSM, 0, 0);
 
             gsGlobal->ActiveBuffer ^= 1;
-            gsGlobal->PrimContext ^= 1;
         }
     }
 

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -442,10 +442,10 @@ void rmDrawQuad(rm_quad_t *q)
         gsGlobal->PrimAlphaEnable = GS_SETTING_OFF;
 
     gsKit_prim_sprite_texture(gsGlobal, q->txt,
-                              q->ul.x + transX, q->ul.y + transY,
-                              q->ul.u + 0.5f, q->ul.v + 0.5f,
-                              q->br.x + transX, q->br.y + transY,
-                              q->br.u - 0.375f, q->br.v + 0.375f, order, q->color);
+                              q->ul.x + transX - 0.5f, q->ul.y + transY - 0.5f,
+                              q->ul.u, q->ul.v,
+                              q->br.x + transX - 0.5f, q->br.y + transY - 0.5f,
+                              q->br.u, q->br.v, order, q->color);
     order++;
 }
 
@@ -470,10 +470,15 @@ void rmDrawOverlayPixmap(GSTEXTURE *overlay, int x, int y, short aligned, int w,
     else
         gsGlobal->PrimAlphaEnable = GS_SETTING_OFF;
 
-    gsKit_prim_quad_texture(gsGlobal, inlay, quad.ul.x + transX + aspectWidth * ulx, quad.ul.y + transY + uly, 0.5f, 0.5f,
-                            quad.ul.x + transX + aspectWidth * urx, quad.ul.y + transY + ury, inlay->Width - 0.375f, 0.5f,
-                            quad.ul.x + transX + aspectWidth * blx, quad.ul.y + transY + bly, 0.5f, inlay->Height - 0.375f,
-                            quad.ul.x + transX + aspectWidth * brx, quad.ul.y + transY + bry, inlay->Width - 0.375f, inlay->Height - 0.375f, order, gDefaultCol);
+    gsKit_prim_quad_texture(gsGlobal, inlay,
+                            quad.ul.x + transX + aspectWidth * ulx - 0.5f, quad.ul.y + transY + uly - 0.5f,
+                            0.0f, 0.0f,
+                            quad.ul.x + transX + aspectWidth * urx - 0.5f, quad.ul.y + transY + ury - 0.5f,
+                            inlay->Width, 0.0f,
+                            quad.ul.x + transX + aspectWidth * blx - 0.5f, quad.ul.y + transY + bly - 0.5f,
+                            0.0f, inlay->Height,
+                            quad.ul.x + transX + aspectWidth * brx - 0.5f, quad.ul.y + transY + bry - 0.5f,
+                            inlay->Width, inlay->Height, order, gDefaultCol);
     order++;
 
     rmDrawQuad(&quad);

--- a/src/themes.c
+++ b/src/themes.c
@@ -621,7 +621,7 @@ static theme_element_t *initBasic(const char *themePath, config_set_t *themeConf
 
     snprintf(elemProp, sizeof(elemProp), "%s_color", name);
     if (configGetColor(themeConfig, elemProp, charColor))
-        elem->color = GS_SETREG_RGBA(charColor[0], charColor[1], charColor[2], 0xff);
+        elem->color = GS_SETREG_RGBA(charColor[0], charColor[1], charColor[2], 0x80);
     else
         elem->color = color;
 
@@ -1017,9 +1017,9 @@ static int thmLoadResource(int texId, const char *themePath, short psm, int useD
 static void thmSetColors(theme_t *theme)
 {
     memcpy(theme->bgColor, gDefaultBgColor, 3);
-    theme->textColor = GS_SETREG_RGBA(gDefaultTextColor[0], gDefaultTextColor[1], gDefaultTextColor[2], 0xff);
-    theme->uiTextColor = GS_SETREG_RGBA(gDefaultUITextColor[0], gDefaultUITextColor[1], gDefaultUITextColor[2], 0xff);
-    theme->selTextColor = GS_SETREG_RGBA(gDefaultSelTextColor[0], gDefaultSelTextColor[1], gDefaultSelTextColor[2], 0xff);
+    theme->textColor = GS_SETREG_RGBA(gDefaultTextColor[0], gDefaultTextColor[1], gDefaultTextColor[2], 0x80);
+    theme->uiTextColor = GS_SETREG_RGBA(gDefaultUITextColor[0], gDefaultUITextColor[1], gDefaultUITextColor[2], 0x80);
+    theme->selTextColor = GS_SETREG_RGBA(gDefaultSelTextColor[0], gDefaultSelTextColor[1], gDefaultSelTextColor[2], 0x80);
 
     theme_element_t *elem = theme->mainElems.first;
     while (elem) {
@@ -1111,13 +1111,13 @@ static void thmLoad(const char *themePath)
 
         unsigned char color[3];
         if (configGetColor(themeConfig, "text_color", color))
-            newT->textColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0xff);
+            newT->textColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0x80);
 
         if (configGetColor(themeConfig, "ui_text_color", color))
-            newT->uiTextColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0xff);
+            newT->uiTextColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0x80);
 
         if (configGetColor(themeConfig, "sel_text_color", color))
-            newT->selTextColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0xff);
+            newT->selTextColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0x80);
 
         // before loading the element definitions, we have to have the fonts prepared
         // for that, we load the fonts and a translation table


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author.

## Pull Request description

- alpha value handling is changed (perhaps the new png's will work now? I didn't test)
- font CLUT now has real alpha values
- pixel perfect texture mapping (especially visible for fonts)
- some minor changes

Before (somehow on the latest git the ART does not display?):
![vlcsnap-00006](https://user-images.githubusercontent.com/4712159/28242617-acda96e8-69b0-11e7-8fce-504110a75e4e.jpg)
After:
![vlcsnap-00008](https://user-images.githubusercontent.com/4712159/28242619-b59514e8-69b0-11e7-9f7b-7331604b08fd.jpg)

