### PR TITLE
(dev9-ingame) removed code that shuts down DEV9, to fix commit e9a679d.

### DIFF
--- a/modules/iopcore/cdvdman/dev9.c
+++ b/modules/iopcore/cdvdman/dev9.c
@@ -222,24 +222,7 @@ static void dev9_set_stat(int stat)
 /* Export 6 */
 void dev9Shutdown(void)
 {
-    int idx;
-    USE_DEV9_REGS;
-
-    for (idx = 0; idx < 16; idx++)
-        if (dev9_shutdown_cbs[idx])
-            dev9_shutdown_cbs[idx]();
-
-    if (dev9type == 0) { /* PCMCIA */
-        DEV9_REG(DEV9_R_POWER) = 0;
-        DEV9_REG(DEV9_R_1474) = 0;
-    } else if (dev9type == 1) {
-        DEV9_REG(DEV9_R_1466) = 1;
-        DEV9_REG(DEV9_R_1464) = 0;
-        DEV9_REG(DEV9_R_1460) = DEV9_REG(DEV9_R_1464);
-        DEV9_REG(DEV9_R_POWER) = DEV9_REG(DEV9_R_POWER) & ~4;
-        DEV9_REG(DEV9_R_POWER) = DEV9_REG(DEV9_R_POWER) & ~1;
-    }
-    DelayThread(1000000);
+    //Do not let the DEV9 interface to be switched off.
 }
 
 /* Export 7 */


### PR DESCRIPTION
Some games would attempt to shut down DEV9, which would disable the ATA and SMAP interfaces.

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Prevents games from shutting down DEV9, which accidentally became possible from commit e9a679d.
The games may shut down DEV9 when the player leaves network-related features, as part of their original design. But this is not desirable because it would cut off ATA (for HDD mode) and network support (for SMB mode).
