### PR TITLE
Poweroff cdvdman fix

### DIFF
--- a/modules/iopcore/cdvdman/dev9.c
+++ b/modules/iopcore/cdvdman/dev9.c
@@ -222,7 +222,24 @@ static void dev9_set_stat(int stat)
 /* Export 6 */
 void dev9Shutdown(void)
 {
-    //Do not let the DEV9 interface to be switched off.
+    int idx;
+    USE_DEV9_REGS;
+
+    for (idx = 0; idx < 16; idx++)
+        if (dev9_shutdown_cbs[idx])
+            dev9_shutdown_cbs[idx]();
+
+    if (dev9type == 0) { /* PCMCIA */
+        DEV9_REG(DEV9_R_POWER) = 0;
+        DEV9_REG(DEV9_R_1474) = 0;
+    } else if (dev9type == 1) {
+        DEV9_REG(DEV9_R_1466) = 1;
+        DEV9_REG(DEV9_R_1464) = 0;
+        DEV9_REG(DEV9_R_1460) = DEV9_REG(DEV9_R_1464);
+        DEV9_REG(DEV9_R_POWER) = DEV9_REG(DEV9_R_POWER) & ~4;
+        DEV9_REG(DEV9_R_POWER) = DEV9_REG(DEV9_R_POWER) & ~1;
+    }
+    DelayThread(1000000);
 }
 
 /* Export 7 */

--- a/modules/iopcore/cdvdman/dev9.c
+++ b/modules/iopcore/cdvdman/dev9.c
@@ -88,7 +88,8 @@ static int dev9x_devctl(iop_file_t *f, const char *name, int cmd, void *args, in
         case DDIOC_MODEL:
             return dev9type;
         case DDIOC_OFF:
-            dev9Shutdown();
+            //Do not let the DEV9 interface to be switched off by other software.
+            //dev9Shutdown();
             return 0;
         default:
             return 0;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Replaces commit e8ecd92, which is mean to fix a problem introduced in e9a679d: some games that support the network adaptor will use DDIOC_OFF, which will power-off the network adaptor.

However, the previous fix disabled the dev9Shutdown() function, which also prevented OPL from switching off the network adaptor, making it impossible to power-down an expansion-bay PS2 model.