### PR TITLE
Use real theme file for builtin <OPL> theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ GFX_OBJS =	usb_icon.o hdd_icon.o eth_icon.o app_icon.o \
 		load0.o load1.o load2.o load3.o load4.o load5.o load6.o load7.o logo.o bg_overlay.o freesans.o \
 		icon_sys.o icon_icn.o
 
-MISC_OBJS =	icon_sys_A.o icon_sys_J.o
+MISC_OBJS =	icon_sys_A.o icon_sys_J.o conf_theme_OPL.o
 
 IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o usbhdfsd.o usbhdfsdfsv.o \
 		ps2atad.o hdpro_atad.o poweroff.o ps2hdd.o xhdd.o genvmc.o hdldsvr.o \
@@ -102,7 +102,7 @@ EE_ASM_DIR = asm/
 
 MAPFILE = opl.map
 EE_LDFLAGS += -Wl,-Map,$(MAPFILE)
- 
+
 EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lgskit_toolkit -lpoweroff -lfileXio -lpatches -ljpeg -lpng -lz -ldebug -lm -lmc -lfreetype -lvux -lcdvd -lnetman -lps2ips
 EE_INCS += -I$(PS2SDK)/ports/include -I$(GSKIT)/include -I$(GSKIT)/ee/dma/include -I$(GSKIT)/ee/gs/include -I$(GSKIT)/ee/toolkit/include -Imodules/iopcore/common -Imodules/network/common -Imodules/hdd/common -Iinclude
 
@@ -111,10 +111,10 @@ BIN2S = $(PS2SDK)/bin/bin2s
 BIN2O = $(PS2SDK)/bin/bin2o
 
 # WARNING: Only extra spaces are allowed and ignored at the beginning of the conditional directives (ifeq, ifneq, ifdef, ifndef, else and endif)
-# but a tab is not allowed; if the line begins with a tab, it will be considered part of a recipe for a rule! 
+# but a tab is not allowed; if the line begins with a tab, it will be considered part of a recipe for a rule!
 
 ifeq ($(VMC),1)
-  IOP_OBJS += usb_mcemu.o hdd_mcemu.o smb_mcemu.o 
+  IOP_OBJS += usb_mcemu.o hdd_mcemu.o smb_mcemu.o
   EE_CFLAGS += -DVMC
   VMC_FLAGS = VMC=1
 else
@@ -161,7 +161,7 @@ else
     IGS_FLAGS = IGS=0
   endif
   ifeq ($(CHEAT),1)
-    FRONTEND_OBJS += cheatman.o 
+    FRONTEND_OBJS += cheatman.o
     EE_CFLAGS += -DCHEAT
     CHEAT_FLAGS = CHEAT=1
   else
@@ -178,7 +178,7 @@ else
   PADEMU_FLAGS = PADEMU=0
 endif
 
-ifeq ($(DEBUG),1) 
+ifeq ($(DEBUG),1)
   EE_CFLAGS += -D__DEBUG -g
   EE_OBJS += debug.o udptty.o ioptrap.o ps2link.o
   MOD_DEBUG_FLAGS = DEBUG=1
@@ -187,7 +187,7 @@ ifeq ($(DEBUG),1)
     EECORE_EXTRA_FLAGS = LOAD_DEBUG_MODULES=1
     CDVDMAN_DEBUG_FLAGS = IOPCORE_DEBUG=1
     MCEMU_DEBUG_FLAGS = IOPCORE_DEBUG=1
-    SMSTCPIP_INGAME_CFLAGS = 
+    SMSTCPIP_INGAME_CFLAGS =
     IOP_OBJS += udptty-ingame.o
   else ifeq ($(EESIO_DEBUG),1)
     EE_CFLAGS += -D__EESIO_DEBUG
@@ -196,7 +196,7 @@ ifeq ($(DEBUG),1)
     EE_CFLAGS += -D__INGAME_DEBUG
     EECORE_EXTRA_FLAGS = LOAD_DEBUG_MODULES=1
     CDVDMAN_DEBUG_FLAGS = USE_DEV9=1
-    SMSTCPIP_INGAME_CFLAGS = 
+    SMSTCPIP_INGAME_CFLAGS =
     ifeq ($(DECI2_DEBUG),1)
       EE_CFLAGS += -D__DECI2_DEBUG
       EECORE_EXTRA_FLAGS += DECI2_DEBUG=1
@@ -232,7 +232,7 @@ release:
 	echo "Building Open PS2 Loader $(OPL_VERSION)..."
 	echo "-Interface"
 	$(MAKE) VMC=1 GSM=1 IGS=1 PADEMU=1 CHEAT=1 $(EE_VPKD).ZIP
-	
+
 childproof:
 	$(MAKE) CHILDPROOF=1 all
 
@@ -736,15 +736,18 @@ $(EE_ASM_DIR)freesans.s: thirdparty/FreeSans_basic_latin.ttf | $(EE_ASM_DIR)
 
 $(EE_ASM_DIR)icon_sys.s: gfx/icon.sys | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ icon_sys
-	
+
 $(EE_ASM_DIR)icon_icn.s: gfx/opl.icn | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ icon_icn	
+	$(BIN2S) $< $@ icon_icn
 
 $(EE_ASM_DIR)icon_sys_A.s: misc/icon_A.sys | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ icon_sys_A
 
 $(EE_ASM_DIR)icon_sys_J.s: misc/icon_J.sys | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ icon_sys_J
+
+$(EE_ASM_DIR)conf_theme_OPL.s: misc/conf_theme_OPL.cfg | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ conf_theme_OPL_cfg
 
 $(EE_ASM_DIR)IOPRP_img.s: modules/iopcore/IOPRP.img | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ IOPRP_img

--- a/misc/conf_theme_OPL.cfg
+++ b/misc/conf_theme_OPL.cfg
@@ -1,0 +1,34 @@
+main0:
+	type=StaticImage
+	aligned=0
+	scaled=0
+	width=DIM_INF
+	height=DIM_INF
+
+main1:
+	type=MenuIcon
+
+main2:
+	type=MenuText
+
+main3:
+	type=ItemsList
+
+main4:
+	type=ItemIcon
+
+# DVD cover size: 129x184mm
+main5:
+	type=ItemCover
+	width=140
+	height=200
+
+main6:
+	type=ItemText
+
+main7:
+	type=HintText
+
+main8:
+	type=LoadingIcon
+

--- a/src/themes.c
+++ b/src/themes.c
@@ -13,6 +13,9 @@
 #define HINT_HEIGHT 32
 #define DECORATOR_SIZE 20
 
+extern const char conf_theme_OPL_cfg;
+extern u16 size_conf_theme_OPL_cfg;
+
 theme_t *gTheme;
 
 static int screenWidth;
@@ -1062,6 +1065,7 @@ static void thmLoadFonts(config_set_t *themeConfig, const char *themePath, theme
 static void thmLoad(const char *themePath)
 {
     LOG("THEMES Load theme path=%s\n", themePath);
+    char path[256];
     theme_t *curT = gTheme;
     theme_t *newT = (theme_t *)malloc(sizeof(theme_t));
     memset(newT, 0, sizeof(theme_t));
@@ -1082,60 +1086,48 @@ static void thmLoad(const char *themePath)
     if (!themePath) {
         //No theme specified. Prepare and load the default theme.
         themeConfig = configAlloc(0, NULL, NULL);
-        configSetInt(themeConfig, "bg_overlay_aligned", ALIGN_NONE);
-        configSetInt(themeConfig, "bg_overlay_scaled", SCALING_NONE);
-        configSetStr(themeConfig, "bg_overlay_width", "DIM_INF");
-        configSetStr(themeConfig, "bg_overlay_height", "DIM_INF");
-        addGUIElem(themePath, themeConfig, newT, &newT->mainElems, elementsType[ELEM_TYPE_STATIC_IMAGE], "bg_overlay");
-        addGUIElem(themePath, themeConfig, newT, &newT->mainElems, elementsType[ELEM_TYPE_MENU_ICON], "category_icon");
-        addGUIElem(themePath, themeConfig, newT, &newT->mainElems, elementsType[ELEM_TYPE_MENU_TEXT], "category_label");
-        addGUIElem(themePath, themeConfig, newT, &newT->mainElems, elementsType[ELEM_TYPE_ITEMS_LIST], "game_list");
-        addGUIElem(themePath, themeConfig, newT, &newT->mainElems, elementsType[ELEM_TYPE_ITEM_ICON], "disc_icon");
-        addGUIElem(themePath, themeConfig, newT, &newT->mainElems, elementsType[ELEM_TYPE_ITEM_COVER], "game_cover");
-        addGUIElem(themePath, themeConfig, newT, &newT->mainElems, elementsType[ELEM_TYPE_ITEM_TEXT], "game_id");
-        addGUIElem(themePath, themeConfig, newT, &newT->mainElems, elementsType[ELEM_TYPE_HINT_TEXT], "hint_text");
-        addGUIElem(themePath, themeConfig, newT, &newT->mainElems, elementsType[ELEM_TYPE_LOADING_ICON], "loading_icon");
+        configReadBuffer(themeConfig, &conf_theme_OPL_cfg, size_conf_theme_OPL_cfg);
     } else {
-        char path[256];
         snprintf(path, sizeof(path), "%sconf_theme.cfg", themePath);
         themeConfig = configAlloc(0, NULL, path);
         configRead(themeConfig); // try to load the theme config file
+    }
 
-        int intValue;
-        if (configGetInt(themeConfig, "use_default", &intValue))
-            newT->useDefault = intValue;
+    int intValue;
+    if (configGetInt(themeConfig, "use_default", &intValue))
+        newT->useDefault = intValue;
 
-        if (configGetInt(themeConfig, "use_real_height", &intValue)) {
-            if (intValue)
-                newT->usedHeight = screenHeight;
-        }
+    if (configGetInt(themeConfig, "use_real_height", &intValue)) {
+        if (intValue)
+            newT->usedHeight = screenHeight;
+    }
 
-        configGetColor(themeConfig, "bg_color", newT->bgColor);
+    configGetColor(themeConfig, "bg_color", newT->bgColor);
 
-        unsigned char color[3];
-        if (configGetColor(themeConfig, "text_color", color))
-            newT->textColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0x80);
+    unsigned char color[3];
+    if (configGetColor(themeConfig, "text_color", color))
+        newT->textColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0x80);
 
-        if (configGetColor(themeConfig, "ui_text_color", color))
-            newT->uiTextColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0x80);
+    if (configGetColor(themeConfig, "ui_text_color", color))
+        newT->uiTextColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0x80);
 
-        if (configGetColor(themeConfig, "sel_text_color", color))
-            newT->selTextColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0x80);
+    if (configGetColor(themeConfig, "sel_text_color", color))
+        newT->selTextColor = GS_SETREG_RGBA(color[0], color[1], color[2], 0x80);
 
-        // before loading the element definitions, we have to have the fonts prepared
-        // for that, we load the fonts and a translation table
+    // before loading the element definitions, we have to have the fonts prepared
+    // for that, we load the fonts and a translation table
+    if (themePath)
         thmLoadFonts(themeConfig, themePath, newT);
 
-        int i = 1;
-        snprintf(path, sizeof(path), "main0");
-        while (addGUIElem(themePath, themeConfig, newT, &newT->mainElems, NULL, path))
-            snprintf(path, sizeof(path), "main%d", i++);
+    int i = 1;
+    snprintf(path, sizeof(path), "main0");
+    while (addGUIElem(themePath, themeConfig, newT, &newT->mainElems, NULL, path))
+        snprintf(path, sizeof(path), "main%d", i++);
 
-        i = 1;
-        snprintf(path, sizeof(path), "info0");
-        while (addGUIElem(themePath, themeConfig, newT, &newT->infoElems, NULL, path))
-            snprintf(path, sizeof(path), "info%d", i++);
-    }
+    i = 1;
+    snprintf(path, sizeof(path), "info0");
+    while (addGUIElem(themePath, themeConfig, newT, &newT->infoElems, NULL, path))
+        snprintf(path, sizeof(path), "info%d", i++);
 
     validateGUIElems(themePath, themeConfig, newT);
     configFree(themeConfig);
@@ -1143,7 +1135,6 @@ static void thmLoad(const char *themePath)
     LOG("THEMES Number of cache: %d\n", newT->gameCacheCount);
     LOG("THEMES Used height: %d\n", newT->usedHeight);
 
-    int i;
     // default all to not loaded...
     for (i = 0; i < TEXTURES_COUNT; i++) {
         newT->textures[i].Mem = NULL;
@@ -1156,16 +1147,16 @@ static void thmLoad(const char *themePath)
     thmFree(curT);
 
     // First start with busy icon
-    const char *path = themePath;
+    const char *themePath_temp = themePath;
     int customBusy = 0;
     for (i = LOAD0_ICON; i <= LOAD7_ICON; i++) {
-        if (thmLoadResource(i, path, GS_PSM_CT32, gTheme->useDefault) >= 0)
+        if (thmLoadResource(i, themePath_temp, GS_PSM_CT32, gTheme->useDefault) >= 0)
             customBusy = 1;
         else {
             if (customBusy)
                 break;
             else
-                path = NULL;
+                themePath_temp = NULL;
         }
     }
     gTheme->loadingIconCount = i;


### PR DESCRIPTION
The default OPL theme was hardcoded. With this patch the default theme becomes a file in "misc/conf_theme_OPL.cfg". This makes it a lot more simple to change the default theme.

I've changed only one small thing to it to make the cover art always display at the same size, even when the cover art texture is a different size. For instance I am now testing with 512x125 and 256x256 (8bit bmp) covers.

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

