### PR TITLE
Always use sio2man/padman/mcman/mcserv from ps2sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ MISC_OBJS =	icon_sys_A.o icon_sys_J.o icon_sys_C.o conf_theme_OPL.o \
 IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o usbhdfsd.o usbhdfsdfsv.o \
 		ps2atad.o hdpro_atad.o poweroff.o ps2hdd.o xhdd.o genvmc.o hdldsvr.o \
 		ps2dev9.o smsutils.o ps2ip.o smap.o isofs.o nbns-iop.o \
+		sio2man.o padman.o mcman.o mcserv.o \
 		httpclient-iop.o netman.o ps2ips.o \
 		usb_mcemu.o hdd_mcemu.o smb_mcemu.o \
 		iremsndpatch.o apemodpatch.o f2techioppatch.o cleareffects.o resetspu.o \
@@ -100,7 +101,7 @@ EE_ASM_DIR = asm/
 MAPFILE = opl.map
 EE_LDFLAGS += -Wl,-Map,$(MAPFILE)
 
-EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lgskit_toolkit -lpoweroff -lfileXio -lpatches -ljpeg -lpng -lz -ldebug -lm -lmc -lfreetype -lvux -lcdvd -lnetman -lps2ips -laudsrv
+EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lgskit_toolkit -lpoweroff -lfileXio -lpatches -ljpeg -lpng -lz -ldebug -lm -lmc -lfreetype -lvux -lcdvd -lnetman -lps2ips -laudsrv -lpadx
 EE_INCS += -I$(PS2SDK)/ports/include -I$(GSKIT)/include -I$(GSKIT)/ee/dma/include -I$(GSKIT)/ee/gs/include -I$(GSKIT)/ee/toolkit/include -Imodules/iopcore/common -Imodules/network/common -Imodules/hdd/common -Iinclude
 
 BIN2C = $(PS2SDK)/bin/bin2c
@@ -117,12 +118,9 @@ endif
 ifeq ($(DTL_T10000),1)
   EE_CFLAGS += -D_DTL_T10000
   EECORE_EXTRA_FLAGS += DTL_T10000=1
-  IOP_OBJS += sio2man.o padman.o mcman.o mcserv.o
-  EE_LIBS += -lpadx
   UDNL_SRC = modules/iopcore/udnl-t300
   UDNL_OUT = modules/iopcore/udnl-t300/udnl.irx
 else
-  EE_LIBS += -lpad
   UDNL_SRC = modules/iopcore/udnl
   UDNL_OUT = modules/iopcore/udnl/udnl.irx
 endif

--- a/src/opl.c
+++ b/src/opl.c
@@ -1345,11 +1345,7 @@ static void reset(void)
 {
     sysReset(SYS_LOAD_MC_MODULES | SYS_LOAD_USB_MODULES | SYS_LOAD_ISOFS_MODULE);
 
-#ifdef _DTL_T10000
     mcInit(MC_TYPE_XMC);
-#else
-    mcInit(MC_TYPE_MC);
-#endif
 }
 
 static void moduleCleanup(opl_io_module_t *mod, int exception, int modeSelected)

--- a/src/system.c
+++ b/src/system.c
@@ -215,25 +215,14 @@ void sysReset(int modload_mask)
     sysLoadModuleBuffer(&iomanx_irx, size_iomanx_irx, 0, NULL);
     sysLoadModuleBuffer(&filexio_irx, size_filexio_irx, 0, NULL);
 
-#ifdef _DTL_T10000
-    SifExecModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, NULL, NULL);
+    sysLoadModuleBuffer(&sio2man_irx, size_sio2man_irx, 0, NULL);
 
     if (modload_mask & SYS_LOAD_MC_MODULES) {
-        SifExecModuleBuffer(&mcman_irx, size_mcman_irx, 0, NULL, NULL);
-        SifExecModuleBuffer(&mcserv_irx, size_mcserv_irx, 0, NULL, NULL);
+        sysLoadModuleBuffer(&mcman_irx, size_mcman_irx, 0, NULL);
+        sysLoadModuleBuffer(&mcserv_irx, size_mcserv_irx, 0, NULL);
     }
 
-    SifExecModuleBuffer(&padman_irx, size_padman_irx, 0, NULL, NULL);
-#else
-    SifLoadModule("rom0:SIO2MAN", 0, NULL);
-
-    if (modload_mask & SYS_LOAD_MC_MODULES) {
-        SifLoadModule("rom0:MCMAN", 0, NULL);
-        SifLoadModule("rom0:MCSERV", 0, NULL);
-    }
-
-    SifLoadModule("rom0:PADMAN", 0, NULL);
-#endif
+    sysLoadModuleBuffer(&padman_irx, size_padman_irx, 0, NULL);
 
     sysLoadModuleBuffer(&poweroff_irx, size_poweroff_irx, 0, NULL);
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Always use sio2man, padman, mcman, and mcserv from ps2sdk.  
This reduces the differences between the DTL_T10000 and non-DTL_T10000 builds of OPL.  
