### PR TITLE
Fix main10 bug and language support update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ USB modes:
 | "CFG" | for saving per-game configuration files | all |
 | "ART" | for game art images | all |
 | "THM" | for themes support | all |
+| "LNG" | for translation support | all |
 | "CHT" | for cheats files | all |
 | "CFG-DEV" | for saving per-game configuration files, when used from a OPL dev build - aka beta build | all |
 

--- a/include/lang.h
+++ b/include/lang.h
@@ -283,6 +283,7 @@ typedef struct
     char *name;
 } language_t;
 
+int lngAddLanguages(char *path, const char *separator);
 void lngInit(void);
 char *lngGetValue(void);
 void lngEnd(void);

--- a/src/config.c
+++ b/src/config.c
@@ -98,6 +98,7 @@ static int parsePrefix(char *line, char *prefix)
     if (colpos && colpos != line) {
         // copy the name and the value
         strncpy(prefix, line, colpos - line);
+        prefix[colpos - line] = 0;
 
         return 1;
     } else {

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -258,6 +258,9 @@ static void ethInitSMB(void)
         sprintf(path, "%sTHM", ethPrefix);
         thmAddElements(path, "\\", ethGameList.mode);
 
+        sprintf(path, "%sLNG", ethPrefix);
+        lngAddLanguages(path, "\\");
+
         sbCreateFolders(ethPrefix, 1);
     } else if (gPCShareName[0] || !(gNetworkStartup >= ERROR_ETH_SMB_OPENSHARE)) {
         ethDisplayErrorStatus();

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -41,6 +41,8 @@ static void hddInitModules(void)
     char path[256];
     sprintf(path, "%sTHM", hddPrefix);
     thmAddElements(path, "/", hddGameList.mode);
+    sprintf(path, "%sLNG", hddPrefix);
+    lngAddLanguages(path, "/");
 
     sbCreateFolders(hddPrefix, 0);
 }

--- a/src/lang.c
+++ b/src/lang.c
@@ -309,12 +309,12 @@ static int lngLoadFont(const char *dir, const char *name)
 {
     char path[256];
 
-    snprintf(path, sizeof(path), "%s/font_%s.ttf", dir, name);
+    snprintf(path, sizeof(path), "%sfont_%s.ttf", dir, name);
     LOG("LANG Custom TTF font path: %s\n", path);
     if (fntLoadDefault(path) == 0)
         return 0;
 
-    snprintf(path, sizeof(path), "%s/font_%s.otf", dir, name);
+    snprintf(path, sizeof(path), "%sfont_%s.otf", dir, name);
     LOG("LANG Custom OTF font path: %s\n", path);
     if (fntLoadDefault(path) == 0)
         return 0;
@@ -326,7 +326,8 @@ static int lngLoadFont(const char *dir, const char *name)
 
 static int lngLoadFromFile(char *path, char *name)
 {
-    int HddStartMode;
+    char dir[128];
+
     file_buffer_t *fileBuffer = openFileBuffer(path, O_RDONLY, 1, 1024);
     if (fileBuffer) {
         // file exists, try to read it and load the custom lang
@@ -350,14 +351,11 @@ static int lngLoadFromFile(char *path, char *name)
             strId++;
         }
 
-        if (lngLoadFont(gBaseMCDir, name) != 0) {
-            if (lngLoadFont("mass0:LNG", name) != 0) {
-                if (configGetInt(configGetByType(CONFIG_OPL), CONFIG_OPL_HDD_MODE, &HddStartMode) && (HddStartMode == START_MODE_AUTO)) {
-                    hddLoadModules();
-                    lngLoadFont("pfs0:LNG", name);
-                }
-            }
-        }
+        int len = strlen(path) - strlen(name) - 9; //-4 for extension,  -5 for prefix
+        strncpy(dir, path, len);
+        dir[len] = '\0';
+
+        lngLoadFont(dir, name);
 
         return 1;
     }
@@ -374,7 +372,7 @@ static int lngReadEntry(int index, const char *path, const char *separator, cons
     if (!FIO_S_ISDIR(mode)) {
         if (strstr(name, ".lng") || strstr(name, ".LNG")) {
 
-            language_t *currLang = &languages[index];
+            language_t *currLang = &languages[nLanguages + index];
 
             // filepath for this language file
             int length = strlen(path) + 1 + strlen(name) + 1;

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -751,7 +751,7 @@ static void sbCreateFoldersFromList(const char *path, const char **folders)
 
 void sbCreateFolders(const char *path, int createDiscImgFolders)
 {
-    const char *basicFolders[] = { OPL_FOLDER, "THM", "ART", "VMC", "CHT", "APPS", NULL };
+    const char *basicFolders[] = { OPL_FOLDER, "THM", "LNG", "ART", "VMC", "CHT", "APPS", NULL };
     const char *discImgFolders[] = { "CD", "DVD", NULL };
 
     sbCreateFoldersFromList(path, basicFolders);

--- a/src/usbsupport.c
+++ b/src/usbsupport.c
@@ -117,6 +117,7 @@ static int usbNeedsUpdate(void)
     char path[256];
     static unsigned int OldGeneration = 0;
     static unsigned char ThemesLoaded = 0;
+    static unsigned char LanguagesLoaded = 0;
     int result = 0;
     iox_stat_t stat;
 
@@ -150,6 +151,13 @@ static int usbNeedsUpdate(void)
         sprintf(path, "%sTHM", usbPrefix);
         if (thmAddElements(path, "/", usbGameList.mode) > 0)
             ThemesLoaded = 1;
+    }
+
+    // update Languages
+    if (!LanguagesLoaded) {
+        sprintf(path, "%sLNG", usbPrefix);
+        if (lngAddLanguages(path, "/") > 0)
+            LanguagesLoaded = 1;
     }
 
     sbCreateFolders(usbPrefix, 1);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

This fixes the root cause of the bug. Tested and working.

Thanks once again to @rickgaiser 

Language support update. 

Language files can now be read from USB, HDD & SMB, .lng files need to be in LNG folder.. ttf and otf font files for these devices also now need to be in LNG folder..
Translations from MC remain the same as before.
OPL now creates a LNG folder on these devices just as it does ART, THM folders etc

Language font files are now loaded from the same location as your .lng files (supporting all devices).

Thanks to jolek for testing. 

Test Build
https://www.sendspace.com/file/5r7nn6

