### PR TITLE
UI Fixes dec18 (Part II)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -127,6 +127,8 @@ typedef struct
 } config_set_t;
 
 void configInit(char *prefix);
+void configSetMove(char *prefix);
+void configMove(config_set_t *configSet, const char *fileName);
 void configEnd();
 config_set_t *configAlloc(int type, config_set_t *configSet, char *fileName);
 void configFree(config_set_t *configSet);

--- a/src/config.c
+++ b/src/config.c
@@ -164,6 +164,25 @@ void configInit(char *prefix)
     configAlloc(CONFIG_NETWORK, &configFiles[CONFIG_INDEX_NETWORK], path);
 }
 
+void configSetMove(char *prefix)
+{
+    char path[256];
+
+    if (prefix)
+        snprintf(legacyNetConfigPath, sizeof(legacyNetConfigPath), "%s/IPCONFIG.DAT", prefix);
+    else
+        prefix = gBaseMCDir;
+
+    snprintf(path, sizeof(path), "%s/conf_opl.cfg", prefix);
+    configMove(&configFiles[CONFIG_INDEX_OPL], path);
+    snprintf(path, sizeof(path), "%s/conf_last.cfg", prefix);
+    configMove(&configFiles[CONFIG_INDEX_OPL], path);
+    snprintf(path, sizeof(path), "%s/conf_apps.cfg", prefix);
+    configMove(&configFiles[CONFIG_INDEX_OPL], path);
+    snprintf(path, sizeof(path), "%s/conf_network.cfg", prefix);
+    configMove(&configFiles[CONFIG_INDEX_OPL], path);
+}
+
 void configEnd()
 {
     int index = 0;
@@ -194,6 +213,13 @@ config_set_t *configAlloc(int type, config_set_t *configSet, char *fileName)
         configSet->filename = NULL;
     configSet->modified = 0;
     return configSet;
+}
+
+void configMove(config_set_t *configSet, const char *fileName)
+{
+    int length = strlen(fileName) + 1;
+    configSet->filename = realloc(configSet->filename, length);
+    memcpy(configSet->filename, fileName, length);
 }
 
 void configFree(config_set_t *configSet)

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -159,8 +159,6 @@ void hddLoadModules(void)
 
         LOG("HDDSUPPORT modules loaded\n");
 
-        hddSetIdleTimeout(gHDDSpindown * 12); // gHDDSpindown [0..20] -> spindown [0..240] -> seconds [0..1200]
-
         ret = fileXioMount(hddPrefix, oplPart, FIO_MT_RDWR);
         if (ret == -ENOENT) {
             //Attempt to create the partition.
@@ -348,6 +346,7 @@ static void hddLaunchGame(int id, config_set_t *configSet)
         dmaMode -= 3;
     }
     hddSetTransferMode(dmaType, dmaMode);
+    // gHDDSpindown [0..20] -> spindown [0..240] -> seconds [0..1200]
     hddSetIdleTimeout(gHDDSpindown * 12);
 
     if (hddHDProKitDetected) {


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
- Fixed network configuration becoming unavailable after deinitialization. 
- ATA IDLE will only be changed when a game is booted from the HDD, to prevent the HDD from possibly being kept awake forever if the user has the setting set to disabled.
- Changed how devices are selected for loading/storing config files. 

New strategy for selecting a device for loading/storing config files:
When loading:
1. Check memory cards.
2. If config could not be loaded, try the device that OPL was booted from (supported devices only).
3. If config could not be loaded, try all supported devices.
4. Default to memory card, if no config file could be loaded.

When saving:
1. Try the device that the config file was loaded from.
2. If config could not be saved, try the device that OPL was booted from (supported devices only).
3. If config could not be saved, try all supported devices.
4. Give up.

Note: how OPL choses the memory card, was not changed because this method is used by other areas like themes etc. It will pick one memory card (at boot) and this will not change, so if it picks slot 2... you cannot get it to use slot 1.
I haven't determined how much work has to be done to correct this.

I could not test any of these, so you might want to check that everything works. The correction to network support and the change to when the IDLE timeout is set are minor changes, but the check to the loading & saving of configuration files was a more major job.