### PR TITLE
VMC-IGR Update

### DIFF
--- a/ee_core/src/cd_igr_rpc.c
+++ b/ee_core/src/cd_igr_rpc.c
@@ -5,19 +5,19 @@
 
 #include "cd_igr_rpc.h"
 
-//This uses the libcdvd power-off RPC, which only has 1 official function implemented.
 int oplIGRShutdown(void)
 {
     SifRpcClientData_t _igr_cd;
     int r;
 
-    while ((r = SifBindRpc(&_igr_cd, 0x80000596, 0)) >= 0 && (!_igr_cd.server))
+    _igr_cd.server = NULL;
+    while ((r = SifBindRpc(&_igr_cd, 0x80000598, 0)) >= 0 && (!_igr_cd.server))
         nopdelay();
 
     if (r < 0)
         return -E_SIF_RPC_BIND;
 
-    if (SifCallRpc(&_igr_cd, 0x0596, 0, NULL, 0, NULL, 0, NULL, NULL) < 0)
+    if (SifCallRpc(&_igr_cd, 1, 0, NULL, 0, NULL, 0, NULL, NULL) < 0)
         return -E_SIF_RPC_CALL;
 
     return 0;

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -52,7 +52,6 @@ int hddCheck(void);
 u32 hddGetTotalSectors(void);
 int hddIs48bit(void);
 int hddSetTransferMode(int type, int mode);
-int hddSetWriteCache(int enable);
 int hddSetIdleTimeout(int timeout);
 int hddGetHDLGamelist(hdl_games_list_t *game_list);
 void hddFreeHDLGamelist(hdl_games_list_t *game_list);

--- a/modules/hdd/common/opl-hdd-ioctl.h
+++ b/modules/hdd/common/opl-hdd-ioctl.h
@@ -4,7 +4,6 @@
 // Commands and structures for XATAD.IRX
 #define ATA_DEVCTL_IS_48BIT 0x6840
 #define ATA_DEVCTL_SET_TRANSFER_MODE 0x6841
-#define ATA_DEVCTL_SET_WRITE_CACHE 0x6842
 
 #define ATA_XFER_MODE_MDMA 0x20
 #define ATA_XFER_MODE_UDMA 0x40
@@ -16,10 +15,5 @@ typedef struct
     int type;
     int mode;
 } hddAtaSetMode_t;
-
-typedef struct
-{
-    int enable;
-} hddAtaSetWriteCache_t;
 
 #endif

--- a/modules/hdd/xhdd/hdpro.c
+++ b/modules/hdd/xhdd/hdpro.c
@@ -10,8 +10,3 @@ int hdproata_device_set_transfer_mode(int device, int type, int mode)
     return 0;
 }
 
-/* Set features - enable/disable write cache.  */
-int hdproata_device_set_write_cache(int device, int enable)
-{   //As the start and finish functions are not exported, disable the write cache within the in-game ATAD instead.
-    return 0;
-}

--- a/modules/hdd/xhdd/xatad.c
+++ b/modules/hdd/xhdd/xatad.c
@@ -77,19 +77,3 @@ int ata_device_set_transfer_mode(int device, int type, int mode)
     return 0;
 }
 
-/* Set features - enable/disable write cache.  */
-int ata_device_set_write_cache(int device, int enable)
-{
-	int res;
-
-	res = ata_io_start(NULL, 1, enable ? 0x02 : 0x82, 0, 0, 0, 0, (device << 4) & 0xffff, ATA_C_SET_FEATURES);
-	if (res)
-		return res;
-
-	res = ata_io_finish();
-	if (res)
-		return res;
-
-	return 0;
-}
-

--- a/modules/hdd/xhdd/xhdd.c
+++ b/modules/hdd/xhdd/xhdd.c
@@ -38,11 +38,6 @@ static int xhddDevctl(iop_file_t *fd, const char *name, int cmd, void *arg, unsi
                 return ata_device_set_transfer_mode(fd->unit, ((hddAtaSetMode_t *)arg)->type, ((hddAtaSetMode_t *)arg)->mode);
             else
                 return hdproata_device_set_transfer_mode(fd->unit, ((hddAtaSetMode_t *)arg)->type, ((hddAtaSetMode_t *)arg)->mode);
-        case ATA_DEVCTL_SET_WRITE_CACHE:
-            if (!isHDPro)
-                return ata_device_set_write_cache(fd->unit, ((hddAtaSetWriteCache_t *)arg)->enable);
-            else
-                return hdproata_device_set_write_cache(fd->unit,  ((hddAtaSetWriteCache_t *)arg)->enable);
         default:
             return -EINVAL;
     }

--- a/modules/iopcore/cdvdfsv/cdvdfsv.c
+++ b/modules/iopcore/cdvdfsv/cdvdfsv.c
@@ -564,9 +564,6 @@ static void *cbrpc_S596(int fno, void *buf, int size)
     }
     else if (fno == 0x0596) {
         //Terminate operations.
-        //Lock all accesses.
-        value = -1;
-        sceCdSC(CDSC_IO_SEMA, &value);
         //Shutdown OPL
         value = 0;
         sceCdSC(CDSC_OPL_SHUTDOWN, &value);

--- a/modules/iopcore/cdvdfsv/cdvdfsv.c
+++ b/modules/iopcore/cdvdfsv/cdvdfsv.c
@@ -259,7 +259,7 @@ static void cdvdfsv_startrpcthreads(void)
     thread_param.attr = TH_C;
     thread_param.option = 0xABCD8001;
     thread_param.thread = (void *)cdvdfsv_rpc1_th;
-    thread_param.stacksize = 0x1900;
+    thread_param.stacksize = 0x500; //Original: 0x1900. Its operations probably won't need so much space, since its functions will never trigger a callback.
     thread_param.priority = 0x51;
 
     rpc1_thread_id = CreateThread(&thread_param);
@@ -277,7 +277,7 @@ static void cdvdfsv_startrpcthreads(void)
     thread_param.attr = TH_C;
     thread_param.option = 0xABCD8000;
     thread_param.thread = (void *)cdvdfsv_rpc0_th;
-    thread_param.stacksize = 0x800;
+    thread_param.stacksize = 0x400; //Original: 0x800. Its operations probably won't need so much space, since its functions will never trigger a callback.
     thread_param.priority = 0x51;
 
     rpc0_thread_id = CreateThread(&thread_param);

--- a/modules/iopcore/cdvdman/atad.c
+++ b/modules/iopcore/cdvdman/atad.c
@@ -55,7 +55,7 @@ static u8 ata_gamestar_workaround = 0;
 
 static int ata_evflg = -1;
 
-static int io_sema = -1;
+int ata_io_sema = -1;
 
 #define WAITIOSEMA(x) WaitSema(x)
 #define SIGNALIOSEMA(x) SignalSema(x)
@@ -166,7 +166,7 @@ int atad_start(void)
     smp.max = 1;
     smp.option = 0;
     smp.attr = SA_THPRI;
-    io_sema = CreateSema(&smp);
+    ata_io_sema = CreateSema(&smp);
 
     res = 0;
     M_PRINTF("Driver loaded.\n");
@@ -576,7 +576,7 @@ int ata_device_sector_io(int device, void *buf, u32 lba, u32 nsectors, int dir)
     int res = 0, retries;
     u16 sector, lcyl, hcyl, select, command, len;
 
-    WAITIOSEMA(io_sema);
+    WAITIOSEMA(ata_io_sema);
 
     while (res == 0 && nsectors > 0) {
         /* Variable lba is only 32 bits so no change for lcyl and hcyl.  */
@@ -627,7 +627,7 @@ int ata_device_sector_io(int device, void *buf, u32 lba, u32 nsectors, int dir)
         nsectors -= len;
     }
 
-    SIGNALIOSEMA(io_sema);
+    SIGNALIOSEMA(ata_io_sema);
 
     return res;
 }

--- a/modules/iopcore/cdvdman/atad.h
+++ b/modules/iopcore/cdvdman/atad.h
@@ -53,6 +53,7 @@ int ata_io_start(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector, 
 int ata_io_finish(void);
 int ata_get_error(void);
 int ata_device_sector_io(int device, void *buf, u32 lba, u32 nsectors, int dir);
+int ata_device_flush_cache(int device);
 
 // APA Partition
 #define APA_MAGIC 0x00415041 // 'APA\0'

--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -279,6 +279,8 @@ static void cdvdman_poff_thread(void *arg)
     int stat;
 
     SleepThread();
+
+    DeviceUnmount();
     dev9Shutdown();
     sceCdPowerOff(&stat);
 }
@@ -836,7 +838,7 @@ int sceCdSC(int code, int *param)
         case CDSC_OPL_SHUTDOWN:
             if(vmcShutdownCb != NULL)
                 vmcShutdownCb();
-            DeviceDeinit();
+            DeviceUnmount();
             result = 1;
             break;
         default:

--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -280,6 +280,8 @@ static void cdvdman_poff_thread(void *arg)
 
     SleepThread();
 
+    if(vmcShutdownCb != NULL)
+        vmcShutdownCb();
     DeviceUnmount();
     dev9Shutdown();
     sceCdPowerOff(&stat);

--- a/modules/iopcore/cdvdman/device-hdd.c
+++ b/modules/iopcore/cdvdman/device-hdd.c
@@ -107,9 +107,13 @@ void DeviceFSInit(void)
 {
 }
 
-void DeviceUnmount(void)
+void DeviceLock(void)
 {
     WaitSema(ata_io_sema);
+}
+
+void DeviceUnmount(void)
+{
     ata_device_flush_cache(0);
 }
 

--- a/modules/iopcore/cdvdman/device-hdd.c
+++ b/modules/iopcore/cdvdman/device-hdd.c
@@ -45,6 +45,8 @@ static hdl_partspecs_t cdvdman_partspecs[HDL_NUM_PART_SPECS];
 extern int ata_device_set_write_cache(int device, int enable);
 #endif
 
+extern int ata_io_sema;
+
 static int cdvdman_get_part_specs(u32 lsn)
 {
     register int i;
@@ -107,6 +109,7 @@ void DeviceFSInit(void)
 
 void DeviceUnmount(void)
 {
+    WaitSema(ata_io_sema);
     ata_device_flush_cache(0);
 }
 

--- a/modules/iopcore/cdvdman/device-smb.c
+++ b/modules/iopcore/cdvdman/device-smb.c
@@ -114,9 +114,13 @@ void DeviceFSInit(void)
     }
 }
 
-void DeviceUnmount(void)
+void DeviceLock(void)
 {
     WaitSema(smb_io_sema);
+}
+
+void DeviceUnmount(void)
+{
     smb_CloseAll();
     smb_Disconnect();
 }

--- a/modules/iopcore/cdvdman/device-smb.c
+++ b/modules/iopcore/cdvdman/device-smb.c
@@ -37,6 +37,8 @@ extern struct cdvdman_settings_smb cdvdman_settings;
 
 extern struct irx_export_table _exp_oplsmb;
 
+extern int smb_io_sema;
+
 static void ps2ip_init(void);
 
 // !!! ps2ip exports functions pointers !!!
@@ -114,6 +116,7 @@ void DeviceFSInit(void)
 
 void DeviceUnmount(void)
 {
+    WaitSema(smb_io_sema);
     smb_CloseAll();
     smb_Disconnect();
 }

--- a/modules/iopcore/cdvdman/device-usb.c
+++ b/modules/iopcore/cdvdman/device-usb.c
@@ -82,9 +82,13 @@ void DeviceFSInit(void)
         DelayThread(200);
 }
 
-void DeviceUnmount(void)
+void DeviceLock(void)
 {
     WaitSema(usb_io_sema);
+}
+
+void DeviceUnmount(void)
+{
 }
 
 int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)

--- a/modules/iopcore/cdvdman/device-usb.c
+++ b/modules/iopcore/cdvdman/device-usb.c
@@ -33,6 +33,8 @@
 
 extern struct cdvdman_settings_usb cdvdman_settings;
 
+extern int usb_io_sema;
+
 static void usbd_init(void);
 
 // !!! usbd exports functions pointers !!!
@@ -82,6 +84,7 @@ void DeviceFSInit(void)
 
 void DeviceUnmount(void)
 {
+    WaitSema(usb_io_sema);
 }
 
 int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)

--- a/modules/iopcore/cdvdman/device.h
+++ b/modules/iopcore/cdvdman/device.h
@@ -2,6 +2,7 @@ void DeviceInit(void);     //Called in _start()
 void DeviceDeinit(void);   //Called in _exit(). Interrupts are disabled.
 
 void DeviceFSInit(void);   //Called when the filesystem layer is initialized
+void DeviceLock(void);     //Prevents further accesses to the device.
 void DeviceUnmount(void);  //Called when OPL is shutting down.
 
 int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors);

--- a/modules/iopcore/cdvdman/hdpro_atad.c
+++ b/modules/iopcore/cdvdman/hdpro_atad.c
@@ -72,7 +72,7 @@ static int ata_evflg = -1;
 /* Used for indicating 48-bit LBA support.  */
 extern char lba_48bit;
 
-static int io_sema = -1;
+int ata_io_sema = -1;
 
 #define WAITIOSEMA(x) WaitSema(x)
 #define SIGNALIOSEMA(x) SignalSema(x)
@@ -186,7 +186,7 @@ int atad_start(void)
     smp.max = 1;
     smp.option = 0;
     smp.attr = SA_THPRI;
-    io_sema = CreateSema(&smp);
+    ata_io_sema = CreateSema(&smp);
 
     res = 0;
     M_PRINTF("Driver loaded.\n");
@@ -677,7 +677,7 @@ int ata_device_sector_io(int device, void *buf, u32 lba, u32 nsectors, int dir)
     unsigned int nbytes;
     u16 sector, lcyl, hcyl, select, command, len;
 
-    WAITIOSEMA(io_sema);
+    WAITIOSEMA(ata_io_sema);
 
     if (!hdpro_io_start())
         return -1;
@@ -720,7 +720,7 @@ int ata_device_sector_io(int device, void *buf, u32 lba, u32 nsectors, int dir)
     if (!hdpro_io_finish())
         return -2;
 
-    SIGNALIOSEMA(io_sema);
+    SIGNALIOSEMA(ata_io_sema);
 
     return res;
 }

--- a/modules/iopcore/cdvdman/hdpro_atad.c
+++ b/modules/iopcore/cdvdman/hdpro_atad.c
@@ -99,7 +99,9 @@ static const ata_cmd_info_t ata_cmd_table[] = {
     {ATA_C_READ_SECTOR, 0x02},
     {ATA_C_READ_SECTOR_EXT, 0x82},
     {ATA_C_WRITE_SECTOR, 0x03},
-    {ATA_C_WRITE_SECTOR_EXT, 0x83}};
+    {ATA_C_WRITE_SECTOR_EXT, 0x83},
+    {ATA_C_FLUSH_CACHE, 0x01},
+    {ATA_C_FLUSH_CACHE_EXT, 0x01}};
 #define ATA_CMD_TABLE_SIZE (sizeof ata_cmd_table / sizeof(ata_cmd_info_t))
 
 static const ata_cmd_info_t smart_cmd_table[] = {
@@ -131,7 +133,7 @@ static void hdpro_io_write(u8 cmd, u16 val);
 static int hdpro_io_read(u8 cmd);
 static int ata_bus_reset(void);
 static int gen_ata_wait_busy(int bits);
-static int ata_device_set_write_cache(int device, int enable);
+int ata_device_set_write_cache(int device, int enable);
 
 static unsigned int ata_alarm_cb(void *unused)
 {
@@ -188,10 +190,6 @@ int atad_start(void)
 
     res = 0;
     M_PRINTF("Driver loaded.\n");
-
-    //Disable write cache for VMC.
-    ata_device_set_write_cache(0, 0);
-    ata_device_set_write_cache(1, 0);
 
 out:
     hdpro_io_finish();
@@ -655,6 +653,23 @@ finish:
     return res;
 }
 
+/* Export 17 */
+int ata_device_flush_cache(int device)
+{
+    int res;
+
+    if (!hdpro_io_start())
+        return -1;
+
+    if(!(res = ata_io_start(NULL, 1, 0, 0, 0, 0, 0, (device << 4) & 0xffff, lba_48bit ? ATA_C_FLUSH_CACHE_EXT : ATA_C_FLUSH_CACHE)))
+        res = ata_io_finish();
+
+    if (!hdpro_io_finish())
+        return -2;
+
+    return res;
+}
+
 /* Export 9 */
 int ata_device_sector_io(int device, void *buf, u32 lba, u32 nsectors, int dir)
 {
@@ -717,18 +732,19 @@ ata_devinfo_t *ata_get_devinfo(int device)
 }
 
 /* Set features - enable/disable write cache.  */
-static int ata_device_set_write_cache(int device, int enable)
+int ata_device_set_write_cache(int device, int enable)
 {
-	int res;
+    int res;
 
-	res = ata_io_start(NULL, 1, enable ? 0x02 : 0x82, 0, 0, 0, 0, (device << 4) & 0xffff, ATA_C_SET_FEATURES);
-	if (res)
-		return res;
+    if (!hdpro_io_start())
+        return -1;
 
-	res = ata_io_finish();
-	if (res)
-		return res;
+    if((res = ata_io_start(NULL, 1, enable ? 0x02 : 0x82, 0, 0, 0, 0, (device << 4) & 0xffff, ATA_C_SET_FEATURES)) == 0)
+        res = ata_io_finish();
 
-	return 0;
+    if (!hdpro_io_finish())
+        return -2;
+
+    return res;
 }
 

--- a/modules/iopcore/cdvdman/mass_driver.c
+++ b/modules/iopcore/cdvdman/mass_driver.c
@@ -95,7 +95,7 @@ typedef struct _read_capacity_data
 
 static UsbDriver driver;
 
-static int io_sema;
+int usb_io_sema;
 
 #define WAITIOSEMA(x) WaitSema(x)
 #define SIGNALIOSEMA(x) SignalSema(x)
@@ -643,20 +643,20 @@ static void cbw_scsi_sector_io(mass_dev *dev, short int dir, unsigned int lba, v
 
 void mass_stor_readSector(unsigned int lba, unsigned short int nsectors, unsigned char *buffer)
 {
-    WAITIOSEMA(io_sema);
+    WAITIOSEMA(usb_io_sema);
 
     cbw_scsi_sector_io(&g_mass_device, USB_BLK_EP_IN, lba, buffer, nsectors);
 
-    SIGNALIOSEMA(io_sema);
+    SIGNALIOSEMA(usb_io_sema);
 }
 
 void mass_stor_writeSector(unsigned int lba, unsigned short int nsectors, const unsigned char *buffer)
 {
-    WAITIOSEMA(io_sema);
+    WAITIOSEMA(usb_io_sema);
 
     cbw_scsi_sector_io(&g_mass_device, USB_BLK_EP_OUT, lba, (void *)buffer, nsectors);
 
-    SIGNALIOSEMA(io_sema);
+    SIGNALIOSEMA(usb_io_sema);
 }
 
 /* test that endpoint is bulk endpoint and if so, update device info */
@@ -958,7 +958,7 @@ int mass_stor_init(void)
     smp.max = 1;
     smp.option = 0;
     smp.attr = SA_THPRI;
-    io_sema = CreateSema(&smp);
+    usb_io_sema = CreateSema(&smp);
 
     driver.next = NULL;
     driver.prev = NULL;

--- a/modules/iopcore/cdvdman/smb.c
+++ b/modules/iopcore/cdvdman/smb.c
@@ -279,12 +279,12 @@ static struct WriteAndXRequest_t smb_Write_Request = {
     0,
     0,
     0,
-    0x01,
+    0x00,
     0,
     0,
     0,
     0x3f,
-    0 //DataOffset = 0x3f, WriteMode = 1
+    0 //DataOffset = 0x3f, WriteMode = 0
 };
 
 static u16 UID, TID;

--- a/modules/iopcore/cdvdman/smb.c
+++ b/modules/iopcore/cdvdman/smb.c
@@ -698,17 +698,26 @@ int smb_Close(int FID)
     rawTCP_SetSessionHeader(41);
     r = GetSMBServerReply();
     if (r <= 0)
+    {
+//      SIGNALIOSEMA(smb_io_sema);
         return -EIO;
+    }
 
     struct CloseResponse_t *CRsp = (struct CloseResponse_t *)SMB_buf;
 
     // check sanity of SMB header
     if (CRsp->smbH.Magic != SMB_MAGIC)
+    {
+//      SIGNALIOSEMA(smb_io_sema);
         return -EIO;
+    }
 
     // check there's no error
     if ((CRsp->smbH.Eclass | (CRsp->smbH.Ecode << 16)) != STATUS_SUCCESS)
+    {
+//      SIGNALIOSEMA(smb_io_sema);
         return -EIO;
+    }
 
 //  SIGNALIOSEMA(smb_io_sema);
 

--- a/modules/iopcore/cdvdman/smb.c
+++ b/modules/iopcore/cdvdman/smb.c
@@ -655,11 +655,17 @@ int smb_OpenAndX(char *filename, u16 *FID, int Write)
 
     // check sanity of SMB header
     if (ORsp->smbH.Magic != SMB_MAGIC)
+    {
+        SIGNALIOSEMA(smb_io_sema);
         return -1;
+    }
 
     // check there's no error
     if (ORsp->smbH.Eclass != STATUS_SUCCESS)
+    {
+        SIGNALIOSEMA(smb_io_sema);
         return -1000;
+    }
 
     *FID = ORsp->FID;
 

--- a/src/hdd.c
+++ b/src/hdd.c
@@ -67,16 +67,6 @@ int hddSetTransferMode(int type, int mode)
 }
 
 //-------------------------------------------------------------------------
-int hddSetWriteCache(int enable)
-{
-    hddAtaSetWriteCache_t *args = (hddAtaSetWriteCache_t *)IOBuffer;
-
-    args->enable = enable;
-
-    return fileXioDevctl("xhdd0:", ATA_DEVCTL_SET_WRITE_CACHE, args, sizeof(hddAtaSetWriteCache_t), NULL, 0);
-}
-
-//-------------------------------------------------------------------------
 int hddSetIdleTimeout(int timeout)
 {
     // From hdparm man:

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -384,9 +384,6 @@ static void hddLaunchGame(int id, config_set_t *configSet)
     if (gPS2Logo)
         EnablePS2Logo = CheckPS2Logo(0, game->start_sector + OPL_HDD_MODE_PS2LOGO_OFFSET);
 
-    // Disable write caching for VMC.
-    hddSetWriteCache(0);
-
     deinit(NO_EXCEPTION); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
 
     sysLaunchLoaderElf(filename, "HDD_MODE", size_irx, irx, size_mcemu_irx, &hdd_mcemu_irx, EnablePS2Logo, compatMode);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

I haven't got the time to test this, but I think it should work fine.
Maybe leave it for a few days to let some people test this: https://www.sendspace.com/file/q2el33

As for what it does:
- Re-enable the ATA write cache for the official HDD. To shut down, either use IGR or press the power button. Do not just switch off/disconnect the PS2 from the mains. For HDPro, the write cache will only be enabled if IGR is enabled, as there is no way to determine whether the PS2 will be switched off without IGR.
- Fixed wrong function call to DeviceDeinit(), when it should have been DeviceUnmount(). This prevented the VMC files from being closed properly and prevented the device from being unmounted.
- OPL will attempt to block further accesses to the device, with the device's I/O semaphore instead. 
CDVDMAN's semaphore does not totally prevent all form of device accesses. Perhaps OPL's semaphore is used differently from how the Sony CDVDMAN module uses its event flag, but the sceCdLayerSearch() function can also be called from the IOP, where this form of access control does not help.

This may/may not fix the problem with IGR getting stuck at some phase for some games.