### PR TITLE
Small improvements and fixes

### DIFF
--- a/src/renderman.c
+++ b/src/renderman.c
@@ -100,7 +100,9 @@ void rmUnloadTexture(GSTEXTURE *txt)
 
 void rmStartFrame(void)
 {
+#ifndef HIRES
     gsKit_clear(gsGlobal, gColBlack);
+#endif
     order = 0;
 }
 

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -38,6 +38,8 @@ static void cacheLoadImage(void *data)
         free(texture->Mem);
         texture->Mem = NULL;
         texture->ClutPSM = 0;
+        if (texture->Clut != NULL)
+            free(texture->Clut);
         texture->Clut = NULL;
         texture->Vram = 0;
         texture->VramClut = 0;
@@ -68,12 +70,14 @@ static void cacheClearItem(cache_entry_t *item, int freeTxt)
     if (freeTxt && item->texture.Mem) {
         rmUnloadTexture(&item->texture);
         free(item->texture.Mem);
+        if (item->texture.Clut)
+            free(item->texture.Clut);
     }
 
     memset(item, 0, sizeof(cache_entry_t));
     item->texture.Mem = NULL;
     item->texture.Vram = 0;
-    item->texture.Clut = 0;
+    item->texture.Clut = NULL;
     item->texture.VramClut = 0;
     item->qr = NULL;
     item->lastUsed = -1;

--- a/src/textures.c
+++ b/src/textures.c
@@ -37,8 +37,7 @@ extern void *logo_png;
 extern void *bg_overlay_png;
 
 // Not related to screen size, just to limit at some point
-static int maxWidth = 720;
-static int maxHeight = 512;
+static int maxSize = 720*512*4;
 
 typedef struct
 {
@@ -96,6 +95,17 @@ static void texUpdate(GSTEXTURE *texture, int width, int height)
 {
     texture->Width = width;
     texture->Height = height;
+}
+
+static int texSizeValidate(int width, int height, short psm)
+{
+    if (width > 1024 || height > 1024)
+        return -1;
+
+    if (gsKit_texture_size(width, height, psm) > maxSize)
+        return -1;
+
+    return 0;
 }
 
 void texPrepare(GSTEXTURE *texture, short psm)
@@ -263,7 +273,7 @@ int texPngLoad(GSTEXTURE *texture, const char *path, int texId, short psm)
     png_uint_32 pngWidth, pngHeight;
     int bitDepth, colorType, interlaceType;
     png_get_IHDR(pngPtr, infoPtr, &pngWidth, &pngHeight, &bitDepth, &colorType, &interlaceType, NULL, NULL);
-    if (pngWidth > maxWidth || pngHeight > maxHeight)
+    if (texSizeValidate(pngWidth, pngHeight, psm) < 0)
         return texPngEnd(pngPtr, infoPtr, file, ERR_BAD_DIMENSION);
     texUpdate(texture, pngWidth, pngHeight);
 
@@ -322,7 +332,7 @@ int texJpgLoad(GSTEXTURE *texture, const char *path, int texId, short psm)
     if (file) {
         jpg = jpgOpenFILE(file, JPG_NORMAL);
         if (jpg != NULL) {
-            if (jpg->width > maxWidth || jpg->height > maxHeight)
+            if (texSizeValidate(jpg->width, jpg->height, psm) < 0)
                 return ERR_BAD_DIMENSION;
 
             size_t size = gsKit_texture_size_ee(jpg->width, jpg->height, psm);
@@ -357,7 +367,6 @@ extern GSGLOBAL *gsGlobal;
 int texBmpLoad(GSTEXTURE *texture, const char *path, int texId, short psm)
 {
     texPrepare(texture, GS_PSM_CT24);
-    int result = ERR_BAD_FILE;
     char filePath[256];
 
     if (texId != -1)
@@ -366,8 +375,23 @@ int texBmpLoad(GSTEXTURE *texture, const char *path, int texId, short psm)
         snprintf(filePath, sizeof(filePath), "%s.bmp", path);
 
     texture->Delayed = 1;
-    result = gsKit_texture_bmp(gsGlobal, texture, filePath);
+    if (gsKit_texture_bmp(gsGlobal, texture, filePath) < 0)
+        return ERR_BAD_FILE;
+
     texture->Filter = GS_FILTER_LINEAR;
 
-    return result;
+    if (texSizeValidate(texture->Width, texture->Height, texture->PSM) < 0) {
+        if (texture->Mem) {
+            free(texture->Mem);
+            texture->Mem = NULL;
+        }
+        if (texture->Clut) {
+            free(texture->Clut);
+            texture->Clut = NULL;
+        }
+
+        return ERR_BAD_DIMENSION;
+    }
+
+    return 0;
 }

--- a/src/themes.c
+++ b/src/themes.c
@@ -721,14 +721,14 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
             if (itemsList->decoratorImage) {
                 GSTEXTURE *itemIconTex = getGameImageTexture(itemsList->decoratorImage->cache, menu->item->userdata, &ps->item);
                 if (itemIconTex && itemIconTex->Mem)
-                    rmDrawPixmap(itemIconTex, posX, posY, ALIGN_NONE, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol);
+                    rmDrawPixmap(itemIconTex, posX, posY, elem->aligned, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol);
                 else {
                     if (itemsList->decoratorImage->defaultTexture)
-                        rmDrawPixmap(&itemsList->decoratorImage->defaultTexture->source, posX, posY, ALIGN_NONE, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol);
+                        rmDrawPixmap(&itemsList->decoratorImage->defaultTexture->source, posX, posY, elem->aligned, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol);
                 }
-                fntRenderString(elem->font, posX + DECORATOR_SIZE, posY, ALIGN_NONE, elem->width, elem->height, submenuItemGetText(&ps->item), color);
+                fntRenderString(elem->font, elem->posX + DECORATOR_SIZE, posY, elem->aligned, elem->width, elem->height, submenuItemGetText(&ps->item), color);
             } else
-                fntRenderString(elem->font, posX, posY, ALIGN_NONE, elem->width, elem->height, submenuItemGetText(&ps->item), color);
+                fntRenderString(elem->font, elem->posX, posY, elem->aligned, elem->width, elem->height, submenuItemGetText(&ps->item), color);
 
             posY += MENU_ITEM_HEIGHT;
             ps = ps->next;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [x] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

In short:
- Fixed memory leak when using 8bit images (the CLUT was not freed)
- Allow higher resolution textures when using lower bit depths -> 1024x1024 8bit is now possible
- Small speed improvement for HIRES mode -> clearing the buffer is not needed
- Allow itemsList to be centered, thanks to Krah from ps2-home.

There have also been improvement to gsKit that affect OPL, so please also update gsKit.