### PR TITLE
Fixes feb19

### DIFF
--- a/ee_core/include/padhook.h
+++ b/ee_core/include/padhook.h
@@ -20,6 +20,9 @@
 #define PADOPEN_CHECK 1
 
 int Install_PadOpen_Hook(u32 mem_start, u32 mem_end, int mode);
+void Install_IGR(void);
+void Remove_Padhook(void);
+void Reset_Padhook(void);
 void IGR_Exit(s32 exit_code);
 
 // DEV9 Registers
@@ -76,6 +79,7 @@ typedef struct
     u16 version;
 } pattern_t;
 
+#define IGR_LIBPAD_NONE 0 //libpad not found
 #define IGR_LIBPAD 1
 #define IGR_LIBPAD2 2
 

--- a/ee_core/src/asm.S
+++ b/ee_core/src/asm.S
@@ -56,6 +56,8 @@
 
 	/* padhook.c */
 	.extern Install_PadOpen_Hook
+	.extern Reset_Padhook
+	.extern Install_IGR
 
 	.globl  g_argbuf
 	.globl	Hook_SifSetDma
@@ -262,6 +264,10 @@ Hook_ExecPS2:
 
 	/* change the stack pointer */
 	la	$sp, _end
+
+	/* call Reset_Padhook to indicate that ExecPS2 will be run. */
+	jal	Reset_Padhook
+	nop
 
 	/* call Install_PadOpen_Hook */
 	lui	$a0, 0x0010

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -450,17 +450,14 @@ static int Hook_scePad2CreateSocket(pad2socketparam_t *SocketParam, void *addr)
     int ret;
 
     // Make sure scePad2CreateSocket function is still available
-    if (SocketParam != NULL)
-    {   //Do only if game specified this structure, as it is optional.
-        if (SocketParam->port == 0 && SocketParam->slot == 0)
-            Install_PadOpen_Hook(0x00100000, 0x01ff0000, PADOPEN_CHECK);
-    }
+    if ((SocketParam == NULL) || (SocketParam->port == 0 && SocketParam->slot == 0))
+        Install_PadOpen_Hook(0x00100000, 0x01ff0000, PADOPEN_CHECK);
 
     // Call original scePad2CreateSocket function
     ret = scePad2CreateSocket(SocketParam, addr);
 
     // Install IGR with libpad2 parameters
-    if (SocketParam->port == 0 && SocketParam->slot == 0)
+    if ((SocketParam == NULL) || (SocketParam->port == 0 && SocketParam->slot == 0))
         Install_IGR(addr);
 
     return ret;

--- a/ee_core/src/syshook.c
+++ b/ee_core/src/syshook.c
@@ -38,7 +38,10 @@ u32 New_SifSetDma(SifDmaTransfer_t *sdd, s32 len)
 {
     // Hook padOpen function to install In Game Reset
     if (!(g_compat_mask & COMPAT_MODE_6) && padOpen_hooked == 0)
+    {
+        Install_IGR();
         padOpen_hooked = Install_PadOpen_Hook(0x00100000, 0x01ff0000, PADOPEN_HOOK);
+    }
 
     struct _iop_reset_pkt *reset_pkt = (struct _iop_reset_pkt *)sdd->src;
 

--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -212,7 +212,7 @@ static iop_sys_clock_t gCallbackSysClock;
 static u8 cdvdman_buf[CDVDMAN_BUF_SECTORS * 2048];
 
 #define CDVDMAN_FS_BUFSIZE CDVDMAN_FS_SECTORS * 2048
-static u8 cdvdman_fs_buf[CDVDMAN_FS_BUFSIZE + 2 * 2048];
+static u8 cdvdman_fs_buf[CDVDMAN_FS_BUFSIZE];
 
 #define CDVDMAN_MODULE_VERSION 0x225
 static int cdvdman_debug_print_flag = 0;

--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -1792,12 +1792,16 @@ static void cdvdman_cdread_Thread(void *args)
         cdvdman_read(cdvdman_stat.cdread_lba, cdvdman_stat.cdread_sectors, cdvdman_stat.cdread_buf);
 
         /* This streaming callback is not compatible with the original SONY stream channel 0 (IOP) callback's design.
-			The original is run from the interrupt handler, but we want it to run
-			from a threaded environment because it's easier to protect critical regions. */
+	   The original is run from the interrupt handler, but we want it to run
+	   from a threaded environment because our interrupt is emulated. */
         if (Stm0Callback != NULL)
 	{
             cdvdman_signal_read_end();
-            Stm0Callback();
+
+            /* Check that the streaming callback was not cleared, as this pointer may get changed between function calls.
+               As per the original semantics, once it is cleared, then it should not be called. */
+            if (Stm0Callback != NULL)
+                Stm0Callback();
 	}
         else
             cdvdman_cb_event(SCECdFuncRead); //Only runs if streaming is not in action.

--- a/modules/iopcore/cdvdman/streaming.c
+++ b/modules/iopcore/cdvdman/streaming.c
@@ -60,12 +60,8 @@ static int StFillStreamBuffer(void)
     int result, OldState;
     void *ptr;
 
-    /*	NOTE:	When this function is called by the timer callback (when a fill request is rescheduled),
-			this critical section here might not be protected properly because CpuSuspendIntr only prevents thread-switching (hardware interrupts are disabled differently).
-			SCEI used a similar design, but their implementation uses a bitmap to mark the filled/empty banks instead
-			(which is probably immune to race conditions, but we are interested in saving memory).
-			I don't think that there will be a problem because the important critical section (AllocBank) is probably far enough beneath this mechanism.
-			If deemed necessary, please replace the rescheduling mechanism with one that is thread-based.	*/
+    /*	SCEI used a similar design, but their implementation uses a bitmap to mark the filled/empty banks instead
+	(which is probably immune to race conditions, but we are interested in saving memory).	*/
     CpuSuspendIntr(&OldState);
 
     if (cdvdman_stat.StreamingData.StIsReading) {
@@ -82,7 +78,7 @@ static int StFillStreamBuffer(void)
     CpuResumeIntr(OldState);
 
     if (result == 0) {
-        //		iDPRINTF("Stream fill buffer: Stream lsn 0x%08x - %u sectors:%p\n", cdvdman_stat.StreamingData.Stlsn, cdvdman_stat.StreamingData.StBanksize, ptr);
+        //iDPRINTF("Stream fill buffer: Stream lsn 0x%08x - %u sectors:%p\n", cdvdman_stat.StreamingData.Stlsn, cdvdman_stat.StreamingData.StBanksize, ptr);
         if (cdvdman_AsyncRead(cdvdman_stat.StreamingData.Stlsn, cdvdman_stat.StreamingData.StBanksize, ptr) == 0) {
             //Failed to start reading.
             cdvdman_stat.StreamingData.StIsReading = 0;

--- a/modules/iopcore/common/cdvdman.h
+++ b/modules/iopcore/common/cdvdman.h
@@ -159,7 +159,8 @@ enum CDIOC_CODE {
 };
 
 // DMA/reading alignment correction buffer. Used by CDVDMAN and CDVDFSV.
-#define CDVDMAN_FS_SECTORS 6 //The size of the actual buffer within CDVDMAN is CDVDMAN_FS_SECTORS+2.
+//The minimum size is 2, as one sector may be used for buffer alignment correction.
+#define CDVDMAN_FS_SECTORS 8
 
 //Codes for use with sceCdSC()
 #define CDSC_GET_DEBUG_STATUS 0xFFFFFFF0 //Get debug status flag.

--- a/modules/isofs/isofs.c
+++ b/modules/isofs/isofs.c
@@ -516,6 +516,7 @@ static int IsofsMount(iop_file_t *f, const char *fsname, const char *devname, in
     WaitSema(MountPoint.sema);
 
     memset(&MountPoint, 0, sizeof(struct MountData));
+    MountPoint.fd = -1;
 
     if ((fd = open(devname, O_RDONLY)) >= 0) {
         if ((result = ProbeISO9660(fd, 16, &MountPoint.layer_info[0])) == 0)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
- Fixed streaming callback potentially executed with a NULL-pointer, due to the pointer getting changed between function calls.
- CDVDMAN: consolidated CDVDFSV_BUF_SECTORS and CDVDMAN_FS_SECTORS, for clarity. CDVDMAN_FS_SECTORS is now set to 8 and CDVDFSV will read up to CDVDMAN_FS_SECTORS sectors per chunk. When the buffer is not aligned, then it will use 1 sector for alignment correction. This is higher than previously because I don't know why we only used 7/8 sectors...
- Added patch for Harvest Moon: A Wonderful Life
- padhook: changed Hook_scePad2CreateSocket() to always check and install IGR if SockParam is null (which is optional). This replaces the incomplete patch from 541d270.
- padhook: do not create padhook thread & interrupt handler in duplicate. Thread will now be installed either at the IOP reboot or when the padhook is triggered, whichever comes first. This will allow the power button to always be used for IGR, even if libpad cannot be located due to the game being protected in some way (i.e. Tekken 5).
- ISOFS: Fixed iso: being stuck in an opened state, if the file cannot be opened for mounting.
