### PR TITLE
Fixed video mode confirmation message always being displayed

### DIFF
--- a/modules/iopcore/cdvdman/streaming.c
+++ b/modules/iopcore/cdvdman/streaming.c
@@ -344,6 +344,7 @@ int sceCdStPause(void)
         CpuSuspendIntr(&OldState);
         //Pause.
         SetStm0Callback(NULL);
+        cdvdman_stat.StreamingData.StIsReading = 0;
         CpuResumeIntr(OldState);
 
         sceCdSync(0);

--- a/src/gui.c
+++ b/src/gui.c
@@ -566,11 +566,13 @@ reselect_video_mode:
         sfxInit(0);
     }
 
-    if (guiConfirmVideoMode() == 0) {
-        //Restore previous video mode, without changing the theme & language settings.
-        gVMode = previousVMode;
-        applyConfig(-1, -1);
-        goto reselect_video_mode;
+    if (previousVMode != gVMode) {
+        if (guiConfirmVideoMode() == 0) {
+            //Restore previous video mode, without changing the theme & language settings.
+            gVMode = previousVMode;
+            applyConfig(-1, -1);
+            goto reselect_video_mode;
+        }
     }
 }
 


### PR DESCRIPTION
…play settings are changed.

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

This will fix the problem with the video mode confirmation message always being displayed, even if other display settings are changed.