### PR TITLE
Ui igr fix

### DIFF
--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -334,11 +334,7 @@ static void appLaunchItem(int id, config_set_t *configSet)
         //To keep the necessary device accessible, we will assume the mode that owns the device which contains the file to boot.
         mode = oplPath2Mode(filename);
         if (mode < 0)
-        {
-            LOG("APPSUPPORT: cannot find mode for path: %s\n", filename);
-            guiMsgBox("APPSUPPORT: cannot find mode for path, please report.", 0, NULL);
-            return;
-        }
+            mode = APP_MODE; //Legacy apps mode (mc?:/*)
 
         deinit(UNMOUNT_EXCEPTION, mode); // CAREFUL: deinit will call appCleanUp, so configApps/cur will be freed
         sysExecElf(filename);

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -728,7 +728,8 @@ static void ethCleanUp(int exception)
         free(ethGames);
 
         // disconnect from the active SMB session
-        ethSMBDisconnect();
+        if ((exception & UNMOUNT_EXCEPTION) == 0)
+            ethSMBDisconnect();
     }
 
     //UI may have initialized modules outside of ETH mode, so deinitialize regardless of the enabled status.
@@ -762,7 +763,7 @@ static int ethCheckVMC(char *name, int createSize)
 
 static void smbGetAppsPath(char *path, int max)
 {
-    snprintf(path, max, "%s/APPS", gETHPrefix);
+    snprintf(path, max, "%sAPPS", ethPrefix);
 }
 
 static item_list_t ethGameList = {

--- a/src/usbsupport.c
+++ b/src/usbsupport.c
@@ -398,6 +398,9 @@ static void usbCleanUp(int exception)
         LOG("USBSUPPORT CleanUp\n");
 
         free(usbGames);
+
+//      if ((exception & UNMOUNT_EXCEPTION) == 0)
+//          ...
     }
 }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
- APPS: changed ETHSUPPORT to not terminate session if APPS needs it. appLaunchItem() will now default to APP_MODE for any unrecognized modes, to support legacy paths.
-  IGR: fixed incorrect bitmasks & patterns for locating calls to scePadOpen(), replaced hardcoded addresses with mem_start & mem_end.

Due to incorrect patterns used by IGR to locate scePadOpen(), sometimes the wrong instructions get patched, which result in undefined behaviour.