### PR TITLE
Move libc to newlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ EE_ASM_DIR = asm/
 MAPFILE = opl.map
 EE_LDFLAGS += -Wl,-Map,$(MAPFILE)
 
-EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lgskit_toolkit -lpoweroff -lfileXio -lpatches -ljpeg -lpng -lz -ldebug -lm -lmc -lfreetype -lvux -lcdvd -lnetman -lps2ips -laudsrv -lc
+EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lgskit_toolkit -lpoweroff -lfileXio -lpatches -ljpeg -lpng -lz -ldebug -lm -lmc -lfreetype -lvux -lcdvd -lnetman -lps2ips -laudsrv
 EE_INCS += -I$(PS2SDK)/ports/include -I$(GSKIT)/include -I$(GSKIT)/ee/dma/include -I$(GSKIT)/ee/gs/include -I$(GSKIT)/ee/toolkit/include -Imodules/iopcore/common -Imodules/network/common -Imodules/hdd/common -Iinclude
 
 BIN2C = $(PS2SDK)/bin/bin2c

--- a/ee_core/Makefile
+++ b/ee_core/Makefile
@@ -46,14 +46,14 @@ endif
 
 EE_OBJS := $(EE_OBJS:%=$(EE_OBJS_DIR)%)
 
-EE_LDFLAGS = -nostartfiles -nostdlib -Tlinkfile -L$(PS2SDK)/ee/lib -s -Wl,-Map,$(MAPFILE)
+EE_LDFLAGS = -nostartfiles -L$(PS2SDK)/ee/lib
 EE_LIBS += -lpatches
 
 ifeq ($(PADEMU),1)
 EE_CFLAGS += -DPADEMU
 endif
 
-EE_LIBS += -lkernel-nopatch
+#EE_LIBS += -lkernel-nopatch
 
 $(EE_OBJS_DIR)%.o : $(EE_SRC_DIR)%.c
 	@mkdir -p $(EE_OBJS_DIR)

--- a/include/opl.h
+++ b/include/opl.h
@@ -11,6 +11,9 @@
 #include <string.h>
 #include <loadfile.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <limits.h>
 #include <sbv_patches.h>
 #include <libcdvd.h>
 #include <libpad.h>
@@ -32,7 +35,7 @@
 #include <debug.h>
 #include <ps2smb.h>
 #include "config.h"
-#include <sys/fcntl.h>
+#include <io_common.h>
 
 // Last Played Auto Start
 #include <time.h>

--- a/modules/iopcore/cdvdman/ioman_add.h
+++ b/modules/iopcore/cdvdman/ioman_add.h
@@ -1,6 +1,8 @@
 #ifndef _IOMAN_ADD_H_
 #define _IOMAN_ADD_H_
 
+#include <iox_stat.h>
+
 #define IOP_DT_FSEXT 0x10000000
 
 typedef struct _iop_ext_device

--- a/modules/network/SMSTCPIP/include/lwip/sockets.h
+++ b/modules/network/SMSTCPIP/include/lwip/sockets.h
@@ -34,6 +34,7 @@
 #ifndef __LWIP_SOCKETS_H__
 #define __LWIP_SOCKETS_H__
 #include "lwip/ip_addr.h"
+#include <sys/time.h>
 
 struct sockaddr_in
 {
@@ -208,15 +209,6 @@ typedef struct fd_set
 {
     unsigned char fd_bits[(FD_SETSIZE + 7) / 8];
 } fd_set;
-#endif
-
-#ifndef TIMEVAL
-#define TIMEVAL
-struct timeval
-{
-    long tv_sec;  /* seconds */
-    long tv_usec; /* and microseconds */
-};
 #endif
 
 int lwip_accept(int s, struct sockaddr *addr, socklen_t *addrlen);

--- a/modules/network/common/smstcpip-common.h
+++ b/modules/network/common/smstcpip-common.h
@@ -48,6 +48,8 @@
  *
  */
 
+#include <sys/time.h>
+
 typedef signed char err_t; /* lwIP error type.  */
 
 /* From src/include/lwip/pbuf.h:  */
@@ -292,15 +294,6 @@ typedef struct fd_set
 {
     unsigned char fd_bits[(FD_SETSIZE + 7) / 8];
 } fd_set;
-#endif
-
-#ifndef TIMEVAL
-#define TIMEVAL
-struct timeval
-{
-    long tv_sec;  /* seconds */
-    long tv_usec; /* and microseconds */
-};
 #endif
 
 #if !defined(INVALID_SOCKET)

--- a/src/OSDHistory.c
+++ b/src/OSDHistory.c
@@ -13,6 +13,9 @@
 #include <limits.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <sys/fcntl.h>
+#include <sys/unistd.h>
 
 #include "include/util.h"
 #include "include/OSDHistory.h"
@@ -35,7 +38,7 @@ int CreateSystemDataFolder(const char *path, char FolderRegionLetter)
 
     sprintf(fullpath, "%s/icon.sys", path);
     if ((fd = open(fullpath, O_RDONLY)) < 0) {
-        mkdir(path);
+        mkdir(path, 0777);
         if ((fd = open(fullpath, O_CREAT | O_TRUNC | O_WRONLY)) >= 0) {
            switch(FolderRegionLetter) {
                case 'I':

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -308,7 +308,7 @@ static void appDeleteItem(int id)
     if (appsList[id].legacy)
     {
         struct config_value_t *cur = appGetConfigValue(id);
-        fileXioRemove(cur->val);
+        unlink(cur->val);
         cur->key[0] = '\0';
         configApps->modified = 1;
         configWrite(configApps);
@@ -358,9 +358,9 @@ static void appLaunchItem(int id, config_set_t *configSet)
     //Retrieve configuration set by appGetConfig()
     configGetStr(configSet, CONFIG_ITEM_STARTUP, &filename);
 
-    fd = fileXioOpen(filename, O_RDONLY);
+    fd = open(filename, O_RDONLY);
     if (fd >= 0) {
-        fileXioClose(fd);
+        close(fd);
 
         //To keep the necessary device accessible, we will assume the mode that owns the device which contains the file to boot.
         mode = oplPath2Mode(filename);

--- a/src/atlas.c
+++ b/src/atlas.c
@@ -5,6 +5,7 @@
 */
 
 #include <stdio.h>
+#include <malloc.h>
 #include "include/atlas.h"
 #include "include/renderman.h"
 

--- a/src/cheatman.c
+++ b/src/cheatman.c
@@ -22,6 +22,7 @@
  * $Id$
  */
 
+#include <unistd.h>
 #include "include/cheatman.h"
 #include "include/ioman.h"
 

--- a/src/config.c
+++ b/src/config.c
@@ -380,8 +380,8 @@ static int configReadLegacyIP(void)
     if (fd >= 0) {
         char ipconfig[256];
         int size = getFileSize(fd);
-        fileXioRead(fd, &ipconfig, size);
-        fileXioClose(fd);
+        read(fd, &ipconfig, size);
+        close(fd);
 
         sscanf(ipconfig, "%d.%d.%d.%d %d.%d.%d.%d %d.%d.%d.%d", &ps2_ip[0], &ps2_ip[1], &ps2_ip[2], &ps2_ip[3],
                &ps2_netmask[0], &ps2_netmask[1], &ps2_netmask[2], &ps2_netmask[3],

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -668,10 +668,10 @@ static void ethLaunchGame(int id, config_set_t *configSet)
     }
 
     if (gPS2Logo) {
-        int fd = fileXioOpen(partname, O_RDONLY, 0666);
+        int fd = open(partname, O_RDONLY, 0666);
         if (fd >= 0) {
             EnablePS2Logo = CheckPS2Logo(fd, 0);
-            fileXioClose(fd);
+            close(fd);
         }
     }
 

--- a/src/gsm.c
+++ b/src/gsm.c
@@ -98,10 +98,10 @@ void PrepareGSM(char *cmdline)
 
     k576p_fix = 0;
     kGsDxDyOffsetSupported = 0;
-    if((fd = fileXioOpen("rom0:ROMVER", O_RDONLY)) >= 0) {
+    if((fd = open("rom0:ROMVER", O_RDONLY)) >= 0) {
         //Read ROM version
-        fileXioRead(fd, romver, sizeof(romver));
-        fileXioClose(fd);
+        read(fd, romver, sizeof(romver));
+        close(fd);
 
         strncpy(romverNum, romver, 4);
         romverNum[4] = '\0';

--- a/src/hdd.c
+++ b/src/hdd.c
@@ -294,7 +294,7 @@ int hddDeleteHDLGame(hdl_game_info_t *ginfo)
 
     sprintf(path, "hdd0:%s", ginfo->partition_name);
 
-    return fileXioRemove(path);
+    return unlink(path);
 }
 
 //-------------------------------------------------------------------------

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -94,8 +94,8 @@ static int CreateOPLPartition(const char *oplPart, const char *mountpoint)
     char cmd[43];
 
     sprintf(cmd, "%s,,,128M,PFS", oplPart);
-    if ((fd = fileXioOpen(cmd, O_CREAT | O_TRUNC | O_WRONLY)) >= 0) {
-        fileXioClose(fd);
+    if ((fd = open(cmd, O_CREAT | O_TRUNC | O_WRONLY)) >= 0) {
+        close(fd);
         result = fileXioFormat(mountpoint, oplPart, (const char *)&formatArg, sizeof(formatArg));
     } else {
         result = fd;

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -1,9 +1,9 @@
-#include <stdio.h>
 #include <string.h>
 #include <kernel.h>
 #include <sifrpc.h>
 
 #include "httpclient.h"
+#include "ioman.h"
 
 static SifRpcClientData_t SifRpcClient;
 static unsigned char RpcTxBuffer[256] ALIGNED(64);
@@ -12,7 +12,7 @@ static unsigned char RpcRxBuffer[64] ALIGNED(64);
 int HttpInit(void)
 {
     while (SifBindRpc(&SifRpcClient, 0x00001B14, 0) < 0 || SifRpcClient.server == NULL) {
-        printf("libhttpclient: bind failed\n");
+        LOG("libhttpclient: bind failed\n");
         nopdelay();
     }
 

--- a/src/ioman.c
+++ b/src/ioman.c
@@ -314,6 +314,9 @@ static char tbuf[2048];
 
 int ioPrintf(const char *format, ...)
 {
+    if (isIORunning == 0)
+        return -1;
+
     WaitSema(gIOPrintfSemaId);
 
     va_list args;

--- a/src/lang.c
+++ b/src/lang.c
@@ -371,7 +371,7 @@ char *lngGetValue(void)
 
 static int lngReadEntry(int index, const char *path, const char *separator, const char *name, unsigned int mode)
 {
-    if (!FIO_S_ISDIR(mode)) {
+    if (!S_ISDIR(mode)) {
         if (strstr(name, ".lng") || strstr(name, ".LNG")) {
 
             language_t *currLang = &languages[index];

--- a/src/nbns.c
+++ b/src/nbns.c
@@ -1,9 +1,9 @@
-#include <stdio.h>
 #include <string.h>
 #include <kernel.h>
 #include <sifrpc.h>
 
 #include "nbns.h"
+#include "ioman.h"
 
 static SifRpcClientData_t SifRpcClient;
 static unsigned char RpcBuffer[64] ALIGNED(64);
@@ -11,7 +11,7 @@ static unsigned char RpcBuffer[64] ALIGNED(64);
 int nbnsInit(void)
 {
     while (SifBindRpc(&SifRpcClient, 0x00001B13, 0) < 0 || SifRpcClient.server == NULL) {
-        printf("libnbns: bind failed\n");
+        LOG("libnbns: bind failed\n");
         nopdelay();
     }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -453,7 +453,7 @@ int oplScanApps(int (*callback)(const char *path, config_set_t *appConfig, void 
             {
                 while (fileXioDread(fd, &dirent) > 0)
                 {
-                    if (strcmp(dirent.name, ".") == 0 || strcmp(dirent.name, "..") == 0 || (!FIO_S_ISDIR(dirent.stat.mode)))
+                    if (strcmp(dirent.name, ".") == 0 || strcmp(dirent.name, "..") == 0 || (!S_ISDIR(dirent.stat.mode)))
                         continue;
 
                     snprintf(dir, sizeof(dir), "%s/%s", appsPath, dirent.name);
@@ -640,9 +640,9 @@ static int checkLoadConfigHDD(int types)
     int value;
 
     hddLoadModules();
-    value = fileXioOpen("pfs0:conf_opl.cfg", O_RDONLY);
+    value = open("pfs0:conf_opl.cfg", O_RDONLY);
     if (value >= 0) {
-        fileXioClose(value);
+        close(value);
         configEnd();
         configInit("pfs0:");
         value = configReadMulti(types);

--- a/src/ps2cnf.c
+++ b/src/ps2cnf.c
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "ps2cnf.h"
 #include "ioman.h"

--- a/src/ps2cnf.c
+++ b/src/ps2cnf.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "ps2cnf.h"
+#include "ioman.h"
 
 #define CNF_LEN_MAX 1024
 
@@ -85,7 +86,7 @@ int ps2cnfGetBootFile(const char *path, char *bootfile)
 
     if ((fd = fopen(path, "r")) == NULL)
     {
-        printf("Can't open %s\n", path);
+        LOG("Can't open %s\n", path);
         return ENOENT;
     }
 
@@ -99,7 +100,7 @@ int ps2cnfGetBootFile(const char *path, char *bootfile)
     if (fread(system_cnf, 1, size, fd) != size)
     {
         fclose(fd);
-        printf("Can't read %s\n", path);
+        LOG("Can't read %s\n", path);
         return EIO;
     }
     fclose(fd);

--- a/src/sound.c
+++ b/src/sound.c
@@ -31,6 +31,7 @@ struct sfxEffect {
     const char *name;
     void *buffer;
     int size;
+    int builtin;
 };
 
 static struct sfxEffect sfx_files[SFX_COUNT] = {
@@ -82,6 +83,7 @@ static int sfxRead(const char *full_path, struct sfxEffect *sfx)
 
     sfx->buffer = buffer;
     sfx->size = size;
+    sfx->builtin = 0;
 
     return 0;
 }
@@ -90,16 +92,22 @@ static void sfxInitDefaults(void)
 {
     sfx_files[SFX_BOOT].buffer = boot_adp;
     sfx_files[SFX_BOOT].size = size_boot_adp;
+    sfx_files[SFX_BOOT].builtin = 1;
     sfx_files[SFX_CANCEL].buffer = cancel_adp;
     sfx_files[SFX_CANCEL].size = size_cancel_adp;
+    sfx_files[SFX_CANCEL].builtin = 1;
     sfx_files[SFX_CONFIRM].buffer = confirm_adp;
     sfx_files[SFX_CONFIRM].size = size_confirm_adp;
+    sfx_files[SFX_CONFIRM].builtin = 1;
     sfx_files[SFX_CURSOR].buffer = cursor_adp;
     sfx_files[SFX_CURSOR].size = size_cursor_adp;
+    sfx_files[SFX_CURSOR].builtin = 1;
     sfx_files[SFX_MESSAGE].buffer = message_adp;
     sfx_files[SFX_MESSAGE].size = size_message_adp;
+    sfx_files[SFX_MESSAGE].builtin = 1;
     sfx_files[SFX_TRANSITION].buffer = transition_adp;
     sfx_files[SFX_TRANSITION].size = size_transition_adp;
+    sfx_files[SFX_TRANSITION].builtin = 1;
 }
 
 //Returns 0 (AUDSRV_ERR_NOERROR) if the sound was loaded successfully.
@@ -108,8 +116,10 @@ static int sfxLoad(struct sfxEffect *sfxData, audsrv_adpcm_t *sfx)
     int ret;
 
     ret = audsrv_load_adpcm(sfx, sfxData->buffer, sfxData->size);
-    free(sfxData->buffer);
-    sfxData->buffer = NULL; //Mark the buffer as freed.
+    if (sfxData->builtin == 0) {
+		free(sfxData->buffer);
+		sfxData->buffer = NULL; //Mark the buffer as freed.
+    }
 
     return ret;
 }

--- a/src/sound.c
+++ b/src/sound.c
@@ -4,6 +4,7 @@
 #include <audsrv.h>
 #include "include/sound.h"
 #include "include/opl.h"
+#include "include/ioman.h"
 #include "include/themes.h"
 
 //default sfx
@@ -52,10 +53,12 @@ static int sfxRead(const char *full_path, struct sfxEffect *sfx)
     void *buffer;
     int ret, size;
 
+    LOG("sfxRead('%s')\n", full_path);
+
     adpcm = fopen(full_path, "rb");
     if (adpcm == NULL)
     {
-        printf("Failed to open adpcm file %s\n", full_path);
+        LOG("Failed to open adpcm file %s\n", full_path);
         return -ENOENT;
     }
 
@@ -66,7 +69,7 @@ static int sfxRead(const char *full_path, struct sfxEffect *sfx)
     buffer = memalign(64, size);
     if (buffer == NULL)
     {
-        printf("Failed to allocate memory for SFX\n");
+        LOG("Failed to allocate memory for SFX\n");
         fclose(adpcm);
         return -ENOMEM;
     }
@@ -76,7 +79,7 @@ static int sfxRead(const char *full_path, struct sfxEffect *sfx)
 
     if(ret != size)
     {
-        printf("Failed to read SFX: %d (expected %d)\n", ret, size);
+        LOG("Failed to read SFX: %d (expected %d)\n", ret, size);
         free(buffer);
         return -EIO;
     }
@@ -136,7 +139,7 @@ static int getFadeDelay(void)
     bootSnd = fopen(boot_path, "rb");
     if (bootSnd == NULL)
     {
-        printf("Failed to open adpcm file %s\n", boot_path);
+        LOG("Failed to open adpcm file %s\n", boot_path);
         return -ENOENT;
     }
 
@@ -194,7 +197,7 @@ int sfxInit(int bootSnd)
             ret = sfxRead(full_path, &sfx_files[i]);
             if (ret != 0)
             {
-                printf("SFX: %s could not be loaded. Using default sound %d.\n", full_path, ret);
+                LOG("SFX: %s could not be loaded. Using default sound %d.\n", full_path, ret);
             }
         }
 
@@ -205,7 +208,7 @@ int sfxInit(int bootSnd)
         }
         else
         {
-           printf("SFX: failed to load %s, error %d\n", full_path, ret);
+           LOG("SFX: failed to load %s, error %d\n", full_path, ret);
         }
     }
 

--- a/src/system.c
+++ b/src/system.c
@@ -785,7 +785,7 @@ void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdv
     //Get the kernel to use our EELOAD module and to begin erasure after module storage. EE core will erase any memory before the module storage (if any).
     if(initKernel((void*)eh->entry, ModuleStorageEnd, &eeloadCopy, &initUserMemory) != 0)
     {   //Should not happen, but...
-        printf("Error - kernel is unsupported.\n");
+        LOG("Error - kernel is unsupported.\n");
         asm volatile("break\n");
     }
     sprintf(KernelConfig, "%u %u", (unsigned int)eeloadCopy, (unsigned int)initUserMemory);

--- a/src/system.c
+++ b/src/system.c
@@ -921,16 +921,16 @@ int sysCheckVMC(const char *prefix, const char *sep, char *name, int createSize,
     snprintf(path, sizeof(path), "%sVMC%s%s.bin", prefix, sep, name);
 
     if (createSize == -1)
-        fileXioRemove(path);
+        unlink(path);
     else {
-        int fd = fileXioOpen(path, O_RDONLY, FIO_S_IRUSR | FIO_S_IWUSR | FIO_S_IXUSR | FIO_S_IRGRP | FIO_S_IWGRP | FIO_S_IXGRP | FIO_S_IROTH | FIO_S_IWOTH | FIO_S_IXOTH);
+        int fd = open(path, O_RDONLY, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH);
         if (fd >= 0) {
-            size = fileXioLseek(fd, 0, SEEK_END);
+            size = lseek(fd, 0, SEEK_END);
 
             if (vmc_superblock) {
                 memset(vmc_superblock, 0, sizeof(vmc_superblock_t));
-                fileXioLseek(fd, 0, SEEK_SET);
-                fileXioRead(fd, (void *)vmc_superblock, sizeof(vmc_superblock_t));
+                lseek(fd, 0, SEEK_SET);
+                read(fd, (void *)vmc_superblock, sizeof(vmc_superblock_t));
 
                 LOG("SYSTEM File size  : 0x%X\n", size);
                 LOG("SYSTEM Magic      : %s\n", vmc_superblock->magic);
@@ -951,10 +951,10 @@ int sysCheckVMC(const char *prefix, const char *sep, char *name, int createSize,
             else
                 size /= 1048576;
 
-            fileXioClose(fd);
+            close(fd);
 
             if (createSize && (createSize != size))
-                fileXioRemove(path);
+                unlink(path);
         }
 
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -999,7 +999,7 @@ static void thmFree(theme_t *theme)
 
 static int thmReadEntry(int index, const char *path, const char *separator, const char *name, unsigned int mode)
 {
-    if (FIO_S_ISDIR(mode) && strstr(name, "thm_")) {
+    if (S_ISDIR(mode) && strstr(name, "thm_")) {
         theme_file_t *currTheme = &themes[nThemes + index];
 
         int length = strlen(name) - 4 + 1;

--- a/src/usbsupport.c
+++ b/src/usbsupport.c
@@ -38,16 +38,16 @@ int usbFindPartition(char *target, const char *name, int write)
         else
             sprintf(path, "mass%d:%s", i, name);
         if (write)
-            fd = fileXioOpen(path, O_WRONLY|O_TRUNC|O_CREAT, 0666);
+            fd = open(path, O_WRONLY|O_TRUNC|O_CREAT, 0666);
         else
-            fd = fileXioOpen(path, O_RDONLY);
+            fd = open(path, O_RDONLY);
 
         if (fd >= 0) {
             if (gUSBPrefix[0] != '\0')
                 sprintf(target, "mass%d:%s/", i, gUSBPrefix);
             else
                 sprintf(target, "mass%d:", i);
-            fileXioClose(fd);
+            close(fd);
             return 1;
         }
     }
@@ -232,7 +232,7 @@ static void usbLaunchGame(int id, config_set_t *configSet)
 
                 sprintf(vmc_path, "%sVMC/%s.bin", usbPrefix, vmc_name);
 
-                fd = fileXioOpen(vmc_path, O_RDONLY);
+                fd = open(vmc_path, O_RDONLY);
                 if (fd >= 0) {
                     if ((start = (unsigned int)fileXioIoctl(fd, USBMASS_IOCTL_GET_LBA, vmc_path)) != 0 && (startCluster = (unsigned int)fileXioIoctl(fd, USBMASS_IOCTL_GET_CLUSTER, vmc_path)) != 0) {
 
@@ -249,7 +249,7 @@ static void usbLaunchGame(int id, config_set_t *configSet)
                         }
                     }
 
-                    fileXioClose(fd);
+                    close(fd);
                 }
             }
         }
@@ -291,13 +291,13 @@ static void usbLaunchGame(int id, config_set_t *configSet)
                 sprintf(partname, "%sul.%08X.%s.%02x", usbPrefix, USBA_crc32(game->name), game->startup, i);
         }
 
-        fd = fileXioOpen(partname, O_RDONLY);
+        fd = open(partname, O_RDONLY);
         if (fd >= 0) {
             settings->LBAs[i] = fileXioIoctl(fd, USBMASS_IOCTL_GET_LBA, partname);
             if (gCheckUSBFragmentation) {
                 if ((startCluster = (unsigned int)fileXioIoctl(fd, USBMASS_IOCTL_GET_CLUSTER, partname)) == 0 || fileXioDevctl("xmass0:", XUSBHDFSD_CHECK_CLUSTER_CHAIN, &startCluster, 4, NULL, 0) == 0) {
 
-                    fileXioClose(fd);
+                    close(fd);
                     //Game is fragmented. Do not continue.
                     if (settings != NULL)
                         sbUnprepare(&settings->common);
@@ -310,7 +310,7 @@ static void usbLaunchGame(int id, config_set_t *configSet)
             if ((gPS2Logo) && (i == 0))
                 EnablePS2Logo = CheckPS2Logo(fd, 0);
 
-            fileXioClose(fd);
+            close(fd);
         } else {
             //Unable to open part of the game. Do not continue.
             if (settings != NULL)


### PR DESCRIPTION
This pull request is 1 of 5 pull requests in 5 different repositories. The goal of these pull requests is to completely remove libc from ps2sdk, and use newlib's libc. The result is both a much smaller codebase (19k lines removed, 1k lines added), and also will the ps2 development environment be a lot more standard. So porting an application to (or from) the ps2 will be more easy.

The interface between newlib and ps2sdk is now in the old ps2sdk/ee/libc folder, that compiles into libps2sdkc.a. All file io functions from newlib can now be used and will automatically map to fio*, or to fileXio* when it's loaded.

The downside to all of this, is that there are some minor incompatibility issues between newlib's libc, and ps2sdk's libc. For instance the include file <stdio.h> in ps2sdk included a lot of things from <unistd.h> and <fcntl.h>. So existing code will have to add a few extra header files. Another more problematic incompatibility is with the file 'open' function, and 'fioOpen' and 'fileXioOpen'. Becouse the flags O_RDONLY, O_WRONLY and O_RDWR have been defined differently in newlib and ps2sdk. This has to be fixed by no longer using fioOpen and fileXioOpen, and only using 'open'. 

This pull request series consists of 5 parts, resulting in a bootable working OPL elf file:
1. ps2toolchain, for removing a lot of hacks and updating the ps2 assembly files in newlib. Upgrading to newer versions of newlib will be a lot simpler after this patch. For now it's updated from v1.10.0 to v1.14.0
2. ps2sdk, mostly for removing libc
3. gsKit, for compatibility
4. ps2sdk-ports, for compatibility
5. open-ps2-loader, for compatbility and a bugfix 

It's likely thhat we will run into some small problems for the next couple of weeks, but I'll be actively trying to fix all the problems that may be caused by these changes.

**NOTE**: Do not merge these changes untill the changes to ps2dev have been merged.