### PR TITLE
Fixed bug introduced in 51c82be: wrong pointer used for VMC.

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -421,7 +421,7 @@ static unsigned int sendIrxKernelRAM(const char *startup, const char *mode_str, 
 #ifdef VMC
     if (modules & CORE_IRX_VMC) {
         irxptr_tab[modcount].info = size_mcemu_irx | SET_OPL_MOD_ID(OPL_MODULE_ID_MCEMU);
-        irxptr_tab[modcount++].ptr = (void *)&mcemu_irx;
+        irxptr_tab[modcount++].ptr = (void *)mcemu_irx;
     }
 #endif
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Fixed bug introduced in 51c82be: wrong pointer used for VMC.