### PR TITLE
Fix MC icon writing and small improvements

### DIFF
--- a/include/gui.h
+++ b/include/gui.h
@@ -127,6 +127,7 @@ void guiShowNetConfig();
 void guiShowParentalLockConfig();
 
 void guiDelay(int milliSeconds);
+void guiCheckNotifications(int checkTheme, int checkLang);
 
 /** Renders the given string on screen for the given function until it's io finishes 
 * @note The ptr pointer is watched for it's value. The IO is considered finished when the value becomes zero. 

--- a/include/opl.h
+++ b/include/opl.h
@@ -138,9 +138,6 @@ int gFadeDelay;
 int toggleSfx;
 
 int showCfgPopup;
-int showThmPopup;
-int showLngPopup;
-int popupSfxPlayed;
 
 #ifdef IGS
 #define IGS_VERSION "0.1"

--- a/include/util.h
+++ b/include/util.h
@@ -5,6 +5,7 @@
 
 int getmcID(void);
 int getFileSize(int fd);
+void checkMCFolder(void);
 int openFile(char *path, int mode);
 void *readFile(char *path, int align, int *size);
 int listDir(char *path, const char *separator, int maxElem,

--- a/src/gui.c
+++ b/src/gui.c
@@ -49,6 +49,10 @@ static int screenWidth;
 static int screenHeight;
 
 static int popupTimer;
+static int popupSfxPlayed;
+
+static int showThmPopup;
+static int showLngPopup;
 
 // forward decl.
 static void guiShow();
@@ -234,18 +238,23 @@ void guiShowAbout()
     toggleSfx = 0;
 }
 
-static void guiBootNotifications(void)
+void guiCheckNotifications(int checkTheme, int checkLang)
 {
     if (gEnableNotifications) {
-        if (thmGetGuiValue() != 0)
-            showThmPopup = 1;
+        if (checkTheme) {
+            if (thmGetGuiValue() != 0)
+                showThmPopup = 1;
+        }
 
-        if (lngGetGuiValue() != 0)   
-            showLngPopup = 1;
+        if (checkLang) {
+            if (lngGetGuiValue() != 0)
+                showLngPopup = 1;
+        }
 
         if (showThmPopup || showLngPopup || showCfgPopup) {
             popupSfxPlayed = 0;
-            popupTimer -= 30;
+            if (showCfgPopup)
+                popupTimer -= 30;
         }
     }
 }
@@ -2216,7 +2225,7 @@ void guiIntroLoop(void)
 void guiMainLoop(void)
 {
     guiResetNotifications();
-    guiBootNotifications();
+    guiCheckNotifications(1, 1);
 
     while (!gTerminate) {
         guiStartFrame();

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -739,14 +739,17 @@ void menuHandleInputMenu()
 void menuRenderMain()
 {
     // selected_item can't be NULL here as we only allow to switch to "Main" rendering when there is at least one device activated
-    theme_element_t *elem = gTheme->mainElems.first;
+    _menuRequestConfig();
 
+    WaitSema(menuSemaId);
+    theme_element_t *elem = gTheme->mainElems.first;
     while (elem) {
         if (elem->drawElem)
-            elem->drawElem(selected_item, selected_item->item->current, NULL, elem);
+            elem->drawElem(selected_item, selected_item->item->current, itemConfig, elem);
 
         elem = elem->next;
     }
+    SignalSema(menuSemaId);
 }
 
 void menuHandleInputMain()

--- a/src/opl.c
+++ b/src/opl.c
@@ -129,10 +129,7 @@ void moduleUpdateMenu(int mode, int themeChanged, int langChanged)
 
     if (langChanged) {
         guiUpdateScreenScale();
-        if (lngGetGuiValue() != 0) {
-            showLngPopup = 1;
-            popupSfxPlayed = 0;
-        }
+        guiCheckNotifications(0, langChanged);
     }
 
     // refresh Hints
@@ -160,10 +157,7 @@ void moduleUpdateMenu(int mode, int themeChanged, int langChanged)
     // refresh Cache
     if (themeChanged) {
         submenuRebuildCache(mod->subMenu);
-        if (thmGetGuiValue() != 0) {
-            showThmPopup = 1;
-            popupSfxPlayed = 0;
-        }
+        guiCheckNotifications(themeChanged, 0);
     }
 }
 
@@ -1027,6 +1021,9 @@ int saveConfig(int types, int showUI)
     if (showUI) {
         if (lscret) {
             char *path = configGetDir();
+            if (!strncmp(path, "mc", 2))
+                checkMCFolder();
+
             snprintf(notification, sizeof(notification), _l(_STR_SETTINGS_SAVED), path);
             if ((col_pos = strchr(notification, ':')) != NULL)
                 *(col_pos + 1) = '\0';


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

- Notifications code improvement.

- Fix MC icon writing and OPL folder creation.
MCs will be checked for OPL folder at boot, if not found OPL will check if MCs are inserted. If MC is inserted, OPL folder and MC icon will be created when saving config. If OPL folder already exists, opl.icn and icon.sys will be checked. If either or both do not exist, both will be written. When saving config to another device, OPL folder will not be created on MC.
This fixes issue #124 

- Allow AttributeText and AttributeImage to be used on Main page of themes.

Test build: https://www.sendspace.com/file/al2e18
Test theme: https://www.sendspace.com/file/36klio