### PR TITLE
(SMSTCPIP) Disabled ETHARP_ALWAYS_INSERT because the ARP table may be small

### DIFF
--- a/modules/network/SMSTCPIP/include/lwipopts.h
+++ b/modules/network/SMSTCPIP/include/lwipopts.h
@@ -193,6 +193,15 @@ a lot of data that needs to be copied, this should be set high. */
 #endif
 #define ARP_QUEUEING 1
 
+/**
+ * If defined to 1, cache entries are updated or added for every kind of ARP traffic
+ * or broadcast IP traffic. Recommended for routers.
+ * If defined to 0, only existing cache entries are updated. Entries are added when
+ * lwIP is sending to them. Recommended for embedded devices.
+ */
+//Do not always insert ARP entries, as the ARP table is small.
+#define ETHARP_ALWAYS_INSERT 0
+
 /* ---------- IP options ---------- */
 /* Define IP_FORWARD to 1 if you wish to have the ability to forward
    IP packets across network interfaces. If you are going to run lwIP


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

