### PR TITLE
Fixes jan19

### DIFF
--- a/include/opl.h
+++ b/include/opl.h
@@ -64,8 +64,7 @@
 #define OPL_VMODE_CHANGE_CONFIRMATION_TIMEOUT_MS 10000
 
 int oplPath2Mode(const char *path);
-char *oplGetModeText(int mode);
-int oplGetAppImage(char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm);
+int oplGetAppImage(const char *device, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm);
 int oplScanApps(int (*callback)(const char *path, config_set_t *appConfig, void *arg), void *arg);
 
 void setErrorMessage(int strId);

--- a/src/opl.c
+++ b/src/opl.c
@@ -353,11 +353,6 @@ static void deinitAllSupport(int exception, int modeSelected)
     moduleCleanup(&list_support[APP_MODE], exception, modeSelected);
 }
 
-char *oplGetModeText(int mode)
-{
-    return(list_support[mode].support->textId == -1 ? list_support[mode].support->text : _l(list_support[mode].support->textId));
-}
-
 //For resolving the mode, given an app's path
 int oplPath2Mode(const char *path)
 {
@@ -386,11 +381,27 @@ int oplPath2Mode(const char *path)
     return -1;
 }
 
-int oplGetAppImage(char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
+int oplGetAppImage(const char *device, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm)
 {
-    int i, remaining;
+    int i, remaining, elfbootmode;
     char priority;
     item_list_t *listSupport;
+
+    elfbootmode = -1;
+    if (device != NULL)
+    {
+        elfbootmode = oplPath2Mode(device);
+        if (elfbootmode >= 0)
+        {
+            listSupport = list_support[elfbootmode].support;
+
+            if ((listSupport != NULL) && (listSupport->enabled))
+            {
+                if (listSupport->itemGetImage(folder, isRelative, value, suffix, resultTex, psm) >= 0)
+                    return 0;
+            }
+        }
+    }
 
     // We search on ever devices from fatest to slowest.
     for (remaining = MODE_COUNT,priority = 0; remaining > 0 && priority < 4; priority++)
@@ -398,6 +409,9 @@ int oplGetAppImage(char *folder, int isRelative, char *value, char *suffix, GSTE
         for (i = 0; i < MODE_COUNT; i++)
         {
             listSupport = list_support[i].support;
+
+            if (i == elfbootmode)
+                continue;
 
             if ((listSupport != NULL) && (listSupport->enabled) && (listSupport->appsPriority == priority))
             {

--- a/src/opl.c
+++ b/src/opl.c
@@ -1360,6 +1360,10 @@ static void moduleCleanup(opl_io_module_t *mod, int exception, int modeSelected)
 
 void deinit(int exception, int modeSelected)
 {
+    // block all io ops, wait for the ones still running to finish
+    ioBlockOps(1);
+    guiExecDeferredOps();
+
     if (gEnableSFX) {
         gEnableSFX = 0;
     }

--- a/src/system.c
+++ b/src/system.c
@@ -386,7 +386,9 @@ static const patchlist_t iop_patch_list[] = {
     {"SLES_513.01", "", &iremsndpatch_irx, &size_iremsndpatch_irx},    //SOS: The Final Escape
     {"SLPS_251.13", "", &iremsndpatch_irx, &size_iremsndpatch_irx},    //Zettai Zetsumei Toshi
     {"SLES_535.08", "", &apemodpatch_irx, &size_apemodpatch_irx},      //Ultimate Pro Pinball
-    {"SLUS_204.13", "", &f2techioppatch_irx, &size_f2techioppatch_irx}, //Shadow Man 2econd Coming (NTSC-U/C)
+    {"SLUS_204.13", "", &f2techioppatch_irx, &size_f2techioppatch_irx}, //Shadow Man: 2econd Coming (NTSC-U/C)
+    {"SLES_504.46", "", &f2techioppatch_irx, &size_f2techioppatch_irx}, //Shadow Man: 2econd Coming (PAL)
+    {"SLES_506.08", "", &f2techioppatch_irx, &size_f2techioppatch_irx}, //Shadow Man: 2econd Coming (PAL German)
     {NULL, NULL, NULL, NULL },  //Terminator
 };
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
-  Fixed missing IOP patch entries for the PAL release of Shadow Man: 2econd Coming (SLES-50446 & SLES-50608).
-  deinit() should block further I/O operations & wait for existing operations to complete. This should prevent the user from interrupting OPL as it accesses storage media.
-  APPSSUPPORT: apps will now always have the full path printed for the startup path, new format will always have the device containing the app checked first for art assets (before other devices).
-  PAD: monitor pad states and reinitialize pad when pad is reconnected, to standardize behaviour.

This should fix #176 .