### PR TITLE
(HDPro) fixed HDPro being unable to communicate with the HDPro device

### DIFF
--- a/modules/iopcore/cdvdman/imports.lst
+++ b/modules/iopcore/cdvdman/imports.lst
@@ -78,6 +78,7 @@ I_iClearEventFlag
 I_SetEventFlag
 I_iSetEventFlag
 I_WaitEventFlag
+I_PollEventFlag
 thevent_IMPORTS_end
 
 sifman_IMPORTS_start

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -93,8 +93,6 @@ static int hddCheckHDProKit(void)
 
     // check result
     if ((res & 0xff) == 0xe7) {
-        HDPROreg_IO8 = 0xe3;
-        CDVDreg_STATUS = 0;
         // HD Pro IO finish commands sequence
         HDPROreg_IO8 = 0xf3;
         CDVDreg_STATUS = 0;
@@ -146,6 +144,9 @@ void hddLoadModules(void)
     if (!hddModulesLoaded) {
         hddModulesLoaded = 1;
 
+        //DEV9 must be loaded, as HDD.IRX depends on it. Even if not required by the I/F (i.e. HDPro)
+        sysInitDev9();
+
         // try to detect HD Pro Kit (not the connected HDD),
         // if detected it loads the specific ATAD module
         hddHDProKitDetected = hddCheckHDProKit();
@@ -153,7 +154,6 @@ void hddLoadModules(void)
             ret = sysLoadModuleBuffer(&hdpro_atad_irx, size_hdpro_atad_irx, 0, NULL);
             sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 6, "-hdpro");
         } else {
-            sysInitDev9();
             ret = sysLoadModuleBuffer(&ps2atad_irx, size_ps2atad_irx, 0, NULL);
             sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 0, NULL);
         }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [x] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

1. Fixed errors in command types for command matrix
2. Removed extra writes in the EE HDPro probe function
3. Replaced WaitEventFlag with PollEventFlag (as per the original)
4. Added a check around PollEventFlag's return value.
5. DEV9 is now loaded for both HDPro ATAD and ATAD, since HDD.IRX depends on it.