### PR TITLE
Updates jan19 (Part II)

### DIFF
--- a/modules/iopcore/cdvdman/streaming.c
+++ b/modules/iopcore/cdvdman/streaming.c
@@ -344,6 +344,7 @@ int sceCdStPause(void)
         CpuSuspendIntr(&OldState);
         //Pause.
         SetStm0Callback(NULL);
+        cdvdman_stat.StreamingData.StIsReading = 0;
         CpuResumeIntr(OldState);
 
         sceCdSync(0);

--- a/src/gui.c
+++ b/src/gui.c
@@ -566,11 +566,13 @@ reselect_video_mode:
         sfxInit(0);
     }
 
-    if (guiConfirmVideoMode() == 0) {
-        //Restore previous video mode, without changing the theme & language settings.
-        gVMode = previousVMode;
-        applyConfig(-1, -1);
-        goto reselect_video_mode;
+    if (previousVMode != gVMode) {
+        if (guiConfirmVideoMode() == 0) {
+            //Restore previous video mode, without changing the theme & language settings.
+            gVMode = previousVMode;
+            applyConfig(-1, -1);
+            goto reselect_video_mode;
+        }
     }
 }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
- Fixed video mode confirmation message always being displayed when display settings are changed.
- This will also fix a problem with sceCdStPause() causing sceCdStResume() to fail to resume streaming.

A number of titles may be affected, such as State of Emergency. I have verified that the game can be booted without any modes.