### PR TITLE
fix bin2s path if have installed other program with the same name

### DIFF
--- a/labs/genvmclab/Makefile
+++ b/labs/genvmclab/Makefile
@@ -6,6 +6,8 @@ EE_LIBS = -lfileXio -lpatches -ldebug -lc -lkernel
 EE_CFLAGS = -g
 EE_LDFLAGS = -s
 
+BIN2S = $(PS2SDK)/bin/bin2s
+
 all:
 	$(MAKE) $(EE_BIN)
 
@@ -25,56 +27,56 @@ clean:
 rebuild: clean all
 
 poweroff.s:
-	bin2s $(PS2SDK)/iop/irx/poweroff.irx poweroff.s poweroff_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/poweroff.irx poweroff.s poweroff_irx
 
 ps2dev9.s:
 	$(MAKE) -C ../../modules/dev9
-	bin2s ../../modules/dev9/ps2dev9.irx ps2dev9.s ps2dev9_irx
+	$(BIN2S) ../../modules/dev9/ps2dev9.irx ps2dev9.s ps2dev9_irx
 
 smsutils.s:
 	$(MAKE) -C ../../modules/network/SMSUTILS
-	bin2s ../../modules/network/SMSUTILS/SMSUTILS.irx smsutils.s smsutils_irx
+	$(BIN2S) ../../modules/network/SMSUTILS/SMSUTILS.irx smsutils.s smsutils_irx
 
 smstcpip.s:
 	$(MAKE) -C ../../modules/network/SMSTCPIP
-	bin2s ../../modules/network/SMSTCPIP/SMSTCPIP.irx smstcpip.s smstcpip_irx
+	$(BIN2S) ../../modules/network/SMSTCPIP/SMSTCPIP.irx smstcpip.s smstcpip_irx
 		
 smsmap.s:
 	$(MAKE) -C ../../modules/network/SMSMAP
-	bin2s ../../modules/network/SMSMAP/SMSMAP.irx smsmap.s smsmap_irx
+	$(BIN2S) ../../modules/network/SMSMAP/SMSMAP.irx smsmap.s smsmap_irx
 
 iomanx.s:
-	bin2s $(PS2SDK)/iop/irx/iomanX.irx iomanx.s iomanx_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/iomanX.irx iomanx.s iomanx_irx
 
 filexio.s:
-	bin2s $(PS2SDK)/iop/irx/fileXio.irx filexio.s filexio_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/fileXio.irx filexio.s filexio_irx
 
 usbd.s:
-	bin2s $(PS2SDK)/iop/irx/usbd.irx usbd.s usbd_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/usbd.irx usbd.s usbd_irx
 
 usbhdfsd.s:
 	$(MAKE) -C ../../modules/usb/usbhdfsd
-	bin2s ../../modules/usb/usbhdfsd/usbhdfsd.irx usbhdfsd.s usbhdfsd_irx
+	$(BIN2S) ../../modules/usb/usbhdfsd/usbhdfsd.irx usbhdfsd.s usbhdfsd_irx
 
 udptty.s:
 	$(MAKE) -C ../../modules/debug/udptty
-	bin2s ../../modules/debug/udptty/udptty.irx udptty.s udptty_irx
+	$(BIN2S) ../../modules/debug/udptty/udptty.irx udptty.s udptty_irx
 
 ioptrap.s:
 	$(MAKE) -C ../../modules/debug/ioptrap
-	bin2s ../../modules/debug/ioptrap/ioptrap.irx ioptrap.s ioptrap_irx
+	$(BIN2S) ../../modules/debug/ioptrap/ioptrap.irx ioptrap.s ioptrap_irx
 
 ps2link.s:
 	$(MAKE) -C ../../modules/debug/ps2link
-	bin2s ../../modules/debug/ps2link/ps2link.irx ps2link.s ps2link_irx
+	$(BIN2S) ../../modules/debug/ps2link/ps2link.irx ps2link.s ps2link_irx
 
 mcman.s:
 	$(MAKE) -C ../../modules/vmc/mcman
-	bin2s ../../modules/vmc/mcman/mcman.irx mcman.s mcman_irx
+	$(BIN2S) ../../modules/vmc/mcman/mcman.irx mcman.s mcman_irx
 
 genvmc.s:
 	$(MAKE) -C ../../modules/vmc/genvmc
-	bin2s ../../modules/vmc/genvmc/genvmc.irx genvmc.s genvmc_irx
+	$(BIN2S) ../../modules/vmc/genvmc/genvmc.irx genvmc.s genvmc_irx
 
 include $(PS2SDK)/samples/Makefile.pref
 include $(PS2SDK)/samples/Makefile.eeglobal

--- a/labs/hdldsvrlab/Makefile
+++ b/labs/hdldsvrlab/Makefile
@@ -6,6 +6,8 @@ EE_LIBS = -lfileXio -lpatches -ldebug -lc -lkernel
 EE_CFLAGS = -g
 EE_LDFLAGS = -s
 
+BIN2S = $(PS2SDK)/bin/bin2s
+
 all:
 	$(MAKE) $(EE_BIN)
 
@@ -24,44 +26,44 @@ rebuild: clean all
 
 discid.s:
 	$(MAKE) -C ../../modules/cdvd/discID
-	bin2s ../../modules/cdvd/discID/discID.irx discid.s discid_irx
+	$(BIN2S) ../../modules/cdvd/discID/discID.irx discid.s discid_irx
 
 poweroff.s:
-	bin2s $(PS2SDK)/iop/irx/poweroff.irx poweroff.s poweroff_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/poweroff.irx poweroff.s poweroff_irx
 
 ps2dev9.s:
 	$(MAKE) -C ../../modules/dev9
-	bin2s ../../modules/dev9/ps2dev9.irx ps2dev9.s ps2dev9_irx
+	$(BIN2S) ../../modules/dev9/ps2dev9.irx ps2dev9.s ps2dev9_irx
 
 smsutils.s:
 	$(MAKE) -C ../../modules/network/SMSUTILS
-	bin2s ../../modules/network/SMSUTILS/SMSUTILS.irx smsutils.s smsutils_irx
+	$(BIN2S) ../../modules/network/SMSUTILS/SMSUTILS.irx smsutils.s smsutils_irx
 
 smstcpip.s:
 	$(MAKE) -C ../../modules/network/SMSTCPIP -f Makefile rebuild
-	bin2s ../../modules/network/SMSTCPIP/SMSTCPIP.irx smstcpip.s smstcpip_irx
+	$(BIN2S) ../../modules/network/SMSTCPIP/SMSTCPIP.irx smstcpip.s smstcpip_irx
 		
 smsmap.s:
 	$(MAKE) -C ../../modules/network/SMSMAP
-	bin2s ../../modules/network/SMSMAP/SMSMAP.irx smsmap.s smsmap_irx
+	$(BIN2S) ../../modules/network/SMSMAP/SMSMAP.irx smsmap.s smsmap_irx
 
 ps2atad.s:
 	$(MAKE) -C ../../modules/hdd/atad
-	bin2s ../../modules/hdd/atad/ps2atad.irx ps2atad.s ps2atad_irx
+	$(BIN2S) ../../modules/hdd/atad/ps2atad.irx ps2atad.s ps2atad_irx
 
 ps2hdd.s:
 	$(MAKE) -C ../../modules/hdd/ps2hdd
-	bin2s ../../modules/hdd/ps2hdd/ps2hdd.irx ps2hdd.s ps2hdd_irx
+	$(BIN2S) ../../modules/hdd/ps2hdd/ps2hdd.irx ps2hdd.s ps2hdd_irx
 
 hdldsvr.s:
 	$(MAKE) -C ../../modules/hdd/hdldsvr
-	bin2s ../../modules/hdd/hdldsvr/hdldsvr.irx hdldsvr.s hdldsvr_irx
+	$(BIN2S) ../../modules/hdd/hdldsvr/hdldsvr.irx hdldsvr.s hdldsvr_irx
 
 iomanx.s:
-	bin2s $(PS2SDK)/iop/irx/iomanX.irx iomanx.s iomanx_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/iomanX.irx iomanx.s iomanx_irx
 
 filexio.s:
-	bin2s $(PS2SDK)/iop/irx/fileXio.irx filexio.s filexio_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/fileXio.irx filexio.s filexio_irx
 
 include $(PS2SDK)/samples/Makefile.pref
 include $(PS2SDK)/samples/Makefile.eeglobal

--- a/labs/smblab/Makefile
+++ b/labs/smblab/Makefile
@@ -6,6 +6,8 @@ EE_LIBS = -lfileXio -lpatches -ldebug -lc -lkernel
 EE_CFLAGS = -g
 EE_LDFLAGS = -s
 
+BIN2S = $(PS2SDK)/bin/bin2s
+
 all:
 	$(MAKE) $(EE_BIN)
 
@@ -22,44 +24,44 @@ clean:
 rebuild: clean all
 
 poweroff.s:
-	bin2s $(PS2SDK)/iop/irx/poweroff.irx poweroff.s poweroff_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/poweroff.irx poweroff.s poweroff_irx
 
 ps2dev9.s:
 	$(MAKE) -C ../../modules/dev9
-	bin2s ../../modules/dev9/ps2dev9.irx ps2dev9.s ps2dev9_irx
+	$(BIN2S) ../../modules/dev9/ps2dev9.irx ps2dev9.s ps2dev9_irx
 
 smsutils.s:
 	$(MAKE) -C ../../modules/network/SMSUTILS
-	bin2s ../../modules/network/SMSUTILS/SMSUTILS.irx smsutils.s smsutils_irx
+	$(BIN2S) ../../modules/network/SMSUTILS/SMSUTILS.irx smsutils.s smsutils_irx
 
 smstcpip.s:
 	$(MAKE) -C ../../modules/network/SMSTCPIP
-	bin2s ../../modules/network/SMSTCPIP/SMSTCPIP.irx smstcpip.s smstcpip_irx
+	$(BIN2S) ../../modules/network/SMSTCPIP/SMSTCPIP.irx smstcpip.s smstcpip_irx
 		
 smsmap.s:
 	$(MAKE) -C ../../modules/network/SMSMAP
-	bin2s ../../modules/network/SMSMAP/SMSMAP.irx smsmap.s smsmap_irx
+	$(BIN2S) ../../modules/network/SMSMAP/SMSMAP.irx smsmap.s smsmap_irx
 
 smbman.s:
-	bin2s $(PS2SDK)/iop/irx/smbman.irx smbman.s smbman_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/smbman.irx smbman.s smbman_irx
 
 udptty.s:
 	$(MAKE) -C ../../modules/debug/udptty
-	bin2s ../../modules/debug/udptty/udptty.irx udptty.s udptty_irx
+	$(BIN2S) ../../modules/debug/udptty/udptty.irx udptty.s udptty_irx
 
 ioptrap.s:
 	$(MAKE) -C ../../modules/debug/ioptrap
-	bin2s ../../modules/debug/ioptrap/ioptrap.irx ioptrap.s ioptrap_irx
+	$(BIN2S) ../../modules/debug/ioptrap/ioptrap.irx ioptrap.s ioptrap_irx
 
 ps2link.s:
 	$(MAKE) -C ../../modules/debug/ps2link
-	bin2s ../../modules/debug/ps2link/ps2link.irx ps2link.s ps2link_irx
+	$(BIN2S) ../../modules/debug/ps2link/ps2link.irx ps2link.s ps2link_irx
 
 iomanx.s:
-	bin2s $(PS2SDK)/iop/irx/iomanX.irx iomanx.s iomanx_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/iomanX.irx iomanx.s iomanx_irx
 
 filexio.s:
-	bin2s $(PS2SDK)/iop/irx/fileXio.irx filexio.s filexio_irx
+	$(BIN2S) $(PS2SDK)/iop/irx/fileXio.irx filexio.s filexio_irx
 
 include $(PS2SDK)/samples/Makefile.pref
 include $(PS2SDK)/samples/Makefile.eeglobal


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

if you have installed any program in the system (/usr/bin or /usr/sbin) with the same name (bin2s), makefile always poit to it instead of use the bin2s provided by ps2-sdk

at this time, the foolabs can't build because is quite outdated, but why not