### PR TITLE
Fixed checks on whether the device can have the configuration written to

### DIFF
--- a/include/usbsupport.h
+++ b/include/usbsupport.h
@@ -17,7 +17,7 @@ typedef struct
 
 void usbInit();
 item_list_t *usbGetObject(int initOnly);
-int usbFindPartition(char *target, char *name);
+int usbFindPartition(char *target, const char *name, int write);
 void usbLoadModules(void);
 
 #endif

--- a/src/opl.c
+++ b/src/opl.c
@@ -507,7 +507,7 @@ static int checkLoadConfigUSB(int types)
     int value;
 
     // check USB
-    if (usbFindPartition(path, "conf_opl.cfg")) {
+    if (usbFindPartition(path, "conf_opl.cfg", 0)) {
         configEnd();
         configInit(path);
         value = configReadMulti(types);
@@ -695,7 +695,7 @@ static int trySaveConfigUSB(int types)
     char path[64];
 
     // check USB
-    if (usbFindPartition(path, "conf_opl.cfg")) {
+    if (usbFindPartition(path, "conf_opl.cfg", 1)) {
         configSetMove(path);
         return configWriteMulti(types);
     }
@@ -705,13 +705,9 @@ static int trySaveConfigUSB(int types)
 
 static int trySaveConfigHDD(int types)
 {
-    int value;
-
     hddLoadModules();
-    value = fileXioOpen("pfs0:conf_opl.cfg", O_RDONLY);
-    if (value >= 0) {
-        fileXioClose(value);
-
+    //Check that the formatted & usable HDD is connected.
+    if (hddCheck() == 0) {
         configSetMove("pfs0:");
         return configWriteMulti(types);
     }

--- a/src/usbsupport.c
+++ b/src/usbsupport.c
@@ -27,7 +27,7 @@ static base_game_info_t *usbGames;
 static item_list_t usbGameList;
 
 //Identifies the partition that the specified file is stored on and generates a full path to it.
-int usbFindPartition(char *target, char *name)
+int usbFindPartition(char *target, const char *name, int write)
 {
     int i, fd;
     char path[256];
@@ -37,7 +37,10 @@ int usbFindPartition(char *target, char *name)
             sprintf(path, "mass%d:%s/%s", i, gUSBPrefix, name);
         else
             sprintf(path, "mass%d:%s", i, name);
-        fd = fileXioOpen(path, O_RDONLY, 0666);
+        if (write)
+            fd = fileXioOpen(path, O_WRONLY|O_TRUNC|O_CREAT, 0666);
+        else
+            fd = fileXioOpen(path, O_RDONLY);
 
         if (fd >= 0) {
             if (gUSBPrefix[0] != '\0')
@@ -121,7 +124,7 @@ static int usbNeedsUpdate(void)
         return 0;
     OldGeneration = UsbGeneration;
 
-    usbFindPartition(usbPrefix, "ul.cfg");
+    usbFindPartition(usbPrefix, "ul.cfg", 0);
 
     sprintf(path, "%sCD", usbPrefix);
     if (fileXioGetStat(path, &stat) != 0)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

This should fix the problem with OPL being unable to create new configuration files on the HDD unit or USB device.
I haven't tested it yet, sorry.

I originally wanted to also change theme and language support to allow files to be loaded from other devices as well, but there might be a possibility that the rest of the UI depends on these two to be initialized first... and I cannot prove/disprove that within the time I have now.