### PR TITLE
Backported timer code from lwIP 1.4.1 to prevent race conditions around the etharp and tcp timers.

### DIFF
--- a/modules/network/SMSTCPIP/Makefile
+++ b/modules/network/SMSTCPIP/Makefile
@@ -1,7 +1,7 @@
 IOP_BIN = SMSTCPIP.irx
 IOP_OBJS = ps2ip.o inet.o ip.o ip_addr.o ip_frag.o etharp.o tcp_in.o tcp_out.o \
 	tcp.o tcpip.o mem.o api_lib.o api_msg.o sockets.o netif.o udp.o memp.o \
-	icmp.o pbuf.o exports.o imports.o
+	icmp.o pbuf.o timers.o exports.o imports.o
 IOP_LIBS =
 
 IOP_INCS += -Iinclude -I../../iopcore/common

--- a/modules/network/SMSTCPIP/imports.lst
+++ b/modules/network/SMSTCPIP/imports.lst
@@ -21,6 +21,7 @@ I_ExitDeleteThread
 I_StartThread
 I_iReleaseWaitThread
 I_USec2SysClock
+I_SysClock2USec
 I_GetThreadId
 I_GetSystemTime
 I_SetAlarm

--- a/modules/network/SMSTCPIP/include/lwip/opt.h
+++ b/modules/network/SMSTCPIP/include/lwip/opt.h
@@ -135,7 +135,7 @@ a lot of data that needs to be copied, this should be set high. */
 /* MEMP_NUM_SYS_TIMEOUT: the number of simulateously active
    timeouts. */
 #ifndef MEMP_NUM_SYS_TIMEOUT
-#define MEMP_NUM_SYS_TIMEOUT 3
+#define MEMP_NUM_SYS_TIMEOUT (LWIP_TCP + LWIP_ARP)
 #endif
 
 /* The following four are used only with the sequential API and can be

--- a/modules/network/SMSTCPIP/include/lwip/sys.h
+++ b/modules/network/SMSTCPIP/include/lwip/sys.h
@@ -69,20 +69,6 @@ struct sys_timeout
 /** Return code for timeouts from sys_arch_mbox_fetch and sys_arch_sem_wait */
 #define SYS_ARCH_TIMEOUT -418
 
-typedef void (*sys_timeout_handler)(void *arg);
-
-struct sys_timeout
-{
-    struct sys_timeout *next;
-    u32_t time;
-    sys_timeout_handler h;
-    void *arg;
-};
-
-struct sys_timeouts
-{
-    struct sys_timeout *next;
-};
 /* Semaphore functions. */
 sys_sem_t sys_sem_new(u8_t count);
 //void sys_sem_signal(sys_sem_t sem);

--- a/modules/network/SMSTCPIP/include/lwip/tcp.h
+++ b/modules/network/SMSTCPIP/include/lwip/tcp.h
@@ -469,6 +469,12 @@ int tcp_pcbs_sane(void);
 #define tcp_pcbs_sane() 1
 #endif /* TCP_DEBUG */
 
+#if NO_SYS
+#define tcp_timer_needed()
+#else
+void tcp_timer_needed(void);
+#endif
+
 /* The TCP PCB lists. */
 extern struct tcp_pcb_listen *tcp_listen_pcbs; /* List of all TCP PCBs in LISTEN state. */
 extern struct tcp_pcb *tcp_active_pcbs;        /* List of all TCP PCBs that are in a
@@ -492,6 +498,7 @@ extern struct tcp_pcb *tcp_tmp_pcb; /* Only used for temporary storage. */
     do {                    \
         npcb->next = *pcbs; \
         *(pcbs) = npcb;     \
+        tcp_timer_needed(); \
     } while (0)
 #define TCP_RMV(pcbs, npcb)                                                                   \
     do {                                                                                      \

--- a/modules/network/SMSTCPIP/include/lwip/tcpip.h
+++ b/modules/network/SMSTCPIP/include/lwip/tcpip.h
@@ -34,6 +34,7 @@
 
 #include "lwip/api_msg.h"
 #include "lwip/pbuf.h"
+#include "lwip/timers.h"
 
 #if LWIP_TCPIP_CORE_LOCKING
 /** The global semaphore to lock the stack. */

--- a/modules/network/SMSTCPIP/include/lwip/timers.h
+++ b/modules/network/SMSTCPIP/include/lwip/timers.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2001-2004 Swedish Institute of Computer Science.
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, 
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED 
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+ * OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ * 
+ * Author: Adam Dunkels <adam@sics.se>
+ *         Simon Goldschmidt
+ *
+ */
+#ifndef __LWIP_TIMERS_H__
+#define __LWIP_TIMERS_H__
+
+#include "lwip/opt.h"
+
+/* Timers are not supported when NO_SYS==1 and NO_SYS_NO_TIMERS==1 */
+#define LWIP_TIMERS (!NO_SYS || (NO_SYS && !NO_SYS_NO_TIMERS))
+
+#if LWIP_TIMERS
+
+#include "lwip/err.h"
+#if !NO_SYS
+#include "lwip/sys.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef LWIP_DEBUG_TIMERNAMES
+#ifdef LWIP_DEBUG
+#define LWIP_DEBUG_TIMERNAMES SYS_DEBUG
+#else /* LWIP_DEBUG */
+#define LWIP_DEBUG_TIMERNAMES 0
+#endif /* LWIP_DEBUG*/
+#endif
+
+/** Function prototype for a timeout callback function. Register such a function
+ * using sys_timeout().
+ *
+ * @param arg Additional argument to pass to the function - set up by sys_timeout()
+ */
+typedef void (* sys_timeout_handler)(void *arg);
+
+struct sys_timeo {
+  struct sys_timeo *next;
+  u32_t time;
+  sys_timeout_handler h;
+  void *arg;
+#if LWIP_DEBUG_TIMERNAMES
+  const char* handler_name;
+#endif /* LWIP_DEBUG_TIMERNAMES */
+};
+
+void sys_timeouts_init(void);
+
+#if LWIP_DEBUG_TIMERNAMES
+void sys_timeout_debug(u32_t msecs, sys_timeout_handler handler, void *arg, const char* handler_name);
+#define sys_timeout(msecs, handler, arg) sys_timeout_debug(msecs, handler, arg, #handler)
+#else /* LWIP_DEBUG_TIMERNAMES */
+void sys_timeout(u32_t msecs, sys_timeout_handler handler, void *arg);
+#endif /* LWIP_DEBUG_TIMERNAMES */
+
+void sys_untimeout(sys_timeout_handler handler, void *arg);
+#if NO_SYS
+void sys_check_timeouts(void);
+void sys_restart_timeouts(void);
+#else /* NO_SYS */
+void sys_timeouts_mbox_fetch(sys_mbox_t mbox, void **msg);
+#endif /* NO_SYS */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LWIP_TIMERS */
+#endif /* __LWIP_TIMERS_H__ */

--- a/modules/network/SMSTCPIP/memp.c
+++ b/modules/network/SMSTCPIP/memp.c
@@ -43,6 +43,7 @@
 #include "lwip/tcpip.h"
 
 #include "lwip/sys.h"
+#include "lwip/timers.h"
 #include "lwip/stats.h"
 
 #include <intrman.h>
@@ -67,7 +68,7 @@ static const u16_t memp_sizes[MEMP_MAX] = {
     sizeof(struct netconn),
     sizeof(struct api_msg),
     sizeof(struct tcpip_msg),
-    sizeof(struct sys_timeout)};
+    sizeof(struct sys_timeo)};
 
 static const u16_t memp_num[MEMP_MAX] = {
     MEMP_NUM_PBUF,
@@ -113,7 +114,7 @@ static u8_t memp_memory[(MEMP_NUM_PBUF *
                              MEM_ALIGN_SIZE(sizeof(struct tcpip_msg) +
                                             sizeof(struct memp)) +
                          MEMP_NUM_SYS_TIMEOUT *
-                             MEM_ALIGN_SIZE(sizeof(struct sys_timeout) +
+                             MEM_ALIGN_SIZE(sizeof(struct sys_timeo) +
                                             sizeof(struct memp)))];
 
 

--- a/modules/network/SMSTCPIP/ps2ip.c
+++ b/modules/network/SMSTCPIP/ps2ip.c
@@ -58,13 +58,9 @@ struct sys_mbox
 typedef struct ip_addr IPAddr;
 
 #define MODNAME "TCP/IP Stack"
-IRX_ID(MODNAME, 1, 4);
+IRX_ID(MODNAME, 1, 5);
 
 extern struct irx_export_table _exp_ps2ip;
-
-#ifdef PS2IP_DHCP
-static int iTimerDHCP = 0;
-#endif /* PS2IP_DHCP */
 
 #if LWIP_HAVE_LOOPIF
 static NetIF LoopIF;
@@ -152,79 +148,6 @@ int ps2ip_setconfig(t_ip_info *pInfo)
     return 1;
 
 } /* end ps2ip_setconfig */
-
-#define ALARM_TCP 0x00000001
-#define ALARM_ARP 0x00000002
-#define ALARM_MSK (ALARM_TCP | ALARM_ARP)
-
-typedef struct AlarmData
-{
-
-    int m_EventFlag;
-    unsigned long m_EventMask;
-    iop_sys_clock_t m_Clock;
-
-} AlarmData;
-
-unsigned int _alarm(void *apArg)
-{
-
-    AlarmData *lpData = (AlarmData *)apArg;
-
-    iSetEventFlag(lpData->m_EventFlag, lpData->m_EventMask);
-
-    return lpData->m_Clock.lo;
-
-} /* end _alarm */
-
-static void TimerThread(void *apArg)
-{
-
-    AlarmData lTCPData;
-    AlarmData lARPData;
-    iop_event_t lEvent;
-
-    lEvent.attr = 0;
-    lEvent.bits = 0;
-    lTCPData.m_EventFlag =
-        lARPData.m_EventFlag = CreateEventFlag(&lEvent);
-    lTCPData.m_EventMask = ALARM_TCP;
-    lARPData.m_EventMask = ALARM_ARP;
-    USec2SysClock(TCP_TMR_INTERVAL * 1024, &lTCPData.m_Clock);
-    USec2SysClock(ARP_TMR_INTERVAL * 1024, &lARPData.m_Clock);
-
-    SetAlarm(&lTCPData.m_Clock, _alarm, &lTCPData);
-    SetAlarm(&lARPData.m_Clock, _alarm, &lARPData);
-
-    while (1) {
-
-        unsigned long lRes;
-
-        WaitEventFlag(lTCPData.m_EventFlag, ALARM_MSK, WEF_CLEAR | WEF_OR, &lRes);
-
-#if LWIP_TCP
-        if (lRes & ALARM_TCP)
-            tcp_tmr();
-#endif
-        if (lRes & ALARM_ARP)
-            etharp_tmr();
-
-    } /* end while */
-
-} /* end TimerThread */
-
-static void InitTimer(void)
-{
-
-    iop_thread_t lThread = {TH_C, 0, TimerThread, 0x800, SYS_THREAD_PRIO_BASE};
-    int lTID = CreateThread(&lThread);
-
-    if (lTID < 0)
-        ExitDeleteThread();
-
-    StartThread(lTID, NULL);
-
-} /* end InitTimer */
 
 #ifdef INGAME_DRIVER
 typedef struct InputMSG
@@ -386,7 +309,6 @@ int _start(int argc, char **argv)
 #if LWIP_HAVE_LOOPIF
     AddLoopIF();
 #endif /* LWIP_HAVE_LOOPIF */
-    InitTimer();
 
     return MODULE_RESIDENT_END;
 

--- a/modules/network/SMSTCPIP/tcpip.c
+++ b/modules/network/SMSTCPIP/tcpip.c
@@ -66,12 +66,16 @@ static void tcpip_thread(void *arg)
 #if LWIP_TCP
     tcp_init();
 #endif /* LWIP_TCP */
+#if LWIP_TIMERS
+    sys_timeouts_init();
+#endif /* LWIP_TIMERS */
+
     tcpip_init_done(tcpip_init_done_arg);
 
     LOCK_TCPIP_CORE();
     while (1) {
         UNLOCK_TCPIP_CORE();
-        sys_mbox_fetch(g_TCPIPMBox, (void *)&msg);
+        sys_timeouts_mbox_fetch(g_TCPIPMBox, (void *)&msg);
         LOCK_TCPIP_CORE();
 
         switch (msg->type) {

--- a/modules/network/SMSTCPIP/timers.c
+++ b/modules/network/SMSTCPIP/timers.c
@@ -1,0 +1,296 @@
+/**
+ * @file
+ * Stack-internal timers implementation.
+ * This file includes timer callbacks for stack-internal timers as well as
+ * functions to set up or stop timers and check for expired timers.
+ *
+ */
+
+/*
+ * Copyright (c) 2001-2004 Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *         Simon Goldschmidt
+ *
+ */
+
+#include <thsemap.h>
+
+#include "lwip/opt.h"
+
+#include "lwip/timers.h"
+#include "lwip/tcp.h"
+
+#if LWIP_TIMERS
+
+#include "lwip/def.h"
+#include "lwip/memp.h"
+#include "lwip/tcpip.h"
+
+#include "lwip/ip_frag.h"
+#include "netif/etharp.h"
+#include "lwip/sys.h"
+#include "lwip/pbuf.h"
+
+/** The one and only timeout list */
+static struct sys_timeo *next_timeout;
+
+#if LWIP_TCP
+/** global variable that shows if the tcp timer is currently scheduled or not */
+static int tcpip_tcp_timer_active;
+
+/**
+ * Timer callback function that calls tcp_tmr() and reschedules itself.
+ *
+ * @param arg unused argument
+ */
+static void
+tcpip_tcp_timer(void *arg)
+{
+  /* call TCP timer handler */
+  tcp_tmr();
+  /* timer still needed? */
+  if (tcp_active_pcbs || tcp_tw_pcbs) {
+    /* restart timer */
+    sys_timeout(TCP_TMR_INTERVAL, tcpip_tcp_timer, NULL);
+  } else {
+    /* disable timer */
+    tcpip_tcp_timer_active = 0;
+  }
+}
+
+/**
+ * Called from TCP_REG when registering a new PCB:
+ * the reason is to have the TCP timer only running when
+ * there are active (or time-wait) PCBs.
+ */
+void
+tcp_timer_needed(void)
+{
+  /* timer is off but needed again? */
+  if (!tcpip_tcp_timer_active && (tcp_active_pcbs || tcp_tw_pcbs)) {
+    /* enable and start timer */
+    tcpip_tcp_timer_active = 1;
+    sys_timeout(TCP_TMR_INTERVAL, tcpip_tcp_timer, NULL);
+  }
+}
+#endif /* LWIP_TCP */
+
+#if LWIP_ARP
+/**
+ * Timer callback function that calls etharp_tmr() and reschedules itself.
+ *
+ * @param arg unused argument
+ */
+static void
+arp_timer(void *arg)
+{
+  LWIP_UNUSED_ARG(arg);
+  LWIP_DEBUGF(TIMERS_DEBUG, ("tcpip: etharp_tmr()\n"));
+  etharp_tmr();
+  sys_timeout(ARP_TMR_INTERVAL, arp_timer, NULL);
+}
+#endif /* LWIP_ARP */
+
+/** Initialize this module */
+void sys_timeouts_init(void)
+{
+#if LWIP_ARP
+  sys_timeout(ARP_TMR_INTERVAL, arp_timer, NULL);
+#endif /* LWIP_ARP */
+}
+
+/**
+ * Create a one-shot timer (aka timeout). Timeouts are processed in the
+ * following cases:
+ * - while waiting for a message using sys_timeouts_mbox_fetch()
+ * - by calling sys_check_timeouts() (NO_SYS==1 only)
+ *
+ * @param msecs time in milliseconds after that the timer should expire
+ * @param handler callback function to call when msecs have elapsed
+ * @param arg argument to pass to the callback function
+ */
+#if LWIP_DEBUG_TIMERNAMES
+void
+sys_timeout_debug(u32_t msecs, sys_timeout_handler handler, void *arg, const char* handler_name)
+#else /* LWIP_DEBUG_TIMERNAMES */
+void
+sys_timeout(u32_t msecs, sys_timeout_handler handler, void *arg)
+#endif /* LWIP_DEBUG_TIMERNAMES */
+{
+  struct sys_timeo *timeout, *t;
+
+  timeout = (struct sys_timeo *)memp_malloc(MEMP_SYS_TIMEOUT);
+  if (timeout == NULL) {
+    LWIP_ASSERT("sys_timeout: timeout != NULL, pool MEMP_SYS_TIMEOUT is empty", timeout != NULL);
+    return;
+  }
+  timeout->next = NULL;
+  timeout->h = handler;
+  timeout->arg = arg;
+  timeout->time = msecs;
+#if LWIP_DEBUG_TIMERNAMES
+  timeout->handler_name = handler_name;
+  LWIP_DEBUGF(TIMERS_DEBUG, ("sys_timeout: %p msecs=%"U32_F" handler=%s arg=%p\n",
+    (void *)timeout, msecs, handler_name, (void *)arg));
+#endif /* LWIP_DEBUG_TIMERNAMES */
+
+  if (next_timeout == NULL) {
+    next_timeout = timeout;
+    return;
+  }
+
+  if (next_timeout->time > msecs) {
+    next_timeout->time -= msecs;
+    timeout->next = next_timeout;
+    next_timeout = timeout;
+  } else {
+    for(t = next_timeout; t != NULL; t = t->next) {
+      timeout->time -= t->time;
+      if (t->next == NULL || t->next->time > timeout->time) {
+        if (t->next != NULL) {
+          t->next->time -= timeout->time;
+        }
+        timeout->next = t->next;
+        t->next = timeout;
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * Go through timeout list (for this task only) and remove the first matching
+ * entry, even though the timeout has not triggered yet.
+ *
+ * @note This function only works as expected if there is only one timeout
+ * calling 'handler' in the list of timeouts.
+ *
+ * @param handler callback function that would be called by the timeout
+ * @param arg callback argument that would be passed to handler
+*/
+void
+sys_untimeout(sys_timeout_handler handler, void *arg)
+{
+  struct sys_timeo *prev_t, *t;
+
+  if (next_timeout == NULL) {
+    return;
+  }
+
+  for (t = next_timeout, prev_t = NULL; t != NULL; prev_t = t, t = t->next) {
+    if ((t->h == handler) && (t->arg == arg)) {
+      /* We have a match */
+      /* Unlink from previous in list */
+      if (prev_t == NULL) {
+        next_timeout = t->next;
+      } else {
+        prev_t->next = t->next;
+      }
+      /* If not the last one, add time of this one back to next */
+      if (t->next != NULL) {
+        t->next->time += t->time;
+      }
+      memp_free(MEMP_SYS_TIMEOUT, t);
+      return;
+    }
+  }
+  return;
+}
+
+
+/**
+ * Wait (forever) for a message to arrive in an mbox.
+ * While waiting, timeouts are processed.
+ *
+ * @param mbox the mbox to fetch the message from
+ * @param msg the place to store the message
+ */
+void
+sys_timeouts_mbox_fetch(sys_mbox_t mbox, void **msg)
+{
+  u32_t time_needed;
+  struct sys_timeo *tmptimeout;
+  sys_timeout_handler handler;
+  void *arg;
+
+ again:
+  if (!next_timeout) {
+    time_needed = sys_arch_mbox_fetch(mbox, msg, 0);
+  } else {
+    if (next_timeout->time > 0) {
+      time_needed = sys_arch_mbox_fetch(mbox, msg, next_timeout->time);
+    } else {
+      time_needed = SYS_ARCH_TIMEOUT;
+    }
+
+    if (time_needed == SYS_ARCH_TIMEOUT) {
+      /* If time == SYS_ARCH_TIMEOUT, a timeout occured before a message
+         could be fetched. We should now call the timeout handler and
+         deallocate the memory allocated for the timeout. */
+      tmptimeout = next_timeout;
+      next_timeout = tmptimeout->next;
+      handler = tmptimeout->h;
+      arg = tmptimeout->arg;
+#if LWIP_DEBUG_TIMERNAMES
+      if (handler != NULL) {
+        LWIP_DEBUGF(TIMERS_DEBUG, ("stmf calling h=%s arg=%p\n",
+          tmptimeout->handler_name, arg));
+      }
+#endif /* LWIP_DEBUG_TIMERNAMES */
+      memp_free(MEMP_SYS_TIMEOUT, tmptimeout);
+      if (handler != NULL) {
+        /* For LWIP_TCPIP_CORE_LOCKING, lock the core before calling the
+           timeout handler function. */
+        LOCK_TCPIP_CORE();
+        handler(arg);
+        UNLOCK_TCPIP_CORE();
+      }
+
+      /* We try again to fetch a message from the mbox. */
+      goto again;
+    } else {
+      /* If time != SYS_ARCH_TIMEOUT, a message was received before the timeout
+         occured. The time variable is set to the number of
+         milliseconds we waited for the message. */
+      if (time_needed < next_timeout->time) {
+        next_timeout->time -= time_needed;
+      } else {
+        next_timeout->time = 0;
+      }
+    }
+  }
+}
+
+#else /* LWIP_TIMERS */
+/* Satisfy the TCP code which calls this function */
+void
+tcp_timer_needed(void)
+{
+}
+#endif /* LWIP_TIMERS */


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

The current timer implementation involves a real timer that wakes up a thread, which will call tcp_tmr and etharp_tmr.
However, as these timers have no critical-region protection, it is possible for a race condition to occur between the timer and tcpip threads.

By back-porting the timer code from lwIP 1.4.1, it is possible to solve this by running the timers from the tcpip thread itself (cannot have a race condition when there is only one thread). When the core locking option is enabled (it is), it is protectected by the core locking semaphore.