### PR TITLE
VU0MixVec only flush used registers

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1014,9 +1014,8 @@ static void VU0MixVec(VU_VECTOR *a, VU_VECTOR *b, float mix, VU_VECTOR *res)
         "vmaddx.xyzw vf1, vf2, vf4x\n" // multiply vf2 by vf4.x add ACC, store the result in vf1
         "sqc2	vf1, (%[res])\n"       // transfer the result in acc to the ee
 #endif
-        : [res] "+r"(res)
-        : [a] "r"(a), [b] "r"(b), [mix] "r"(mix)
-        : "memory");
+        : [res] "+r"(res), "=m"(*res)
+        : [a] "r"(a), [b] "r"(b), [mix] "r"(mix), "m"(*a), "m"(*b));
 }
 
 static float guiCalcPerlin(float x, float y, float z)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

I did some more research this morning and realized that the `"memory"` clobber flushed all of the registers. The gcc documentation recommends listing additional inputs/outputs for the accessed memory and this is the approach I took. Technically all the used registers should be listed as scratch registers so that gcc knows not to use them but I could not get it to accept any of the register names `a0, $a0, etc` it would only accept 0-64. AFAIK gcc cannot use the v0 vector registers directly anyway so I don't think there will be an issue. If any problems ever arise then we can fallback to the `"memory"` clobber.

Here is the gcc documentation https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html#Clobbers-and-Scratch-Registers