### PR TITLE
IGR + VMC Update

### DIFF
--- a/ee_core/Makefile
+++ b/ee_core/Makefile
@@ -18,7 +18,7 @@ IGSCORE_EE_OBJS = igs_api.o
 CHEATCORE_EE_OBJS = cheat_engine.o cheat_api.o
 
 EE_OBJS = main.o syshook.o iopmgr.o modmgr.o util.o patches.o patches_asm.o \
-	  padhook.o spu.o tlb.o asm.o crt0.o $(GSMCORE_EE_OBJS) $(CHEATCORE_EE_OBJS)
+	  padhook.o spu.o cd_igr_rpc.o tlb.o asm.o crt0.o $(GSMCORE_EE_OBJS) $(CHEATCORE_EE_OBJS)
 MAPFILE = ee_core.map
 
 EE_INCS := -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -Iinclude -I.

--- a/ee_core/include/asm.h
+++ b/ee_core/include/asm.h
@@ -18,7 +18,7 @@ u32 Hook_SifSetDma(SifDmaTransfer_t *sdd, s32 len);
 int Hook_SifSetReg(u32 register_num, int register_value);
 int Hook_ExecPS2(void *entry, void *gp, int num_args, char *args[]);
 int Hook_CreateThread(ee_thread_t *thread_param);
-
+void Hook_Exit(s32 exit_code);
 void CleanExecPS2(void *epc, void *gp, int argc, char **argv);
 
 #endif /* ASM */

--- a/ee_core/include/cd_igr_rpc.h
+++ b/ee_core/include/cd_igr_rpc.h
@@ -1,0 +1,2 @@
+int oplIGRShutdown(void);
+

--- a/ee_core/include/padhook.h
+++ b/ee_core/include/padhook.h
@@ -20,7 +20,7 @@
 #define PADOPEN_CHECK 1
 
 int Install_PadOpen_Hook(u32 mem_start, u32 mem_end, int mode);
-
+void IGR_Exit(s32 exit_code);
 
 // DEV9 Registers
 #define DEV9_R_1460 ((volatile u16 *)0xBF801460)

--- a/ee_core/include/syshook.h
+++ b/ee_core/include/syshook.h
@@ -19,7 +19,9 @@ u32 (*Old_SifSetDma)(SifDmaTransfer_t *sdd, s32 len);
 int (*Old_SifSetReg)(u32 register_num, int register_value);
 int (*Old_ExecPS2)(void *entry, void *gp, int num_args, char *args[]);
 int (*Old_CreateThread)(ee_thread_t *thread_param);
+void (*Old_Exit)(s32 exit_code);
 
 void sysLoadElf(char *filename, int argc, char **argv);
+void sysExit(s32 exit_code);
 
 #endif /* SYSHOOK */

--- a/ee_core/src/asm.S
+++ b/ee_core/src/asm.S
@@ -48,6 +48,7 @@
 	.extern disable_padOpen_hook
 	.extern Old_ExecPS2
 	.extern Old_CreateThread
+	.extern sysExit
 
 	/* loader.h */
 	.extern g_compat_mask
@@ -61,6 +62,7 @@
 	.globl	Hook_SifSetReg
 	.globl	Hook_ExecPS2
 	.globl	Hook_CreateThread
+	.globl	Hook_Exit
 	.globl CleanExecPS2
 
 /*
@@ -343,6 +345,14 @@ Hook_CreateThread:
 	nop
 
 	.end	Hook_CreateThread
+
+	.ent	Hook_Exit
+Hook_Exit:
+	la	$v1, sysExit
+	jr 	$ra
+	sw 	$v1, 0x0008($sp)
+
+	.end	Hook_Exit
 
 .ent CleanExecPS2
 CleanExecPS2:

--- a/ee_core/src/cd_igr_rpc.c
+++ b/ee_core/src/cd_igr_rpc.c
@@ -1,0 +1,25 @@
+#include <tamtypes.h>
+#include <ps2lib_err.h>
+#include <kernel.h>
+#include <sifrpc.h>
+
+#include "cd_igr_rpc.h"
+
+//This uses the libcdvd power-off RPC, which only has 1 official function implemented.
+int oplIGRShutdown(void)
+{
+    SifRpcClientData_t _igr_cd;
+    int r;
+
+    while ((r = SifBindRpc(&_igr_cd, 0x80000596, 0)) >= 0 && (!_igr_cd.server))
+        nopdelay();
+
+    if (r < 0)
+        return -E_SIF_RPC_BIND;
+
+    if (SifCallRpc(&_igr_cd, 0x0596, 0, NULL, 0, NULL, 0, NULL, NULL) < 0)
+        return -E_SIF_RPC_CALL;
+
+    return 0;
+}
+

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -265,16 +265,21 @@ static void IGR_Thread(void *arg)
         // Exit services
         SifExitRpc();
 
-        // Execute home loader
-        if (ExitPath[0] != '\0')
-            ExecPS2(t_loadElf, &_gp, 0, NULL);
-
-        // Return to PS2 Browser
-        Exit(0);
+        IGR_Exit(0);
     }
 
     // If combo is R3 + L3 or Reset failed, Poweroff PS2
     PowerOff_PS2();
+}
+
+void IGR_Exit(s32 exit_code)
+{
+    // Execute home loader
+    if (ExitPath[0] != '\0')
+        ExecPS2(t_loadElf, &_gp, 0, NULL);
+
+    // Return to PS2 Browser
+    Exit(exit_code);
 }
 
 // IGR VBLANK_END interrupt handler install to monitor combo trick in pad data aera

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -31,6 +31,7 @@
 #include "igs_api.h"
 #endif
 #include "cheat_api.h"
+#include "cd_igr_rpc.h"
 
 /* scePadPortOpen & scePad2CreateSocket prototypes */
 static int (*scePadPortOpen)(int port, int slot, void *addr);
@@ -189,6 +190,11 @@ static void IGR_Thread(void *arg)
 
         // Reset SPU
         ResetSPU();
+
+        if (!DisableDebug)
+            GS_BGCOLOUR = 0xFF8000; // Blue sky
+
+        oplIGRShutdown();
 
         if (!DisableDebug)
             GS_BGCOLOUR = 0x0000FF; // Red

--- a/ee_core/src/syshook.c
+++ b/ee_core/src/syshook.c
@@ -161,6 +161,12 @@ static void unpatchInitUserMemory(void)
     p[4] = 0x2000;
 }
 
+void sysExit(s32 exit_code)
+{
+    Remove_Kernel_Hooks();
+    IGR_Exit(exit_code);
+}
+
 /*----------------------------------------------------------------------------------------*/
 /* Replace SifSetDma, SifSetReg, LoadExecPS2 syscalls in kernel. (Game Loader)            */
 /* Replace CreateThread and ExecPS2 syscalls in kernel. (In Game Reset)                   */
@@ -181,16 +187,20 @@ void Install_Kernel_Hooks(void)
         Old_ExecPS2 = GetSyscallHandler(__NR__ExecPS2);
         SetSyscall(__NR__ExecPS2, &Hook_ExecPS2);
     }
+
+    Old_Exit = GetSyscallHandler(__NR__Exit);
+    SetSyscall(__NR__Exit, &Hook_Exit);
 }
 
-/*----------------------------------------------------------------------------------------*/
-/* Restore original SifSetDma, SifSetReg, LoadExecPS2 syscalls in kernel. (Game loader)   */
-/* Restore original CreateThread and ExecPS2 syscalls in kernel. (In Game Reset)          */
-/*----------------------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------------------------------*/
+/* Restore original SifSetDma, SifSetReg, LoadExecPS2, Exit syscalls in kernel. (Game loader)   */
+/* Restore original CreateThread and ExecPS2 syscalls in kernel. (In Game Reset)                */
+/*----------------------------------------------------------------------------------------------*/
 void Remove_Kernel_Hooks(void)
 {
     SetSyscall(__NR_SifSetDma, Old_SifSetDma);
     SetSyscall(__NR_SifSetReg, Old_SifSetReg);
+    SetSyscall(__NR__Exit, Old_Exit);
 
     DI();
     ee_kmode_enter();

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -52,6 +52,7 @@ int hddCheck(void);
 u32 hddGetTotalSectors(void);
 int hddIs48bit(void);
 int hddSetTransferMode(int type, int mode);
+int hddSetWriteCache(int enable);
 int hddSetIdleTimeout(int timeout);
 int hddGetHDLGamelist(hdl_games_list_t *game_list);
 void hddFreeHDLGamelist(hdl_games_list_t *game_list);

--- a/modules/hdd/common/opl-hdd-ioctl.h
+++ b/modules/hdd/common/opl-hdd-ioctl.h
@@ -4,6 +4,7 @@
 // Commands and structures for XATAD.IRX
 #define ATA_DEVCTL_IS_48BIT 0x6840
 #define ATA_DEVCTL_SET_TRANSFER_MODE 0x6841
+#define ATA_DEVCTL_SET_WRITE_CACHE 0x6842
 
 #define ATA_XFER_MODE_MDMA 0x20
 #define ATA_XFER_MODE_UDMA 0x40
@@ -15,5 +16,10 @@ typedef struct
     int type;
     int mode;
 } hddAtaSetMode_t;
+
+typedef struct
+{
+    int enable;
+} hddAtaSetWriteCache_t;
 
 #endif

--- a/modules/hdd/xhdd/hdpro.c
+++ b/modules/hdd/xhdd/hdpro.c
@@ -9,3 +9,9 @@ int hdproata_device_set_transfer_mode(int device, int type, int mode)
 {
     return 0;
 }
+
+/* Set features - enable/disable write cache.  */
+int hdproata_device_set_write_cache(int device, int enable)
+{   //As the start and finish functions are not exported, disable the write cache within the in-game ATAD instead.
+    return 0;
+}

--- a/modules/hdd/xhdd/xatad.c
+++ b/modules/hdd/xhdd/xatad.c
@@ -76,3 +76,20 @@ int ata_device_set_transfer_mode(int device, int type, int mode)
 
     return 0;
 }
+
+/* Set features - enable/disable write cache.  */
+int ata_device_set_write_cache(int device, int enable)
+{
+	int res;
+
+	res = ata_io_start(NULL, 1, enable ? 0x02 : 0x82, 0, 0, 0, 0, (device << 4) & 0xffff, ATA_C_SET_FEATURES);
+	if (res)
+		return res;
+
+	res = ata_io_finish();
+	if (res)
+		return res;
+
+	return 0;
+}
+

--- a/modules/hdd/xhdd/xhdd.c
+++ b/modules/hdd/xhdd/xhdd.c
@@ -9,7 +9,7 @@
 #include "xhdd.h"
 
 #define MODNAME "xhdd"
-IRX_ID(MODNAME, 1, 1);
+IRX_ID(MODNAME, 1, 2);
 
 static int isHDPro;
 
@@ -38,6 +38,11 @@ static int xhddDevctl(iop_file_t *fd, const char *name, int cmd, void *arg, unsi
                 return ata_device_set_transfer_mode(fd->unit, ((hddAtaSetMode_t *)arg)->type, ((hddAtaSetMode_t *)arg)->mode);
             else
                 return hdproata_device_set_transfer_mode(fd->unit, ((hddAtaSetMode_t *)arg)->type, ((hddAtaSetMode_t *)arg)->mode);
+        case ATA_DEVCTL_SET_WRITE_CACHE:
+            if (!isHDPro)
+                return ata_device_set_write_cache(fd->unit, ((hddAtaSetWriteCache_t *)arg)->enable);
+            else
+                return hdproata_device_set_write_cache(fd->unit,  ((hddAtaSetWriteCache_t *)arg)->enable);
         default:
             return -EINVAL;
     }

--- a/modules/hdd/xhdd/xhdd.h
+++ b/modules/hdd/xhdd/xhdd.h
@@ -1,2 +1,4 @@
 int ata_device_set_transfer_mode(int device, int type, int mode);
+int ata_device_set_write_cache(int device, int enable);
 int hdproata_device_set_transfer_mode(int device, int type, int mode);
+int hdproata_device_set_write_cache(int device, int enable);

--- a/modules/iopcore/cdvdfsv/cdvdfsv.c
+++ b/modules/iopcore/cdvdfsv/cdvdfsv.c
@@ -567,6 +567,9 @@ static void *cbrpc_S596(int fno, void *buf, int size)
         //Lock all accesses.
         value = -1;
         sceCdSC(CDSC_IO_SEMA, &value);
+        //Shutdown OPL
+        value = 0;
+        sceCdSC(CDSC_OPL_SHUTDOWN, &value);
     }
 
     *(int *)buf = 1;

--- a/modules/iopcore/cdvdfsv/cdvdfsv.c
+++ b/modules/iopcore/cdvdfsv/cdvdfsv.c
@@ -555,12 +555,18 @@ static void *cbrpc_cdvdNcmds(int fno, void *buf, int size)
 //--------------------------------------------------------------
 static void *cbrpc_S596(int fno, void *buf, int size)
 {
-    int cdvdman_intr_ef, dummy;
+    int cdvdman_intr_ef, dummy, value;
 
     if (fno == 1) {
         cdvdman_intr_ef = sceCdSC(CDSC_GET_INTRFLAG, &dummy);
         ClearEventFlag(cdvdman_intr_ef, ~4);
         WaitEventFlag(cdvdman_intr_ef, 4, WEF_AND, NULL);
+    }
+    else if (fno == 0x0596) {
+        //Terminate operations.
+        //Lock all accesses.
+        value = -1;
+        sceCdSC(CDSC_IO_SEMA, &value);
     }
 
     *(int *)buf = 1;

--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -227,6 +227,14 @@ static unsigned int ReadPos = 0; /* Current buffer offset in 2048-byte sectors. 
 static int POFFThreadID;
 #endif
 
+typedef void (*oplShutdownCb_t)(void);
+static oplShutdownCb_t vmcShutdownCb = NULL;
+
+void oplRegisterShutdownCallback(oplShutdownCb_t cb)
+{
+    vmcShutdownCb = cb;
+}
+
 //--------------------------------------------------------------
 static void fs_init(void)
 {
@@ -824,6 +832,12 @@ int sceCdSC(int code, int *param)
             break;
         case CDSC_SET_ERROR:
             result = cdvdman_stat.err = *param;
+            break;
+        case CDSC_OPL_SHUTDOWN:
+            if(vmcShutdownCb != NULL)
+                vmcShutdownCb();
+            DeviceDeinit();
+            result = 1;
             break;
         default:
             result = 1; // dummy result

--- a/modules/iopcore/cdvdman/device-hdd.c
+++ b/modules/iopcore/cdvdman/device-hdd.c
@@ -93,6 +93,10 @@ void DeviceFSInit(void)
 {
 }
 
+void DeviceUnmount(void)
+{
+}
+
 int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
 {
     u32 offset = 0;

--- a/modules/iopcore/cdvdman/device-smb.c
+++ b/modules/iopcore/cdvdman/device-smb.c
@@ -77,7 +77,6 @@ void DeviceInit(void)
 
 void DeviceDeinit(void)
 {
-    smb_Disconnect();
 }
 
 void DeviceFSInit(void)
@@ -111,6 +110,12 @@ void DeviceFSInit(void)
             smb_OpenAndX(tmp_str, &cdvdman_settings.FIDs[i], 0);
         }
     }
+}
+
+void DeviceUnmount(void)
+{
+    smb_CloseAll();
+    smb_Disconnect();
 }
 
 int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)

--- a/modules/iopcore/cdvdman/device-usb.c
+++ b/modules/iopcore/cdvdman/device-usb.c
@@ -80,6 +80,10 @@ void DeviceFSInit(void)
         DelayThread(200);
 }
 
+void DeviceUnmount(void)
+{
+}
+
 int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
 {
     register u32 r, sectors_to_read, lbound, ubound, nlsn, offslsn;

--- a/modules/iopcore/cdvdman/device.h
+++ b/modules/iopcore/cdvdman/device.h
@@ -1,6 +1,7 @@
-void DeviceInit(void);   //Called in _start()
-void DeviceDeinit(void); //Called in _exit()
+void DeviceInit(void);     //Called in _start()
+void DeviceDeinit(void);   //Called in _exit(). Interrupts are disabled.
 
-void DeviceFSInit(void); //Called when the filesystem layer is initialized
+void DeviceFSInit(void);   //Called when the filesystem layer is initialized
+void DeviceUnmount(void);  //Called when OPL is shutting down.
 
 int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors);

--- a/modules/iopcore/cdvdman/exports.tab
+++ b/modules/iopcore/cdvdman/exports.tab
@@ -192,12 +192,13 @@ DECLARE_EXPORT_TABLE(smsutils, 1, 1)
 END_EXPORT_TABLE
 
 // opl io utils export table
-DECLARE_EXPORT_TABLE(oplutils, 1, 1)
+DECLARE_EXPORT_TABLE(oplutils, 1, 2)
 	DECLARE_EXPORT(_retonly)
 	DECLARE_EXPORT(_retonly)
 	DECLARE_EXPORT(_retonly)
 	DECLARE_EXPORT(_retonly)
 	DECLARE_EXPORT(getModInfo)
+	DECLARE_EXPORT(oplRegisterShutdownCallback)
 #ifdef USB_DRIVER
 	DECLARE_EXPORT(mass_stor_readSector)
 	DECLARE_EXPORT(mass_stor_writeSector)
@@ -209,6 +210,7 @@ DECLARE_EXPORT_TABLE(oplutils, 1, 1)
 	DECLARE_EXPORT(smb_OpenAndX)
 	DECLARE_EXPORT(smb_ReadFile)
 	DECLARE_EXPORT(smb_WriteFile)
+	DECLARE_EXPORT(smb_Close)
 #endif
 END_EXPORT_TABLE
 

--- a/modules/iopcore/cdvdman/smb.h
+++ b/modules/iopcore/cdvdman/smb.h
@@ -280,9 +280,11 @@ int smb_SessionSetupTreeConnect(char *share_name);
 int smb_SessionSetupAndX(u32 capabilities); // process a Session Setup message, for NT LM 0.12 dialect, Non Extended Security negociated
 int smb_TreeConnectAndX(char *ShareName);
 int smb_OpenAndX(char *filename, u16 *FID, int Write); // process a Open AndX message
+int smb_Close(int FID);
 int smb_ReadFile(u16 FID, u32 offsetlow, u32 offsethigh, void *readbuf, u16 nbytes);
 int smb_WriteFile(u16 FID, u32 offsetlow, u32 offsethigh, void *writebuf, u16 nbytes);
 int smb_ReadCD(unsigned int lsn, unsigned int nsectors, void *buf, int part_num);
+void smb_CloseAll(void);
 int smb_Disconnect(void);
 
 #define MAX_SMB_SECTORS 2

--- a/modules/iopcore/common/cdvdman.h
+++ b/modules/iopcore/common/cdvdman.h
@@ -167,6 +167,7 @@ enum CDIOC_CODE {
 #define CDSC_IO_SEMA 0xFFFFFFF6          //Wait (param != 0) or signal (param == 0) high-level I/O semaphore.
 #define CDSC_GET_VERSION 0xFFFFFFF7      //Get CDVDMAN version.
 #define CDSC_SET_ERROR 0xFFFFFFFE        //Used by CDVDFSV and CDVDSTM to set the error code (Typically READCF*).
+#define CDSC_OPL_SHUTDOWN 0x00000001     //Shutdown OPL
 
 // exported functions prototypes
 #define cdvdman_IMPORTS_start DECLARE_IMPORT_TABLE(cdvdman, 1, 1)

--- a/modules/mcemu/device-hdd.c
+++ b/modules/mcemu/device-hdd.c
@@ -47,3 +47,8 @@ int DeviceReadPage(int mc_num, void *buf, u32 page_num)
 
     return (ata_device_sector_io(0, buf, lba, 1, ATA_DIR_READ) == 0 ? 1 : 0);
 }
+
+void DeviceShutdown(void)
+{
+}
+

--- a/modules/mcemu/device-smb.c
+++ b/modules/mcemu/device-smb.c
@@ -31,3 +31,19 @@ int DeviceReadPage(int mc_num, void *buf, u32 page_num)
 
     return (smb_ReadFile(vmcSpec[mc_num].fid, offset, 0, buf, vmcSpec[mc_num].cspec.PageSize) != 0 ? 1 : 0);
 }
+
+void DeviceShutdown(void)
+{
+    int i;
+
+    for (i = 0; i < 2; i++)
+    {
+        if (vmcSpec[i].active)
+        {
+            smb_Close(vmcSpec[i].fid);
+            vmcSpec[i].fid = 0xFFFF;
+            vmcSpec[i].active = 0;
+        }
+    }
+}
+

--- a/modules/mcemu/device-usb.c
+++ b/modules/mcemu/device-usb.c
@@ -30,3 +30,8 @@ int DeviceReadPage(int mc_num, void *buf, u32 page_num)
 
     return 1;
 }
+
+void DeviceShutdown(void)
+{
+}
+

--- a/modules/mcemu/device.h
+++ b/modules/mcemu/device.h
@@ -1,2 +1,4 @@
 int DeviceWritePage(int mc_num, void *buf, u32 page_num);
 int DeviceReadPage(int mc_num, void *buf, u32 page_num);
+void DeviceShutdown(void);
+

--- a/modules/mcemu/imports.lst
+++ b/modules/mcemu/imports.lst
@@ -18,6 +18,7 @@ loadcore_IMPORTS_end
 
 oplutils_IMPORTS_start
 I_getModInfo
+I_oplRegisterShutdownCallback
 #ifdef USB_DRIVER
 I_mass_stor_readSector
 I_mass_stor_writeSector
@@ -29,6 +30,7 @@ I_ata_device_sector_io
 I_smb_OpenAndX
 I_smb_ReadFile
 I_smb_WriteFile
+I_smb_Close
 #endif
 oplutils_IMPORTS_end
 

--- a/modules/mcemu/mcemu.c
+++ b/modules/mcemu/mcemu.c
@@ -18,12 +18,22 @@ void (*pademu_hookSio2man)(Sio2Packet *sd, Sio2McProc sio2proc) = no_pademu;
 #endif
 
 //---------------------------------------------------------------------------
+// Shutdown callback
+//---------------------------------------------------------------------------
+static void mcemuShutdown(void)
+{   //If necessary, implement some locking mechanism to prevent further requests from being made.
+    DeviceShutdown();
+}
+
+//---------------------------------------------------------------------------
 // Entry point
 //---------------------------------------------------------------------------
 int _start(int argc, char *argv[])
 {
     int thid;
     iop_thread_t param;
+
+    oplRegisterShutdownCallback(&mcemuShutdown);
 
     param.attr = TH_C;
     param.thread = StartNow;

--- a/modules/mcemu/mcemu_utils.h
+++ b/modules/mcemu/mcemu_utils.h
@@ -16,6 +16,8 @@ typedef struct
     void **exports;
 } modinfo_t;
 
+typedef void (*oplShutdownCb_t)(void);
+
 /* SMS Utils Imports */
 #define smsutils_IMPORTS_start DECLARE_IMPORT_TABLE(smsutils, 1, 1)
 
@@ -28,19 +30,22 @@ void mips_memset(void *, int, unsigned);
 #define smsutils_IMPORTS_end END_IMPORT_TABLE
 
 
-#define oplutils_IMPORTS_start DECLARE_IMPORT_TABLE(oplutils, 1, 1)
+#define oplutils_IMPORTS_start DECLARE_IMPORT_TABLE(oplutils, 1, 2)
 
 int getModInfo(u8 *modname, modinfo_t *info);
 #define I_getModInfo DECLARE_IMPORT(4, getModInfo)
+
+int oplRegisterShutdownCallback(oplShutdownCb_t cb);
+#define I_oplRegisterShutdownCallback DECLARE_IMPORT(5, oplRegisterShutdownCallback)
 
 /* MASS Transfer Imports */
 #ifdef USB_DRIVER
 
 void mass_stor_readSector(unsigned int lba, unsigned short int nsectors, unsigned char *buffer);
-#define I_mass_stor_readSector DECLARE_IMPORT(5, mass_stor_readSector)
+#define I_mass_stor_readSector DECLARE_IMPORT(6, mass_stor_readSector)
 
 void mass_stor_writeSector(unsigned int lba, unsigned short int nsectors, const unsigned char *buffer);
-#define I_mass_stor_writeSector DECLARE_IMPORT(6, mass_stor_writeSector)
+#define I_mass_stor_writeSector DECLARE_IMPORT(7, mass_stor_writeSector)
 
 #endif
 
@@ -52,7 +57,7 @@ void mass_stor_writeSector(unsigned int lba, unsigned short int nsectors, const 
 #define ATA_DIR_WRITE 1
 
 int ata_device_sector_io(unsigned int unit, void *buf, unsigned int lba, unsigned int sectors, int dir);
-#define I_ata_device_sector_io DECLARE_IMPORT(5, ata_device_sector_io)
+#define I_ata_device_sector_io DECLARE_IMPORT(6, ata_device_sector_io)
 
 #endif
 
@@ -60,13 +65,16 @@ int ata_device_sector_io(unsigned int unit, void *buf, unsigned int lba, unsigne
 #ifdef SMB_DRIVER
 
 int smb_OpenAndX(char *filename, u16 *FID, int Write);
-#define I_smb_OpenAndX DECLARE_IMPORT(5, smb_OpenAndX)
+#define I_smb_OpenAndX DECLARE_IMPORT(6, smb_OpenAndX)
 
 int smb_ReadFile(u16 FID, u32 offsetlow, u32 offsethigh, void *readbuf, u16 nbytes);
-#define I_smb_ReadFile DECLARE_IMPORT(6, smb_ReadFile)
+#define I_smb_ReadFile DECLARE_IMPORT(7, smb_ReadFile)
 
 int smb_WriteFile(u16 FID, u32 offsetlow, u32 offsethigh, void *writebuf, u16 nbytes);
-#define I_smb_WriteFile DECLARE_IMPORT(7, smb_WriteFile)
+#define I_smb_WriteFile DECLARE_IMPORT(8, smb_WriteFile)
+
+int smb_Close(int FID);
+#define I_smb_Close DECLARE_IMPORT(9, smb_Close)
 
 #endif
 

--- a/src/hdd.c
+++ b/src/hdd.c
@@ -67,6 +67,16 @@ int hddSetTransferMode(int type, int mode)
 }
 
 //-------------------------------------------------------------------------
+int hddSetWriteCache(int enable)
+{
+    hddAtaSetWriteCache_t *args = (hddAtaSetWriteCache_t *)IOBuffer;
+
+    args->enable = enable;
+
+    return fileXioDevctl("xhdd0:", ATA_DEVCTL_SET_WRITE_CACHE, args, sizeof(hddAtaSetWriteCache_t), NULL, 0);
+}
+
+//-------------------------------------------------------------------------
 int hddSetIdleTimeout(int timeout)
 {
     // From hdparm man:

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -384,6 +384,9 @@ static void hddLaunchGame(int id, config_set_t *configSet)
     if (gPS2Logo)
         EnablePS2Logo = CheckPS2Logo(0, game->start_sector + OPL_HDD_MODE_PS2LOGO_OFFSET);
 
+    // Disable write caching for VMC.
+    hddSetWriteCache(0);
+
     deinit(NO_EXCEPTION); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
 
     sysLaunchLoaderElf(filename, "HDD_MODE", size_irx, irx, size_mcemu_irx, &hdd_mcemu_irx, EnablePS2Logo, compatMode);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

- If the game calls Exit(), OPL will deinitialize. In the current implementation, it will act according to the IGR exit path; if no path is specified, it will quit to the browser, otherwise it will boot the specified ELF. This is so that games that have a quit function can quit.
- IGR will now lock accesses to the virtual CD/DVD device, to avoid the risk of putting the physical device (ATA device, USB disk etc) into an undefined state. This should increase the reliability of IGR.
- For SMB: the disc image and VMC file will be closed if you do IGR, so that it is possible to reopen the files again. However, this is only possible if you actually use IGR successfully; if you switch off or hard-reset the PS2, then the SMB server may not release the exclusive lock on the files (particularly for VMC images).
- The write cache will be disabled for ATA devices. For HDPro, this is done in-game, since the start and finish functions are not exported by the HDPro driver and I see some ATA device reset in the in-game HDPro code...

Note: In the current implementation, do not invoke IGR while saving to a VMC. There are no safeguards against this.