### PR TITLE
Replaced locking mechanism for IREMSND patch, corrected pointer computation

### DIFF
--- a/modules/iopcore/patches/iremsndpatch/Makefile
+++ b/modules/iopcore/patches/iremsndpatch/Makefile
@@ -1,5 +1,5 @@
 IOP_BIN  = iremsndpatch.irx
-IOP_OBJS = main.o imports.o
+IOP_OBJS = main.o asm.o imports.o
 
 IOP_INCS +=
 IOP_CFLAGS += -Os -Wall -fno-builtin

--- a/modules/iopcore/patches/iremsndpatch/asm.S
+++ b/modules/iopcore/patches/iremsndpatch/asm.S
@@ -1,0 +1,30 @@
+.set noreorder
+
+.text
+
+.extern _lock
+.extern _unlock
+
+.globl _lock_RpcFunc
+.ent _lock_RpcFunc
+_lock_RpcFunc:
+	#$a0 already preserved in s2
+	move $s1, $a1
+
+	addiu $sp, $sp, -0x18
+	sw $ra, 0x010($sp)
+
+	jal _lock
+	move $s0, $a2
+
+	lw $ra, 0x010($sp)
+
+	#Restore $a0, $a1, $a2
+	move $a0, $s2
+	move $a1, $s1
+	move $a2, $s0
+
+	jr $ra
+	addiu $sp, $sp, 0x18
+.end _lock_RpcFunc
+

--- a/modules/iopcore/patches/iremsndpatch/imports.lst
+++ b/modules/iopcore/patches/iremsndpatch/imports.lst
@@ -6,3 +6,9 @@ thbase_IMPORTS_start
 I_WakeupThread
 thbase_IMPORTS_end
 
+thsemap_IMPORTS_start
+I_CreateSema
+I_SignalSema
+I_WaitSema
+thsemap_IMPORTS_end
+

--- a/modules/iopcore/patches/iremsndpatch/irx_imports.h
+++ b/modules/iopcore/patches/iremsndpatch/irx_imports.h
@@ -19,5 +19,6 @@
 /* Please keep these in alphabetical order!  */
 #include <loadcore.h>
 #include <thbase.h>
+#include <thsemap.h>
 
 #endif /* IOP_IRX_IMPORTS_H */

--- a/modules/iopcore/patches/iremsndpatch/main.c
+++ b/modules/iopcore/patches/iremsndpatch/main.c
@@ -1,5 +1,6 @@
 #include <loadcore.h>
 #include <thbase.h>
+#include <thsemap.h>
 
 #define JAL(addr) (0x0c000000 | (((addr)&0x03ffffff) >> 2))
 #define JMP(addr) (0x08000000 | (0x3ffffff & ((addr) >> 2)))
@@ -15,9 +16,15 @@
    But sndIopSesqCmd_STOPSE does not ever call the modseseq and/or modhsyn atick functions!
 
    So to correct this, we wake up the tick thread, after the sndIopSesqCmd_STOPSE or sndIopSesqCmd_STOPSEID RPC functions are called.
-   While Sony also documented that this could cause a change in tempo, it is a small price to pay for such a simple fix. */
+   While Sony also documented that this could cause a change in tempo, it is a small price to pay for such a simple fix.
+
+   The inter-task protection mechanism was a simple one that involved a flag, which ran under the assumption that the atick thread will always run where the RPC thread does not.
+   However, if the atick thread does get changed to WAIT, then the RPC thread can RUN (which allows the critical section to be violated). */
+
+extern void _lock_RpcFunc(void);
 
 static int *tickThreadId;
+static int lockSema;
 
 static int postStopSeseqTick(void)
 {
@@ -25,11 +32,23 @@ static int postStopSeseqTick(void)
     return 1;
 }
 
+int _lock(void)
+{
+	return WaitSema(lockSema);
+}
+
+int _unlock(void)
+{
+	return SignalSema(lockSema);
+}
+
 int _start(int argc, char **argv)
 {
     lc_internals_t *lc;
     ModuleInfo_t *m, *prevM;
-    u16 lo16, hi16;
+    u16 hi16;
+    s16 lo16;
+    iop_sema_t sema;
 
     lc = GetLoadcoreInternalData();
 
@@ -45,12 +64,30 @@ int _start(int argc, char **argv)
 
     if (m != NULL)
     {
+        sema.initial = 1;
+        sema.max = 1;
+        sema.option = 0;
+        sema.attr = 0;
+
+        lockSema = CreateSema(&sema);
+
         //Generate pointer to the threadId variable.
 	hi16 = *(vu16*)(m->text_start + 0x00000ac0);
-	lo16 = *(vu16*)(m->text_start + 0x00000ac4);
-	tickThreadId = (int*)(((u32)hi16 << 16) | lo16);
+	lo16 = *(volatile s16*)(m->text_start + 0x00000ac4);
+	tickThreadId = (int*)(((u32)hi16 << 16) + lo16);
 
         //Apply patch on module.
+        //sndIopAtick
+	*(vu32*)(m->text_start + 0x00000418) = JAL((u32)&_lock);
+	*(vu32*)(m->text_start + 0x000018f4) = JMP((u32)&_unlock);
+
+        //ndIopRpcFunc
+	*(vu32*)(m->text_start + 0x00000d58) = JAL((u32)&_lock_RpcFunc);
+	*(vu32*)(m->text_start + 0x00000d64) = 0x00000000; //nop
+	*(vu32*)(m->text_start + 0x00000d80) = 0xac233d24; //sw v1, $3d24(at) - Replace instruction at 0xd64.
+	*(vu32*)(m->text_start + 0x00000f54) = JAL((u32)&_unlock);
+	*(vu32*)(m->text_start + 0x00000f58) = 0x00000000; //nop
+
 	//sndIopSesqCmd_STOPSE
         *(vu32*)(m->text_start + 0x00001f4c) = JMP((u32)&postStopSeseqTick);
 	//sndIopSesqCmd_STOPSEID


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

The locking mechanism within the IREMSND module involves using a flag. It might work well if the atick thread does not ever sleep (allowing the RPC thread to enter the critical section), but...