### PR TITLE
Fix for renaming on USB disks

### DIFF
--- a/src/usbsupport.c
+++ b/src/usbsupport.c
@@ -193,53 +193,7 @@ static void usbDeleteGame(int id)
 
 static void usbRenameGame(int id, char *newName)
 {
-    char oldpath[256], newpath[256];
-    base_game_info_t *game = &usbGames[id];
-    int fd;
-
-    if (game->format != GAME_FORMAT_USBLD) {
-        if (game->format == GAME_FORMAT_OLD_ISO) {
-            if (game->media == 0x12) {
-                snprintf(oldpath, sizeof(oldpath), "%sCD/%s.%s%s", usbPrefix, game->startup, game->name, game->extension);
-                snprintf(newpath, sizeof(newpath), "%sCD/%s.%s%s", usbPrefix, game->startup, newName, game->extension);
-            } else {
-                snprintf(oldpath, sizeof(oldpath), "%sDVD/%s.%s%s", usbPrefix, game->startup, game->name, game->extension);
-                snprintf(newpath, sizeof(newpath), "%sDVD/%s.%s%s", usbPrefix, game->startup, newName, game->extension);
-            }
-        } else {
-            if (game->media == 0x12) {
-                snprintf(oldpath, sizeof(oldpath), "%sCD/%s%s", usbPrefix, game->name, game->extension);
-                snprintf(newpath, sizeof(newpath), "%sCD/%s%s", usbPrefix, newName, game->extension);
-            } else {
-                snprintf(oldpath, sizeof(oldpath), "%sDVD/%s%s", usbPrefix, game->name, game->extension);
-                snprintf(newpath, sizeof(newpath), "%sDVD/%s%s", usbPrefix, newName, game->extension);
-            }
-        }
-
-        if ((fd = fileXioOpen(oldpath, O_RDONLY)) >= 0) {
-            fileXioIoctl(fd, USBMASS_IOCTL_RENAME, newpath);
-            fileXioClose(fd);
-        }
-    } else {
-        const char *pathStr = "%sul.%08X.%s.%02x";
-        unsigned int oldcrc = USBA_crc32(game->name);
-        unsigned int newcrc = USBA_crc32(newName);
-        int i;
-
-        for (i = 0; i < game->parts; i++) {
-            snprintf(oldpath, sizeof(oldpath), pathStr, usbPrefix, oldcrc, game->startup, i);
-            snprintf(newpath, sizeof(newpath), pathStr, usbPrefix, newcrc, game->startup, i);
-            if ((fd = fileXioOpen(oldpath, O_RDONLY)) >= 0) {
-                fileXioIoctl(fd, USBMASS_IOCTL_RENAME, newpath);
-                fileXioClose(fd);
-            }
-        }
-
-        memset(game->name, 0, UL_GAME_NAME_MAX + 1);
-        memcpy(game->name, newName, UL_GAME_NAME_MAX);
-        sbRebuildULCfg(&usbGames, usbPrefix, usbGameCount, -1);
-    }
-
+    sbRename(&usbGames, usbPrefix, "/", usbGameCount, id, newName);
     usbULSizePrev = -2;
 }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [X] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Renaming games on USB devices has not worked in quite a while. I think it was because of a mistake I made a long time ago, whereby the semantics of the rename function (then just an IOCTL code) had some ambiguity and some software still followed the old design.

With the recent update to the PS2SDK that also gave USBHDFSD a rename() function, it is now easier to rename things on USB disks. I know that OPL did this at some point, but it was changed to fit the standard SDK USBHDFSD module.

So now usbRename() will once again use sbRename(), will be used with the standard rename() function. Requires updated USBHDFSD module from PS2SDK.