### PR TITLE
Virtuaquest patch

### DIFF
--- a/include/iosupport.h
+++ b/include/iosupport.h
@@ -59,13 +59,12 @@ enum ERROR_CODE {
 #define COMPAT_MODE_4 0x08 // Skip Videos: Apply 0 (zero) file size to PSS videos and also skip Bink (.BIK) ones
 #define COMPAT_MODE_5 0x10 // Emulate DVD-DL
 #define COMPAT_MODE_6 0x20 // Disable IGR
-#define COMPAT_MODE_7 0x40 // High Module Storage
+#define COMPAT_MODE_7 0x40 // Unused
 #define COMPAT_MODE_8 0x80 // Hide DEV9 module
 
 #define COMPAT_MODE_COUNT 8
 
 #define OPL_MOD_STORAGE 0x00097000    //(default) Address of the module storage region
-#define OPL_MOD_STORAGE_HI 0x01C00000 //Alternate address of the module storage region
 
 // minimal inactive frames for cover display, can be pretty low since it means no button is pressed :)
 #define MENU_MIN_INACTIVE_FRAMES 8

--- a/src/lang.c
+++ b/src/lang.c
@@ -125,7 +125,7 @@ static char *internalEnglish[LANG_STR_COUNT] = {
     "Skip Videos",
     "Emulate DVD-DL",
     "Disable IGR",
-    "High module storage",
+    "Unused",
     "Hide DEV9 module",
     "Changing the size will reformat the VMC",
     "Create",

--- a/src/system.c
+++ b/src/system.c
@@ -397,7 +397,7 @@ static void *GetModStorageLocation(const char *startup, unsigned compatFlags)
         }
     }
 
-    return((void *)((compatFlags & COMPAT_MODE_7) ? OPL_MOD_STORAGE_HI : OPL_MOD_STORAGE));
+    return((void *)OPL_MOD_STORAGE);
 }
 
 static unsigned int sendIrxKernelRAM(const char *startup, const char *mode_str, unsigned int modules, void *ModuleStorage, int size_cdvdman_irx, void **cdvdman_irx, int size_mcemu_irx, void **mcemu_irx)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

- The game loads at a very low address of 0x000A0000. OPL was reworked a long time ago, to stay below that address. However, its module storage cannot fit below there.
- The module storage has hence been moved to the end of memory.
- However, the stack can, and will overwrite the module storage. For now, the module storage overlaps with the main thread's stack.
- This will mean that further IOP reboots will not work, but I don't think this game will reboot the IOP.
- I could not carve out dedicated space for the module storage because reducing the amount of memory for the game further results in a NULL getting returned by the allocation function, which gets passed to memset().


There are 2 parts to this fix:
- Fixing the stack's location, as specified as an argument to SetupThread. This is so that the EE kernel will not allocate 4KB for itself, for debugging purposes. This should keep the stack pointer as far away from the actual modules within the module storage, until the IOP is reboot and the game actually does something.
- Manipulate a pointer that the game uses as the "end of memory". This pointer includes the stack region, which the game will subtract the size of the stack from (0x18000). For the fix, this pointer is lowered, so that the modules can be stored after it.
