### PR TITLE
Added fix for SOS: The Final Escape/Disaster Report/Zettai Zetsumei Toshi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,8 @@ MISC_OBJS =	icon_sys_A.o icon_sys_J.o conf_theme_OPL.o
 IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o usbhdfsd.o usbhdfsdfsv.o \
 		ps2atad.o hdpro_atad.o poweroff.o ps2hdd.o xhdd.o genvmc.o hdldsvr.o \
 		ps2dev9.o smsutils.o ps2ip.o smap.o isofs.o nbns-iop.o \
-		httpclient-iop.o netman.o ps2ips.o
+		httpclient-iop.o netman.o ps2ips.o \
+		iremsndpatch.o
 
 EECORE_OBJS = ee_core.o ioprp.o util.o \
 		elfldr.o udnl.o imgdrv.o eesync.o \
@@ -282,6 +283,9 @@ clean:
 	$(MAKE) -C modules/iopcore/cdvdman USE_HDPRO=1 clean
 	echo " -cdvdfsv"
 	$(MAKE) -C modules/iopcore/cdvdfsv clean
+	echo "  -patches"
+	echo "   -iremsnd"
+	$(MAKE) -C modules/iopcore/patches/iremsndpatch clean
 	echo " -isofs"
 	$(MAKE) -C modules/isofs clean
 	echo " -usbhdfsdfsv"
@@ -429,6 +433,13 @@ modules/iopcore/cdvdfsv/cdvdfsv.irx: modules/iopcore/cdvdfsv
 
 $(EE_ASM_DIR)cdvdfsv.s: modules/iopcore/cdvdfsv/cdvdfsv.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ cdvdfsv_irx
+
+modules/iopcore/patches/iremsndpatch/iremsndpatch.irx: modules/iopcore/patches/iremsndpatch
+	echo " -iremsnd patch"
+	$(MAKE) -C $<
+
+$(EE_ASM_DIR)iremsndpatch.s: modules/iopcore/patches/iremsndpatch/iremsndpatch.irx | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ iremsndpatch_irx
 
 modules/mcemu/usb_mcemu.irx: modules/mcemu
 	echo " -usb_mcemu"

--- a/ee_core/include/modules.h
+++ b/ee_core/include/modules.h
@@ -23,6 +23,9 @@ enum OPL_MODULE_ID {
     OPL_MODULE_ID_DRVTIF,
     OPL_MODULE_ID_TIFINET,
 
+    //Special patches
+    OPL_MODULE_ID_IOP_PATCH,
+
     OPL_MODULE_ID_COUNT
 };
 

--- a/include/extern_irx.h
+++ b/include/extern_irx.h
@@ -58,6 +58,9 @@ extern int size_ioptrap_irx;
 extern void *isofs_irx;
 extern int size_isofs_irx;
 
+extern void *iremsndpatch_irx;
+extern int size_iremsndpatch_irx;
+
 extern void *mcman_irx;
 extern int size_mcman_irx;
 

--- a/include/system.h
+++ b/include/system.h
@@ -17,13 +17,7 @@ void sysReset(int modload_mask);
 void sysExecExit();
 void sysPowerOff(void);
 
-#ifdef VMC
-#define MCEMU int size_mcemu_irx, void **mcemu_irx,
-#else
-#define MCEMU
-#endif
-
-void sysLaunchLoaderElf(char *filename, char *mode_str, int size_cdvdman_irx, void **cdvdman_irx, MCEMU int EnablePS2Logo, unsigned int compatflags);
+void sysLaunchLoaderElf(char *filename, char *mode_str, int size_cdvdman_irx, void **cdvdman_irx, int size_mcemu_irx, void **mcemu_irx, int EnablePS2Logo, unsigned int compatflags);
 
 int sysExecElf(char *path);
 int sysLoadModuleBuffer(void *buffer, int size, int argc, char *argv);

--- a/modules/iopcore/patches/iremsndpatch/Makefile
+++ b/modules/iopcore/patches/iremsndpatch/Makefile
@@ -1,0 +1,14 @@
+IOP_BIN  = iremsndpatch.irx
+IOP_OBJS = main.o imports.o
+
+IOP_INCS +=
+IOP_CFLAGS += -Os -Wall -fno-builtin
+IOP_LDFLAGS += -s
+
+all: $(IOP_BIN)
+
+clean:
+	-rm -f $(IOP_OBJS) $(IOP_BIN)
+
+include $(PS2SDK)/Defs.make
+include ../../../Rules.make

--- a/modules/iopcore/patches/iremsndpatch/imports.lst
+++ b/modules/iopcore/patches/iremsndpatch/imports.lst
@@ -1,0 +1,8 @@
+loadcore_IMPORTS_start
+I_GetLoadcoreInternalData
+loadcore_IMPORTS_end
+
+thbase_IMPORTS_start
+I_WakeupThread
+thbase_IMPORTS_end
+

--- a/modules/iopcore/patches/iremsndpatch/irx_imports.h
+++ b/modules/iopcore/patches/iremsndpatch/irx_imports.h
@@ -1,0 +1,23 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+# $Id: irx_imports.h 577 2004-09-14 14:41:46Z pixel $
+# Defines all IRX imports.
+*/
+
+#ifndef IOP_IRX_IMPORTS_H
+#define IOP_IRX_IMPORTS_H
+
+#include "irx.h"
+
+/* Please keep these in alphabetical order!  */
+#include <loadcore.h>
+#include <thbase.h>
+
+#endif /* IOP_IRX_IMPORTS_H */

--- a/modules/iopcore/patches/iremsndpatch/main.c
+++ b/modules/iopcore/patches/iremsndpatch/main.c
@@ -1,0 +1,64 @@
+#include <loadcore.h>
+#include <thbase.h>
+
+#define JAL(addr) (0x0c000000 | (((addr)&0x03ffffff) >> 2))
+#define JMP(addr) (0x08000000 | (0x3ffffff & ((addr) >> 2)))
+
+/* There was a memo dated July 2000, which went along the lines of saying that the atick functions of modmidi and modhsyn should be called,
+   if related sequence data is stopped and removed.
+
+   The explanation was that these modules only process sequence data when their atick functions are called.
+   If data is removed and their atick functions are not called before further calls to the library are made,
+   then the correct operation of the library cannot be guaranteed because the data would be dequeued.
+
+   By logging the commands issued to the RPC server of IREMSND, it can be established that the game eventually calls sndIopSesqCmd_STOPSE.
+   But sndIopSesqCmd_STOPSE does not ever call the modseseq and/or modhsyn atick functions!
+
+   So to correct this, we wake up the tick thread, after the sndIopSesqCmd_STOPSE or sndIopSesqCmd_STOPSEID RPC functions are called.
+   While Sony also documented that this could cause a change in tempo, it is a small price to pay for such a simple fix. */
+
+static int *tickThreadId;
+
+static int postStopSeseqTick(void)
+{
+    WakeupThread(*tickThreadId);
+    return 1;
+}
+
+int _start(int argc, char **argv)
+{
+    lc_internals_t *lc;
+    ModuleInfo_t *m, *prevM;
+    u16 lo16, hi16;
+
+    lc = GetLoadcoreInternalData();
+
+    //Locate the last-registered module.
+    m = lc->image_info;
+    prevM = NULL;
+    while(m->next != NULL)
+    {
+      prevM = m;
+      m = m->next;
+    }
+    m = prevM;
+
+    if (m != NULL)
+    {
+        //Generate pointer to the threadId variable.
+	hi16 = *(vu16*)(m->text_start + 0x00000ac0);
+	lo16 = *(vu16*)(m->text_start + 0x00000ac4);
+	tickThreadId = (int*)(((u32)hi16 << 16) | lo16);
+
+        //Apply patch on module.
+	//sndIopSesqCmd_STOPSE
+        *(vu32*)(m->text_start + 0x00001f4c) = JMP((u32)&postStopSeseqTick);
+	//sndIopSesqCmd_STOPSEID
+        *(vu32*)(m->text_start + 0x00001ff8) = JMP((u32)&postStopSeseqTick);
+
+        return MODULE_RESIDENT_END;
+    }
+
+    return MODULE_NO_RESIDENT_END;
+}
+

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -691,10 +691,10 @@ static void ethLaunchGame(int id, config_set_t *configSet)
 #ifdef VMC
 #define ETH_MCEMU size_mcemu_irx, &smb_mcemu_irx,
 #else
-#define ETH_MCEMU
+#define ETH_MCEMU 0, NULL,
 #endif
 
-    sysLaunchLoaderElf(filename, "ETH_MODE", size_smb_cdvdman_irx, &smb_cdvdman_irx, ETH_MCEMU EnablePS2Logo, compatmask);
+    sysLaunchLoaderElf(filename,  "ETH_MODE", size_smb_cdvdman_irx, &smb_cdvdman_irx, ETH_MCEMU EnablePS2Logo, compatmask);
 }
 
 static config_set_t *ethGetConfig(int id)

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -393,7 +393,7 @@ static void hddLaunchGame(int id, config_set_t *configSet)
 #ifdef VMC
 #define HDD_MCEMU size_mcemu_irx, &hdd_mcemu_irx,
 #else
-#define HDD_MCEMU
+#define HDD_MCEMU 0, NULL,
 #endif
 
     sysLaunchLoaderElf(filename, "HDD_MODE", size_irx, irx, HDD_MCEMU EnablePS2Logo, compatMode);

--- a/src/usbsupport.c
+++ b/src/usbsupport.c
@@ -427,7 +427,7 @@ static void usbLaunchGame(int id, config_set_t *configSet)
 #ifdef VMC
 #define USB_MCEMU size_mcemu_irx, &usb_mcemu_irx,
 #else
-#define USB_MCEMU
+#define USB_MCEMU 0, NULL,
 #endif
 
     sysLaunchLoaderElf(filename, "USB_MODE", irx_size, irx, USB_MCEMU EnablePS2Logo, compatmask);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

This also includes new IOP patch functions.

The game suffered from a sound problem, which sometimes lead to instability.

There was a memo dated July 2000, which went along the lines of saying that the atick functions of modmidi and modhsyn should be called,
if related sequence data is stopepd and removed.

The explanation was that these modules only process sequence data when their atick functions are called.
If data is removed and their atick functions are not called before further callsto the library are made,
then the correct operation of the library cannot be guaranteed because the data would be dequeued.

So to correct this, the tick thread must be woken up after sequence data is dequeued.