### PR TITLE
Small stuff

### DIFF
--- a/include/themes.h
+++ b/include/themes.h
@@ -126,7 +126,7 @@ theme_t *gTheme;
 void thmInit(void);
 void thmReinit(const char *path);
 void thmReloadScreenExtents(void);
-int thmAddElements(char *path, const char *separator, int mode);
+int thmAddElements(char *path, const char *separator, int forceRefresh);
 const char *thmGetValue(void);
 GSTEXTURE *thmGetTexture(unsigned int id);
 void thmEnd(void);

--- a/modules/iopcore/common/cdvdman.h
+++ b/modules/iopcore/common/cdvdman.h
@@ -10,7 +10,7 @@
 #define CDVDreg_HOWTO (*(volatile unsigned char *)0xBF402006)
 #define CDVDreg_ABORT (*(volatile unsigned char *)0xBF402007)
 #define CDVDreg_PWOFF (*(volatile unsigned char *)0xBF402008)
-#define CDVDreg_9 (*(volatile unsigned char *)0xBF402008)
+#define CDVDreg_9 (*(volatile unsigned char *)0xBF402009)
 #define CDVDreg_STATUS (*(volatile unsigned char *)0xBF40200A)
 #define CDVDreg_B (*(volatile unsigned char *)0xBF40200B)
 #define CDVDreg_C (*(volatile unsigned char *)0xBF40200C)

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -259,7 +259,7 @@ static void ethInitSMB(void)
         // update Themes
         char path[256];
         sprintf(path, "%sTHM", ethPrefix);
-        thmAddElements(path, "\\", ethGameList.mode);
+        thmAddElements(path, "\\", 1);
 
         sprintf(path, "%sLNG", ethPrefix);
         lngAddLanguages(path, "\\", ethGameList.mode);

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -43,7 +43,7 @@ static void hddInitModules(void)
     // update Themes
     char path[256];
     sprintf(path, "%sTHM", hddPrefix);
-    thmAddElements(path, "/", hddGameList.mode);
+    thmAddElements(path, "/", 1);
 
     sprintf(path, "%sLNG", hddPrefix);
     lngAddLanguages(path, "/", hddGameList.mode);

--- a/src/themes.c
+++ b/src/themes.c
@@ -193,16 +193,21 @@ static void drawAttributeText(struct menu_list *menu, struct submenu_list *item,
                     fntFitString(elem->font, mutableText->currentValue, elem->width);
             }
         }
-        if (mutableText->currentValue) {
-            if (mutableText->displayMode == DISPLAY_NEVER) {
-                if (!strncmp(mutableText->alias, "Size", 4))
-                    snprintf(result, sizeof(result), "%s MiB", mutableText->currentValue);
-                else
-                    snprintf(result, sizeof(result), mutableText->currentValue);
+    }
 
-                goto render;
-            }
+    if (mutableText->displayMode == DISPLAY_NEVER) {
+        if (mutableText->currentValue) {
+            if (!strncmp(mutableText->alias, "Size", 4))
+                snprintf(result, sizeof(result), "%s MiB", mutableText->currentValue);
+            else
+                snprintf(result, sizeof(result), mutableText->currentValue);
+
+            if (mutableText->sizingMode == SIZING_NONE)
+                fntRenderString(elem->font, elem->posX, elem->posY, elem->aligned, 0, 0, result, elem->color);
+            else
+                fntRenderString(elem->font, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, result, elem->color);
         }
+        return;
     }
 
     if (mutableText->displayMode == DISPLAY_DEFINED && mutableText->currentValue == NULL)
@@ -238,7 +243,6 @@ static void drawAttributeText(struct menu_list *menu, struct submenu_list *item,
             strcat(result, " MiB");
     }
 
-render:
     if (mutableText->sizingMode == SIZING_NONE)
         fntRenderString(elem->font, elem->posX, elem->posY, elem->aligned, 0, 0, result, elem->color);
     else

--- a/src/themes.c
+++ b/src/themes.c
@@ -1269,9 +1269,9 @@ static void thmRebuildGuiNames(void)
     guiThemesNames[nThemes + 1] = NULL;
 }
 
-int thmAddElements(char *path, const char *separator, int mode)
+int thmAddElements(char *path, const char *separator, int forceRefresh)
 {
-    int result;
+    int result, i;
 
     result = listDir(path, separator, THM_MAX_FILES - nThemes, &thmReadEntry);
     nThemes += result;
@@ -1280,8 +1280,10 @@ int thmAddElements(char *path, const char *separator, int mode)
     const char *temp;
     if (configGetStr(configGetByType(CONFIG_OPL), "theme", &temp)) {
         LOG("THEMES Trying to set again theme: %s\n", temp);
-        if (thmSetGuiValue(thmFindGuiID(temp), 0))
-            moduleUpdateMenu(mode, 1, 0);
+        if (thmSetGuiValue(thmFindGuiID(temp), 0) && forceRefresh) {
+            for (i = 0; i < MODE_COUNT; i++)
+                moduleUpdateMenu(i, 1, 0);
+        }
     }
 
     return result;
@@ -1297,7 +1299,7 @@ void thmInit(void)
     // initialize default internal
     thmLoad(NULL);
 
-    thmAddElements(gBaseMCDir, "/", -1);
+    thmAddElements(gBaseMCDir, "/", 0);
 }
 
 void thmReinit(const char *path)

--- a/src/usbsupport.c
+++ b/src/usbsupport.c
@@ -152,7 +152,7 @@ static int usbNeedsUpdate(void)
     // update Themes
     if (!ThemesLoaded) {
         sprintf(path, "%sTHM", usbPrefix);
-        if (thmAddElements(path, "/", usbGameList.mode) > 0)
+        if (thmAddElements(path, "/", 1) > 0)
             ThemesLoaded = 1;
     }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
This is to fix #276 
and #280 ( thanks to @AKuHAK )

When a theme loads at boot its only refreshing the hints of the mode/device the theme was loaded from leaving the others with outdated hints from the internal theme.. Loading custom themes from MC however happens much sooner in the init cycle at thmInit() so in this case we don't need to force refresh of all modes hints.

Attribute text was displaying incorrectly for custom themes.. fixed.
