### PR TITLE
Fix for USB - fix issues that were introduced in 18780d5

### DIFF
--- a/modules/iopcore/cdvdman/device-usb.c
+++ b/modules/iopcore/cdvdman/device-usb.c
@@ -79,7 +79,7 @@ void DeviceFSInit(void)
 
     // configure mass device
     while (mass_stor_configureDevice() <= 0)
-        DelayThread(200);
+        DelayThread(5000);
 }
 
 void DeviceLock(void)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [X] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

 (mass_driver.c) Fix glitches related to USB support that were introduced with commit 18780d5 on June 8th.
1. Some devices to cease being compatible due to SET INTERFACE failing.
By the USB 1.1 specification, section 9.4.10: Devices that only support a default setting for the specified interface may return a STALL.
If that happens, we shall clear the halt state of the interface's pipes and continue, as with Linux.
2. Fixed faulty logic for reading data from devices with sector sizes > 2048 bytes.
As the code for making reads in blocks was removed, the loop only iterates once.
That is wrong, as reading from a 4096-byte device (for example) could require the loop to iterate twice if the last LBA is not aligned with the device's physical LBAs.
At the 2nd iteration, nsectors would have been 1, when it should then read a complete sector and copy the first half of it with memcpy.

The other commit is something I added in case sceCdInit() is called from a high-priority thread... but may be just more for correctness in the end:
- (device-usb.c) Increase delay while waiting for USB devices to become ready from 200 to 5000us, to avoid ever blocking the progress of USBD during device detection.