### PR TITLE
Added workaround for bad GameStar adaptor to in-game ATAD code.

### DIFF
--- a/modules/iopcore/cdvdman/atad.c
+++ b/modules/iopcore/cdvdman/atad.c
@@ -50,6 +50,7 @@ extern int netlog_inited;
 #define VERSION "v1.2"
 
 extern char lba_48bit;
+static u8 ata_gamestar_workaround = 0;
 
 static int ata_evflg = -1;
 
@@ -110,14 +111,14 @@ static unsigned int ata_alarm_cb(void *unused);
 static void ata_set_dir(int dir);
 
 /* In v1.04, DMA was enabled in ata_set_dir() instead. */
-static void AtadPreDmaCb(int bcr, int dir)
+static void ata_pre_dma_cb(int bcr, int dir)
 {
     USE_SPD_REGS;
 
     SPD_REG16(SPD_R_XFR_CTRL) |= 0x80;
 }
 
-static void AtadPostDmaCb(int bcr, int dir)
+static void ata_post_dma_cb(int bcr, int dir)
 {
     USE_SPD_REGS;
 
@@ -138,9 +139,7 @@ static int ata_create_event_flag(void)
 
 int atad_start(void)
 {
-#ifdef DEV9_DEBUG
     USE_SPD_REGS;
-#endif
     iop_event_t event;
     int res = 1;
 
@@ -152,6 +151,12 @@ int atad_start(void)
         goto out;
     }
 #endif
+
+    /* Some compatible adaptors may malfunction if transfers are not done according to the old ps2atad design.
+       Official adaptors appear to have a 0x0001 set for this register, but not compatibles.
+       While official I/O to this register are 8-bit, some compatibles have a 0x01 for the lower 8-bits,
+       but the upper 8-bits contain some random value. Hence perform a 16-bit read instead. */
+    ata_gamestar_workaround = (SPD_REG16(0x20) != 1);
 
     event.attr = 0;
     event.bits = 0;
@@ -167,8 +172,10 @@ int atad_start(void)
     /* In v1.04, PIO mode 0 was set here. In late versions, it is set in ata_init_devices(). */
     dev9RegisterIntrCb(1, &ata_intr_cb);
     dev9RegisterIntrCb(0, &ata_intr_cb);
-    dev9RegisterPreDmaCb(0, &AtadPreDmaCb);
-    dev9RegisterPostDmaCb(0, &AtadPostDmaCb);
+    if (!ata_gamestar_workaround) {
+      dev9RegisterPreDmaCb(0, &ata_pre_dma_cb);
+      dev9RegisterPostDmaCb(0, &ata_post_dma_cb);
+    }
 
 #ifdef VMC_DRIVER
     iop_sema_t smp;
@@ -606,11 +613,16 @@ int ata_device_sector_io(int device, void *buf, u32 lba, u32 nsectors, int dir)
         }
 
         for (retries = 3; retries > 0; retries--) {
+            /* Due to the retry loop, put this call (for the GameStar workaround) here instead of the old location. */
+            if (ata_gamestar_workaround)
+                ata_set_dir(dir);
+
             if ((res = ata_io_start(buf, len, 0, len, sector, lcyl, hcyl, select, command)) != 0)
                 break;
 
             /* Set up (part of) the transfer here. In v1.04, this was called at the top of the outer loop. */
-            ata_set_dir(dir);
+            if (!ata_gamestar_workaround)
+                ata_set_dir(dir);
 
             res = ata_io_finish();
 
@@ -646,5 +658,5 @@ static void ata_set_dir(int dir)
     val = SPD_REG16(SPD_R_IF_CTRL) & 1;
     val |= (dir == ATA_DIR_WRITE) ? 0x4c : 0x4e;
     SPD_REG16(SPD_R_IF_CTRL) = val;
-    SPD_REG16(SPD_R_XFR_CTRL) = dir | 0x6; //In v1.04, DMA was enabled here (0x86 instead of 0x6)
+    SPD_REG16(SPD_R_XFR_CTRL) = dir | (ata_gamestar_workaround ? 0x86 : 0x6); //In v1.04, DMA was enabled here (0x86 instead of 0x6)
 }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [x] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
Added workaround for bad GameStar adaptor to in-game ATAD code.

As of the end of [this discussion](https://github.com/ps2dev/ps2sdk/issues/49), I've decided that it wouldn't cost much to add a workaround.

Untested because I have no PlayStation 2 consoles. Please remember to update your PS2SDK as well, so that the UI side will also have the same fix.