### PR TITLE
Disables PS2 controller when using pademu

### DIFF
--- a/modules/pademu/pademu.c
+++ b/modules/pademu/pademu.c
@@ -214,6 +214,7 @@ void pademu_hookSio2man(sio2_transfer_data_t *td, Sio2McProc sio2proc)
             if (port2 == 1) { //2 sio cmds
                 if (mtap_inited) {
                     if (pad[0].enabled) {
+                        td->in[0] = 0x00;
                         sio2proc(td);
                         sio2proc = pademu;
                     }
@@ -221,7 +222,23 @@ void pademu_hookSio2man(sio2_transfer_data_t *td, Sio2McProc sio2proc)
                     if (pad[0].enabled && pad[1].enabled) { //emulating 2 pads
                         sio2proc = pademu;
                     } else if (pad[0].enabled || pad[1].enabled) { //only one
-                        sio2proc(td);
+                        if (pad[0].enabled) {
+                            td->in[0] = 0x00;
+                        } else if (pad[1].enabled) {
+                            for (ctrl = 5; ctrl < td->in_size - 3; ctrl++) {
+                                if (td->in[ctrl] == 0x01 && (td->in[ctrl + 1] & 0xF0) == 0x40 && td->in[ctrl + 2] == 0x00) {
+                                    if (ctrl != 5 && ctrl != 9 && ctrl != 21)
+                                        continue;
+                                    else
+                                        break;
+                                }
+                            }
+                            if (ctrl + 3 != td->in_size) {
+                                td->in[ctrl] = 0x00;
+                            }
+                        }
+						sio2proc(td);
+                        td->in[ctrl] = 0x01;
                         sio2proc = pademu;
                     }
                 }

--- a/modules/pademu/pademu.c
+++ b/modules/pademu/pademu.c
@@ -223,7 +223,7 @@ void pademu_hookSio2man(sio2_transfer_data_t *td, Sio2McProc sio2proc)
                         sio2proc = pademu;
                     } else if (pad[0].enabled || pad[1].enabled) { //only one
                         if (pad[0].enabled) {
-                            td->in[0] = 0x00;
+                            ctrl = 0;
                         } else if (pad[1].enabled) {
                             for (ctrl = 5; ctrl < td->in_size - 3; ctrl++) {
                                 if (td->in[ctrl] == 0x01 && (td->in[ctrl + 1] & 0xF0) == 0x40 && td->in[ctrl + 2] == 0x00) {
@@ -233,11 +233,12 @@ void pademu_hookSio2man(sio2_transfer_data_t *td, Sio2McProc sio2proc)
                                         break;
                                 }
                             }
-                            if (ctrl + 3 != td->in_size) {
-                                td->in[ctrl] = 0x00;
+                            if (ctrl + 3 == td->in_size) {
+                                return;
                             }
                         }
-						sio2proc(td);
+                        td->in[ctrl] = 0x00;
+                        sio2proc(td);
                         td->in[ctrl] = 0x01;
                         sio2proc = pademu;
                     }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Pull request related to issue: https://github.com/ifcaro/Open-PS2-Loader/issues/204#issue-443183270