### PR TITLE
CDVDFSV: increased stack size of RPC 1. Related to d25a8eab.

### DIFF
--- a/modules/iopcore/cdvdfsv/cdvdfsv.c
+++ b/modules/iopcore/cdvdfsv/cdvdfsv.c
@@ -264,7 +264,7 @@ static void cdvdfsv_startrpcthreads(void)
     thread_param.attr = TH_C;
     thread_param.option = 0xABCD8001;
     thread_param.thread = (void *)cdvdfsv_rpc1_th;
-    thread_param.stacksize = 0x500; //Original: 0x1900. Its operations probably won't need so much space, since its functions will never trigger a callback.
+    thread_param.stacksize = 0x600; //Original: 0x1900. Its operations probably won't need so much space, since its functions will never trigger a callback.
     thread_param.priority = 0x51;
 
     rpc1_thread_id = CreateThread(&thread_param);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
This is to fix the breaking change, by increasing the stack size for RPC 1 a little more.
