### PR TITLE
Fix for Samurai Warriors 2 and Warriors Orochi series

### DIFF
--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -31,6 +31,8 @@
 #include <usbd.h>
 #include "ioman_add.h"
 
+#include <defs.h>
+
 #define MODNAME "cdvd_driver"
 IRX_ID(MODNAME, 1, 1);
 
@@ -421,6 +423,7 @@ static int cdvdman_read(u32 lsn, u32 sectors, void *buf)
 {
     cdvdman_stat.status = CDVD_STAT_READ;
 
+    buf = (void *)PHYSADDR(buf);
 #ifdef HDD_DRIVER //As of now, only the ATA interface requires this. We do this here to share cdvdman_buf.
     if ((u32)(buf)&3) {
         //For transfers to unaligned buffers, a double-copy is required to avoid stalling the device's DMA channel.


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Some games, such as Warriors Orochi (USA), calls `sceCdReadIOPMem` with a logical IOP RAM address (in this specific game, the passed pointer is a KSEG0 - a.k.a. Kernel Mode, Segment 0 - logical IOP RAM address) as its third parameter, which normally is not an issue, but on slim consoles (SCPH-75000 series and newer), the game crashes when being run from USB media. Fix this issue by ensuring that the provided pointer to IOP RAM is a physical address.

Note that a similar measure is applied at `cdvd_readee` function (see [/modules/iopcore/cdvdfsv/cdvdfsv.c line 807](/ifcaro/Open-PS2-Loader/blob/f112b26d6745989252e907cfee1e8ae6b86c0603/modules/iopcore/cdvdfsv/cdvdfsv.c#L807)):

As a side note, this fix should apply for related koei games (Warriors Orochi 2, Samurai Warriors 2 series and Dynasty Warriors 6), as those games do the same thing as Warriors Orochi regarding `sceCdReadIOPMem`.

Should fix #220

Test build: http://www.mediafire.com/file/up131y0287zyg2a/OPNPS2LD.ELF/file

**Update**: Here is a new test build, with the change proposed by @sp193 at [comment 14](/ifcaro/Open-PS2-Loader/pull/226#issuecomment-538709087)

Test build 2: http://www.mediafire.com/file/fxdolduex8sezw9/OPNPS2LD_test_02.ELF/file