### PR TITLE
Added patch for .hack (all PAL releases).

### DIFF
--- a/ee_core/include/patches.h
+++ b/ee_core/include/patches.h
@@ -13,6 +13,6 @@
 
 #define COMPAT_MODE_4 0x08 // Skip Videos
 
-void apply_patches(void);
+void apply_patches(const char *path);
 
 #endif /* PATCHES */

--- a/ee_core/src/syshook.c
+++ b/ee_core/src/syshook.c
@@ -119,7 +119,7 @@ void t_loadElf(void)
 
         DPRINTF("t_loadElf: trying to apply patches...\n");
         // applying needed patches
-        apply_patches();
+        apply_patches(g_argv[0]);
 
         FlushCache(0);
         FlushCache(2);


### PR DESCRIPTION
The games have language select menus, which boots the main ELF.
However, they do not call scePadEnd() before LoadExecPS2().

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
The PAL release of the .hack series of games had a language-select screen added to them. However, the developers neglected to call scePadEnd() before LoadExecPS2().
That likely caused the SIF to hang up when sceSifRebootIop() is used by EELOAD (or in our case, OPL's EE core).

There may be other issues within the game, but this should fix the crash after the language select screen.