### PR TITLE
Changed call to strcmp to _strcmp for .hack fix - avoid linking with …

### DIFF
--- a/ee_core/src/patches.c
+++ b/ee_core/src/patches.c
@@ -367,25 +367,25 @@ static void DotHack_patches(const char *path)
     };
     u32 *ptr, *pPadEnd, *pLoadExecPS2;
 
-    if (strcmp(path, "cdrom0:\\SLES_522.37;1") == 0)
+    if (_strcmp(path, "cdrom0:\\SLES_522.37;1") == 0)
     {
         ptr = (void*)0x0011a5fc;
         pPadEnd = (void*)0x00119290;
 	pLoadExecPS2 = (void*)FNADDR(ptr[2]);
     }
-    else if (strcmp(path, "cdrom0:\\SLES_524.67;1") == 0)
+    else if (_strcmp(path, "cdrom0:\\SLES_524.67;1") == 0)
     {
         ptr = (void*)0x0011a8bc;
         pPadEnd = (void*)0x00119550;
 	pLoadExecPS2 = (void*)FNADDR(ptr[2]);
     }
-    else if (strcmp(path, "cdrom0:\\SLES_524.68;1") == 0)
+    else if (_strcmp(path, "cdrom0:\\SLES_524.68;1") == 0)
     {
         ptr = (void*)0x00111d34;
         pPadEnd = (void*)0x001109b0;
 	pLoadExecPS2 = (void*)FNADDR(ptr[3]);
     }
-    else if (strcmp(path, "cdrom0:\\SLES_524.69;1") == 0)
+    else if (_strcmp(path, "cdrom0:\\SLES_524.69;1") == 0)
     {
         ptr = (void*)0x00111d34;
         pPadEnd = (void*)0x001109b0;


### PR DESCRIPTION
…libc's strcmp.

## Pull Request description

Due to changes to the toolchain, libc is now automatically linked to, which is why I could compile with no problems. But for compatibility and also because we prefer to not use the libc functions, I have gotten the patch to use the OPL libc functions.

It was noted that with the addition of the new patches, it becomes impossible to build OPL with all features enabled at compile-time.