### PR TITLE
themes: refresh hints for all modes when loading custom theme at boot up

### DIFF
--- a/src/themes.c
+++ b/src/themes.c
@@ -1267,7 +1267,7 @@ static void thmRebuildGuiNames(void)
 
 int thmAddElements(char *path, const char *separator, int mode)
 {
-    int result;
+    int result, i;
 
     result = listDir(path, separator, THM_MAX_FILES - nThemes, &thmReadEntry);
     nThemes += result;
@@ -1276,8 +1276,10 @@ int thmAddElements(char *path, const char *separator, int mode)
     const char *temp;
     if (configGetStr(configGetByType(CONFIG_OPL), "theme", &temp)) {
         LOG("THEMES Trying to set again theme: %s\n", temp);
-        if (thmSetGuiValue(thmFindGuiID(temp), 0))
-            moduleUpdateMenu(mode, 1, 0);
+        if (thmSetGuiValue(thmFindGuiID(temp), 0)) {
+            for (i = 0; i < MODE_COUNT; i++)
+                moduleUpdateMenu(i, 1, 0);
+        }
     }
 
     return result;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
This is just to fix #276 

when a theme loads at boot its only refreshing the hints of the mode/device the theme was loaded from leaving the others with outdated hints from the internal theme. 
