### PR TITLE
Fixes dec18 (part III)

### DIFF
--- a/ee_core/include/cd_igr_rpc.h
+++ b/ee_core/include/cd_igr_rpc.h
@@ -1,2 +1,2 @@
-int oplIGRShutdown(void);
+int oplIGRShutdown(int poff);
 

--- a/ee_core/src/cd_igr_rpc.c
+++ b/ee_core/src/cd_igr_rpc.c
@@ -5,10 +5,11 @@
 
 #include "cd_igr_rpc.h"
 
-int oplIGRShutdown(void)
+int oplIGRShutdown(int poff)
 {
     SifRpcClientData_t _igr_cd;
     int r;
+    s32 poffData;
 
     _igr_cd.server = NULL;
     while ((r = SifBindRpc(&_igr_cd, 0x80000598, 0)) >= 0 && (!_igr_cd.server))
@@ -17,7 +18,8 @@ int oplIGRShutdown(void)
     if (r < 0)
         return -E_SIF_RPC_BIND;
 
-    if (SifCallRpc(&_igr_cd, 1, 0, NULL, 0, NULL, 0, NULL, NULL) < 0)
+    *(s32*)UNCACHED_SEG(&poffData) = poff;
+    if (SifCallRpc(&_igr_cd, 1, SIF_RPC_M_NOWBDC, &poffData, sizeof(poffData), NULL, 0, NULL, NULL) < 0)
         return -E_SIF_RPC_CALL;
 
     return 0;

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -173,17 +173,18 @@ static void IGR_Thread(void *arg)
 
     DPRINTF("IGR thread woken up!\n");
 
+    if (!DisableDebug)
+        GS_BGCOLOUR = 0xFFFFFF; // White
+
+    // Re-Init RPC & CMD
+    SifInitRpc(0);
+
     // If Pad Combo is Start + Select then Return to Home, else if Pad Combo is UP then take IGS
     if ((Pad_Data.combo_type == IGR_COMBO_START_SELECT)
 #ifdef IGS
         || ((Pad_Data.combo_type == IGR_COMBO_UP) && (EnableGSMOp))
 #endif
             ) {
-        if (!DisableDebug)
-            GS_BGCOLOUR = 0xFFFFFF; // White
-
-        // Re-Init RPC & CMD
-        SifInitRpc(0);
 
         if (!DisableDebug)
             GS_BGCOLOUR = 0x800000; // Dark Blue
@@ -194,7 +195,7 @@ static void IGR_Thread(void *arg)
         if (!DisableDebug)
             GS_BGCOLOUR = 0xFF8000; // Blue sky
 
-        oplIGRShutdown();
+        oplIGRShutdown(0);
 
         if (!DisableDebug)
             GS_BGCOLOUR = 0x0000FF; // Red
@@ -272,10 +273,15 @@ static void IGR_Thread(void *arg)
         SifExitRpc();
 
         IGR_Exit(0);
-    }
+    } else {
+        // If combo is R3 + L3, Poweroff PS2
+        oplIGRShutdown(1);
 
-    // If combo is R3 + L3 or Reset failed, Poweroff PS2
-    PowerOff_PS2();
+        if (!DisableDebug)
+            GS_BGCOLOUR = 0x0000FF; // Red
+
+        PowerOff_PS2();
+    }
 }
 
 void IGR_Exit(s32 exit_code)

--- a/modules/iopcore/cdvdfsv/cdvdfsv.c
+++ b/modules/iopcore/cdvdfsv/cdvdfsv.c
@@ -598,7 +598,7 @@ static void *cbrpc_shutdown(int fno, void *buf, int size)
     if (fno == 1) {
         //Terminate operations.
         //Shutdown OPL
-        value = 0;
+        value = *(int*)buf;
         sceCdSC(CDSC_OPL_SHUTDOWN, &value);
     }
 

--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -108,7 +108,7 @@ typedef struct
 } FHANDLE;
 
 // internal functions prototypes
-static void oplShutdown(void);
+static void oplShutdown(int poff);
 static void fs_init(void);
 static void cdvdman_init(void);
 static int cdvdman_readMechaconVersion(char *mname, u32 *stat);
@@ -236,12 +236,14 @@ void oplRegisterShutdownCallback(oplShutdownCb_t cb)
     vmcShutdownCb = cb;
 }
 
-static void oplShutdown(void)
+static void oplShutdown(int poff)
 {
     DeviceLock();
     if(vmcShutdownCb != NULL)
         vmcShutdownCb();
     DeviceUnmount();
+    if (poff)
+        DeviceStop();
 }
 
 //--------------------------------------------------------------
@@ -289,7 +291,7 @@ static void cdvdman_poff_thread(void *arg)
 
     SleepThread();
 
-    oplShutdown();
+    oplShutdown(1);
     dev9Shutdown();
     sceCdPowerOff(&stat);
 }
@@ -845,7 +847,7 @@ int sceCdSC(int code, int *param)
             result = cdvdman_stat.err = *param;
             break;
         case CDSC_OPL_SHUTDOWN:
-            oplShutdown();
+            oplShutdown(*param);
             result = 1;
             break;
         default:

--- a/modules/iopcore/cdvdman/device-hdd.c
+++ b/modules/iopcore/cdvdman/device-hdd.c
@@ -117,6 +117,11 @@ void DeviceUnmount(void)
     ata_device_flush_cache(0);
 }
 
+void DeviceStop(void)
+{
+    //This will be handled by ATAD.
+}
+
 int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
 {
     u32 offset = 0;

--- a/modules/iopcore/cdvdman/device-smb.c
+++ b/modules/iopcore/cdvdman/device-smb.c
@@ -125,6 +125,10 @@ void DeviceUnmount(void)
     smb_Disconnect();
 }
 
+void DeviceStop(void)
+{
+}
+
 int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
 {
     register u32 r, sectors_to_read, lbound, ubound, nlsn, offslsn;

--- a/modules/iopcore/cdvdman/device-usb.c
+++ b/modules/iopcore/cdvdman/device-usb.c
@@ -69,6 +69,11 @@ void DeviceDeinit(void)
 {
 }
 
+void DeviceStop(void)
+{
+    mass_stor_stop_unit();
+}
+
 void DeviceFSInit(void)
 {
     // initialize usbd exports

--- a/modules/iopcore/cdvdman/device.h
+++ b/modules/iopcore/cdvdman/device.h
@@ -4,5 +4,6 @@ void DeviceDeinit(void);   //Called in _exit(). Interrupts are disabled.
 void DeviceFSInit(void);   //Called when the filesystem layer is initialized
 void DeviceLock(void);     //Prevents further accesses to the device.
 void DeviceUnmount(void);  //Called when OPL is shutting down.
+void DeviceStop(void);     //Called before the PS2 is to be shut down.
 
 int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors);

--- a/modules/iopcore/cdvdman/mass_stor.h
+++ b/modules/iopcore/cdvdman/mass_stor.h
@@ -26,5 +26,6 @@ void mass_stor_readSector(unsigned int lba, unsigned short int nsectors, unsigne
 void mass_stor_writeSector(unsigned int lba, unsigned short int nsectors, const unsigned char *buffer);
 int mass_stor_configureDevice(void);
 int mass_stor_ReadCD(unsigned int lsn, unsigned int nsectors, void *buf, int part_num);
+int mass_stor_stop_unit(void);
 
 #endif

--- a/src/opl.c
+++ b/src/opl.c
@@ -513,10 +513,10 @@ static int checkLoadConfigUSB(int types)
         value = configReadMulti(types);
         config_set_t *configOPL = configGetByType(CONFIG_OPL);
         configSetInt(configOPL, CONFIG_OPL_USB_MODE, START_MODE_AUTO);
-        return 0;
+        return value;
     }
 
-    return -ENOENT;
+    return 0;
 }
 
 static int checkLoadConfigHDD(int types)
@@ -532,10 +532,10 @@ static int checkLoadConfigHDD(int types)
         value = configReadMulti(types);
         config_set_t *configOPL = configGetByType(CONFIG_OPL);
         configSetInt(configOPL, CONFIG_OPL_HDD_MODE, START_MODE_AUTO);
-        return 0;
+        return value;
     }
 
-    return -ENOENT;
+    return 0;
 }
 
 //When this function is called, the current device for loading/saving config is the memory card.
@@ -549,22 +549,22 @@ static int tryAlternateDevice(int types)
     //First, try the device that OPL booted from.
     if (!strncmp(pwd, "mass", 4) && (pwd[4] == ':' || pwd[5] == ':'))
     {
-        if (checkLoadConfigUSB(types) == 0)
-            return 0;
+        if ((value = checkLoadConfigUSB(types)) != 0)
+            return value;
     }
     else if (!strncmp(pwd, "hdd", 3) && (pwd[3] == ':' || pwd[4] == ':'))
     {
-        if (checkLoadConfigHDD(types) == 0)
-            return 0;
+        if ((value = checkLoadConfigHDD(types)) != 0)
+            return value;
     }
 
     //Config was not found on the boot device. Check all supported devices.
     // Check USB device
-    if (checkLoadConfigUSB(types) == 0)
-        return 0;
+    if ((value = checkLoadConfigUSB(types)) != 0)
+        return value;
     // Check HDD
-    if (checkLoadConfigHDD(types) == 0)
-        return 0;
+    if ((value = checkLoadConfigHDD(types)) != 0)
+        return value;
 
     // At this point, the user has no loadable config files on any supported device, so try to find a device to save on.
     // We don't want to get users into alternate mode for their very first launch of OPL (i.e no config file at all, but still want to save on MC)
@@ -587,7 +587,6 @@ static int tryAlternateDevice(int types)
         }
     }
 
-    //We tried everything, but... maybe the user will connect a device later.
     return 0;
 }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [X] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
-  Fixed incorrect handling of the config load result (did not return the types of config files loaded).
-  (ingame ATAD) port patch for issuing STANDBY IMMEDIATE before DEV9 is shut down, to avoid causing an "emergency park" for some HDDs.
-  (ingame USB) Patched USB support to issue STOP UNIT before the PS2 is shut down.
- Added shutdown mode to IGR.

Note: nothing was tested again. Any inconvenience is regretted.
The changes related to STANDBY IMMEDIATE and STOP UNIT are related to [this problem with modern (typically 2.5") HDDs](https://github.com/ps2dev/ps2sdk/issues/85).
For the devices to be shut down correctly in both the UI and in-game, the PS2SDK must be updated to get the new drivers for the UI.