### PR TITLE
Fix main10 bug

### DIFF
--- a/misc/conf_theme_OPL.cfg
+++ b/misc/conf_theme_OPL.cfg
@@ -1,29 +1,29 @@
-main0:
+main00:
 	type=Background
 	pattern=BG
-main1:
+main01:
 	type=MenuIcon
-main2:
+main02:
 	type=MenuText
-main3:
+main03:
 	type=ItemsList
-main4:
+main04:
 	type=ItemIcon
-main5:
+main05:
 #	DVD cover size: 129x184mm
 	type=ItemCover
 	width=140
 	height=200
-main6:
+main06:
 	type=ItemText
-main7:
+main07:
 	type=HintText
-main8:
+main08:
 	type=LoadingIcon
-info0:
+info00:
 	type=Background
 	pattern=BG
-info1:
+info01:
 #	Game Title
 	type=AttributeText
 	attribute=Title
@@ -32,7 +32,7 @@ info1:
 	x=33
 	y=22
 	width=470
-info2:
+info02:
 #	Game Genre
 	type=AttributeText
 	attribute=Genre
@@ -41,7 +41,7 @@ info2:
 	x=33
 	y=41
 	width=470
-info3:
+info03:
 #	Game Release Date
 	type=AttributeText
 	attribute=Release
@@ -50,7 +50,7 @@ info3:
 	x=33
 	y=61
 	width=470
-info4:
+info04:
 #	Game Developer
 	type=AttributeText
 	attribute=Developer
@@ -59,7 +59,7 @@ info4:
 	x=33
 	y=81
 	width=470
-info5:
+info05:
 #	Game Description
 	type=AttributeText
 	attribute=Description
@@ -70,7 +70,7 @@ info5:
 	width=580
 	height=64
 	wrap=1
-info6:
+info06:
 #	Screenshot Left
 	type=GameImage
 	pattern=SCR
@@ -79,7 +79,7 @@ info6:
 	y=-121
 	width=173
 	height=148
-info7:
+info07:
 #	Screenshot Right
 	type=GameImage
 	pattern=SCR2
@@ -88,7 +88,7 @@ info7:
 	y=-121
 	width=173
 	height=148
-info8:
+info08:
 	type=InfoHintText
 	color=#E6E6E6
 	x=272

--- a/src/themes.c
+++ b/src/themes.c
@@ -1144,14 +1144,14 @@ static void thmLoad(const char *themePath)
         thmLoadFonts(themeConfig, themePath, newT);
 
     int i = 1;
-    snprintf(path, sizeof(path), "main0");
+    snprintf(path, sizeof(path), "main00");
     while (addGUIElem(themePath, themeConfig, newT, &newT->mainElems, NULL, path))
-        snprintf(path, sizeof(path), "main%d", i++);
+        snprintf(path, sizeof(path), "main%02d", i++);
 
     i = 1;
-    snprintf(path, sizeof(path), "info0");
+    snprintf(path, sizeof(path), "info00");
     while (addGUIElem(themePath, themeConfig, newT, &newT->infoElems, NULL, path))
-        snprintf(path, sizeof(path), "info%d", i++);
+        snprintf(path, sizeof(path), "info%02d", i++);
 
     validateGUIElems(themePath, themeConfig, newT);
     configFree(themeConfig);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

This is a fix for a very old bug with custom themes that use the info page where if the main page elements go into double digits, e.g. "main10:", the single digit info page elements are not loaded, e.g. "info0:" to "info9:".

We are now using 2 digit integers, left padded with zeroes.
The default theme has been updated for compatibility.

From this commit, custom theme creators should use the new element naming convention.
E.g. "main00:", "main01:" etc.

Unfortunately this fix breaks custom theme compatibility, however, thanks to @dekkit, here is a .bat file that can be used to update custom themes very simply to be compatible. Read me is included.
https://www.sendspace.com/file/6w2zp1

Test build: https://www.sendspace.com/file/zwlonn

Test theme: https://www.sendspace.com/file/qutppm
