### PR TITLE
Change HIRES to runtime option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,6 @@ IGS ?= 0
 #Enables/disables pad emulator
 PADEMU ?= 0
 
-#Enables/disables high resolution multi-pass rendering for the OPL GUI
-HIRES ?= 0
-
 #Enables/disables building of an edition of OPL that will support the DTL-T10000 (SDK v2.3+)
 DTL_T10000 ?= 0
 
@@ -137,10 +134,6 @@ else
   PADEMU_FLAGS = PADEMU=0
 endif
 
-ifeq ($(HIRES),1)
-  EE_CFLAGS += -DHIRES
-endif
-
 ifeq ($(DEBUG),1)
   EE_CFLAGS += -D__DEBUG -g
   EE_OBJS += debug.o udptty.o ioptrap.o ps2link.o
@@ -195,7 +188,7 @@ endif
 release:
 	echo "Building Open PS2 Loader $(OPL_VERSION)..."
 	echo "-Interface"
-	$(MAKE) IGS=1 PADEMU=1 HIRES=0 $(EE_VPKD).ZIP
+	$(MAKE) IGS=1 PADEMU=1 $(EE_VPKD).ZIP
 
 debug:
 	$(MAKE) DEBUG=1 all

--- a/include/renderman.h
+++ b/include/renderman.h
@@ -64,17 +64,6 @@ const u64 gColFocus;
 const u64 gDefaultCol;
 const u64 gDefaultAlpha;
 
-enum rm_vmode {
-    RM_VMODE_AUTO = 0,
-    RM_VMODE_PAL,
-    RM_VMODE_NTSC,
-    RM_VMODE_DTV480P,
-    RM_VMODE_DTV576P,
-    RM_VMODE_DTV720P,
-    RM_VMODE_DTV1080I,
-    RM_VMODE_VGA_640_60
-};
-
 enum rm_aratio {
     RM_ARATIO_4_3 = 0,
     RM_ARATIO_16_9,

--- a/src/gui.c
+++ b/src/gui.c
@@ -59,7 +59,9 @@ static void guiShow();
 static u32 curtime = 0;
 static u32 time_since_last = 0;
 static u32 time_render = 0;
+static float fps = 0.0f;
 
+extern GSGLOBAL *gsGlobal;
 #endif
 
 struct gui_update_list_t
@@ -1968,15 +1970,31 @@ static void guiDrawOverlays()
         guiDrawBusy();
 
 #ifdef __DEBUG
-    // fps meter
-    char fps[20];
+    char text[20];
+    int x = screenWidth - 120;
+    int y = 15;
+    int yadd = 15;
 
-    if (time_since_last != 0)
-        snprintf(fps, sizeof(fps), "%3d ms %3.1f FPS", time_render, 1000.0f / (float)time_since_last);
-    else
-        snprintf(fps, sizeof(fps), "%3d ms ----- FPS", time_render);
+    snprintf(text, sizeof(text), "VRAM:");
+    fntRenderString(gTheme->fonts[0], x, y, ALIGN_LEFT, 0, 0, text, GS_SETREG_RGBA(0x60, 0x60, 0x60, 0x80));
+    y += yadd;
 
-    fntRenderString(gTheme->fonts[0], screenWidth - 90, 30, ALIGN_CENTER, 0, 0, fps, GS_SETREG_RGBA(0x60, 0x60, 0x60, 0x80));
+    snprintf(text, sizeof(text), "%dKiB FIXED", gsGlobal->CurrentPointer / 1024);
+    fntRenderString(gTheme->fonts[0], x, y, ALIGN_LEFT, 0, 0, text, GS_SETREG_RGBA(0x60, 0x60, 0x60, 0x80));
+    y += yadd;
+
+    snprintf(text, sizeof(text), "%dKiB TEXMAN", ((4*1024*1024) - gsGlobal->CurrentPointer) / 1024);
+    fntRenderString(gTheme->fonts[0], x, y, ALIGN_LEFT, 0, 0, text, GS_SETREG_RGBA(0x60, 0x60, 0x60, 0x80));
+    y += yadd;
+    y += yadd; // Empty line
+
+    if (time_since_last != 0) {
+        fps = fps * 0.99 + 10.0f / (float)time_since_last;
+
+        snprintf(text, sizeof(text), "%.1f FPS", fps);
+        fntRenderString(gTheme->fonts[0], x, y, ALIGN_LEFT, 0, 0, text, GS_SETREG_RGBA(0x60, 0x60, 0x60, 0x80));
+        y += yadd;
+    }
 #endif
 
     // Last Played Auto Start

--- a/src/gui.c
+++ b/src/gui.c
@@ -217,9 +217,6 @@ void guiShowAbout()
 #ifdef PADEMU
         " PADEMU"
 #endif
-#ifdef HIRES
-        " HIRES"
-#endif
         //Version numbers
         , GSM_VERSION
 #ifdef IGS
@@ -506,21 +503,12 @@ void guiShowUIConfig(void)
         , "EDTV 640x448p @60Hz 24bit"
         , "EDTV 640x512p @50Hz 24bit"
         , "VGA 640x480p @60Hz 24bit"
-#ifdef HIRES
-        , "PAL 704x576i @50Hz 24bit"
-        , "NTSC 704x480i @60Hz 24bit"
-        , "EDTV 704x480p @60Hz 24bit"
-        , "EDTV 704x576p @50Hz 24bit"
-        , "HDTV 1280x720p @60Hz 16bit"
-        , "HDTV 1920x1080i @60Hz 16bit"
-#else
-        , "PAL 704x576i @50Hz 16bit"
-        , "NTSC 704x480i @60Hz 16bit"
-        , "EDTV 704x480p @60Hz 16bit"
-        , "EDTV 704x576p @50Hz 16bit"
-        , "HDTV 1280x720p @60Hz 16bit scaled"
-        , "HDTV 1920x1080i @60Hz 16bit scaled"
-#endif
+        , "PAL 704x576i @50Hz 24bit (HIRES)"
+        , "NTSC 704x480i @60Hz 24bit (HIRES)"
+        , "EDTV 704x480p @60Hz 24bit (HIRES)"
+        , "EDTV 704x576p @50Hz 24bit (HIRES)"
+        , "HDTV 1280x720p @60Hz 16bit (HIRES)"
+        , "HDTV 1920x1080i @60Hz 16bit (HIRES)"
         , NULL};
 
     diaSetEnum(diaUIConfig, UICFG_SCROLL, scrollSpeeds);

--- a/src/opl.c
+++ b/src/opl.c
@@ -1204,7 +1204,7 @@ static void setDefaults(void)
 
     frameCounter = 0;
 
-    gVMode = RM_VMODE_AUTO;
+    gVMode = 0;
     gXOff = 0;
     gYOff = 0;
     gOverscan = 0;


### PR DESCRIPTION
## Pull Request checklist

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

This removes one more compile-time option: HIRES. It now switches automatically between normal rendering and multipass rendering. The list of resolutions is the same:
- PAL 640x512i @50Hz 24bit
- NTSC 640x448i @60Hz 24bit
- EDTV 640x448p @60Hz 24bit
- EDTV 640x512p @50Hz 24bit
- VGA 640x480p @60Hz 24bit
- PAL 704x576i @50Hz 24bit (HIRES)
- NTSC 704x480i @60Hz 24bit (HIRES)
- EDTV 704x480p @60Hz 24bit (HIRES)
- EDTV 704x576p @50Hz 24bit (HIRES)
- HDTV 1280x720p @60Hz 16bit (HIRES)
- HDTV 1920x1080i @60Hz 16bit (HIRES)

When doing a debug build, you will also see more debugging information in the top-right corner. Besides the FPS counter there is now also information about the VRAM usage.