### PR TITLE
Small improvements to Apps system

### DIFF
--- a/include/iosupport.h
+++ b/include/iosupport.h
@@ -104,6 +104,8 @@ typedef struct
 
     void (*itemGetLegacyAppsPath)(char *path, int max);
 
+    void (*itemGetLegacyAppsInfo)(char *path, int max, char *name);
+
     void (*itemInit)(void);
 
     /** @return 1 if update is needed, 0 otherwise */

--- a/include/iosupport.h
+++ b/include/iosupport.h
@@ -102,6 +102,8 @@ typedef struct
     /// @return path to applications storage on the device (set callback to NULL if not applicable).
     void (*itemGetAppsPath)(char *path, int max);
 
+    void (*itemGetLegacyAppsPath)(char *path, int max);
+
     void (*itemInit)(void);
 
     /** @return 1 if update is needed, 0 otherwise */

--- a/include/opl.h
+++ b/include/opl.h
@@ -72,6 +72,7 @@ int oplGetAppImage(const char *device, char *folder, int isRelative, char *value
 int oplScanApps(int (*callback)(const char *path, config_set_t *appConfig, void *arg), void *arg);
 int oplShouldAppsUpdate(void);
 config_set_t *oplGetLegacyAppsConfig(void);
+config_set_t *oplGetLegacyAppsInfo(char *name);
 
 void setErrorMessage(int strId);
 void setErrorMessageWithCode(int strId, int error);

--- a/include/opl.h
+++ b/include/opl.h
@@ -71,6 +71,7 @@ int oplPath2Mode(const char *path);
 int oplGetAppImage(const char *device, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm);
 int oplScanApps(int (*callback)(const char *path, config_set_t *appConfig, void *arg), void *arg);
 int oplShouldAppsUpdate(void);
+config_set_t *oplGetLegacyAppsConfig(void);
 
 void setErrorMessage(int strId);
 void setErrorMessageWithCode(int strId, int error);

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -356,8 +356,10 @@ static config_set_t *appGetConfig(int id)
     config_set_t *config;
 
     if (appsList[id].legacy) {
-        config = configAlloc(0, NULL, NULL);
         struct config_value_t *cur = appGetConfigValue(id);
+        config = oplGetLegacyAppsInfo(appGetELFName(cur->val));
+        configRead(config);
+
         configSetStr(config, CONFIG_ITEM_NAME, appGetELFName(cur->val));
         configSetStr(config, CONFIG_ITEM_LONGNAME, cur->key);
         configSetStr(config, CONFIG_ITEM_STARTUP, cur->val);
@@ -406,6 +408,6 @@ static void appShutdown(void)
 }
 
 static item_list_t appItemList = {
-    APP_MODE, -1, 0, MODE_FLAG_NO_COMPAT | MODE_FLAG_NO_UPDATE, MENU_MIN_INACTIVE_FRAMES, APP_MODE_UPDATE_DELAY, "Applications", _STR_APPS, NULL, NULL, &appInit, &appNeedsUpdate, &appUpdateItemList,
+    APP_MODE, -1, 0, MODE_FLAG_NO_COMPAT | MODE_FLAG_NO_UPDATE, MENU_MIN_INACTIVE_FRAMES, APP_MODE_UPDATE_DELAY, "Applications", _STR_APPS, NULL, NULL, NULL, &appInit, &appNeedsUpdate, &appUpdateItemList,
     &appGetItemCount, NULL, &appGetItemName, &appGetItemNameLength, &appGetItemStartup, &appDeleteItem, &appRenameItem, &appLaunchItem,
     &appGetConfig, &appGetImage, &appCleanUp, &appShutdown, NULL, APP_ICON};

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -125,6 +125,9 @@ static int appNeedsUpdate(void)
     if (oplShouldAppsUpdate())
         update = 1;
 
+    if (update)
+        configApps = oplGetLegacyAppsConfig();
+
     return update;
 }
 

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -83,7 +83,7 @@ void appInit(void)
     LOG("APPSUPPORT Init\n");
     appForceUpdate = 1;
     configGetInt(configGetByType(CONFIG_OPL), "app_frames_delay", &appItemList.delay);
-    configApps = configGetByType(CONFIG_APPS);
+    configApps = oplGetLegacyAppsConfig();
     appsList = NULL;
     appItemList.enabled = 1;
 }
@@ -278,7 +278,7 @@ static char *appGetItemStartup(int id)
 {
     if (appsList[id].legacy) {
         struct config_value_t *cur = appGetConfigValue(id);
-        return cur->val;
+        return appGetELFName(cur->val);
     } else {
         return appsList[id].boot;
     }
@@ -406,6 +406,6 @@ static void appShutdown(void)
 }
 
 static item_list_t appItemList = {
-    APP_MODE, -1, 0, MODE_FLAG_NO_COMPAT | MODE_FLAG_NO_UPDATE, MENU_MIN_INACTIVE_FRAMES, APP_MODE_UPDATE_DELAY, "Applications", _STR_APPS, NULL, &appInit, &appNeedsUpdate, &appUpdateItemList,
+    APP_MODE, -1, 0, MODE_FLAG_NO_COMPAT | MODE_FLAG_NO_UPDATE, MENU_MIN_INACTIVE_FRAMES, APP_MODE_UPDATE_DELAY, "Applications", _STR_APPS, NULL, NULL, &appInit, &appNeedsUpdate, &appUpdateItemList,
     &appGetItemCount, NULL, &appGetItemName, &appGetItemNameLength, &appGetItemStartup, &appDeleteItem, &appRenameItem, &appLaunchItem,
     &appGetConfig, &appGetImage, &appCleanUp, &appShutdown, NULL, APP_ICON};

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -777,8 +777,13 @@ static void ethGetLegacyAppsPath(char *path, int max)
     snprintf(path, max, "%sconf_apps.cfg", ethPrefix);
 }
 
+static void ethGetLegacyAppsInfo(char *path, int max, char *name)
+{
+    snprintf(path, max, "%s" OPL_FOLDER "\\%s.cfg", ethPrefix, name);
+}
+
 static item_list_t ethGameList = {
-    ETH_MODE, 1, 0, 0, MENU_MIN_INACTIVE_FRAMES, ETH_MODE_UPDATE_DELAY, "ETH Games", _STR_NET_GAMES, &ethGetAppsPath, &ethGetLegacyAppsPath, &ethInit, &ethNeedsUpdate,
+    ETH_MODE, 1, 0, 0, MENU_MIN_INACTIVE_FRAMES, ETH_MODE_UPDATE_DELAY, "ETH Games", _STR_NET_GAMES, &ethGetAppsPath, &ethGetLegacyAppsPath, &ethGetLegacyAppsInfo, &ethInit, &ethNeedsUpdate,
     &ethUpdateGameList, &ethGetGameCount, &ethGetGame, &ethGetGameName, &ethGetGameNameLength, &ethGetGameStartup, &ethDeleteGame, &ethRenameGame,
     &ethLaunchGame, &ethGetConfig, &ethGetImage, &ethCleanUp, &ethShutdown, &ethCheckVMC, ETH_ICON};
 

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -767,13 +767,18 @@ static int ethCheckVMC(char *name, int createSize)
     return sysCheckVMC(ethPrefix, "\\", name, createSize, NULL);
 }
 
-static void smbGetAppsPath(char *path, int max)
+static void ethGetAppsPath(char *path, int max)
 {
     snprintf(path, max, "%sAPPS", ethPrefix);
 }
 
+static void ethGetLegacyAppsPath(char *path, int max)
+{
+    snprintf(path, max, "%sconf_apps.cfg", ethPrefix);
+}
+
 static item_list_t ethGameList = {
-    ETH_MODE, 1, 0, 0, MENU_MIN_INACTIVE_FRAMES, ETH_MODE_UPDATE_DELAY, "ETH Games", _STR_NET_GAMES, &smbGetAppsPath, &ethInit, &ethNeedsUpdate,
+    ETH_MODE, 1, 0, 0, MENU_MIN_INACTIVE_FRAMES, ETH_MODE_UPDATE_DELAY, "ETH Games", _STR_NET_GAMES, &ethGetAppsPath, &ethGetLegacyAppsPath, &ethInit, &ethNeedsUpdate,
     &ethUpdateGameList, &ethGetGameCount, &ethGetGame, &ethGetGameName, &ethGetGameNameLength, &ethGetGameStartup, &ethDeleteGame, &ethRenameGame,
     &ethLaunchGame, &ethGetConfig, &ethGetImage, &ethCleanUp, &ethShutdown, &ethCheckVMC, ETH_ICON};
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -596,7 +596,12 @@ static void hddGetAppsPath(char *path, int max)
     snprintf(path, max, "%s/APPS", hddPrefix);
 }
 
+static void hddGetLegacyAppsPath(char *path, int max)
+{
+    snprintf(path, max, "%sconf_apps.cfg", hddPrefix);
+}
+
 static item_list_t hddGameList = {
-    HDD_MODE, 0, 0, MODE_FLAG_COMPAT_DMA, MENU_MIN_INACTIVE_FRAMES, HDD_MODE_UPDATE_DELAY, "HDD Games", _STR_HDD_GAMES, &hddGetAppsPath, &hddInit, &hddNeedsUpdate, &hddUpdateGameList,
+    HDD_MODE, 0, 0, MODE_FLAG_COMPAT_DMA, MENU_MIN_INACTIVE_FRAMES, HDD_MODE_UPDATE_DELAY, "HDD Games", _STR_HDD_GAMES, &hddGetAppsPath, &hddGetLegacyAppsPath, &hddInit, &hddNeedsUpdate, &hddUpdateGameList,
     &hddGetGameCount, &hddGetGame, &hddGetGameName, &hddGetGameNameLength, &hddGetGameStartup, &hddDeleteGame, &hddRenameGame,
     &hddLaunchGame, &hddGetConfig, &hddGetImage, &hddCleanUp, &hddShutdown, &hddCheckVMC, HDD_ICON};

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -601,7 +601,12 @@ static void hddGetLegacyAppsPath(char *path, int max)
     snprintf(path, max, "%sconf_apps.cfg", hddPrefix);
 }
 
+static void hddGetLegacyAppsInfo(char *path, int max, char *name)
+{
+    snprintf(path, max, "%s" OPL_FOLDER "/%s.cfg", hddPrefix, name);
+}
+
 static item_list_t hddGameList = {
-    HDD_MODE, 0, 0, MODE_FLAG_COMPAT_DMA, MENU_MIN_INACTIVE_FRAMES, HDD_MODE_UPDATE_DELAY, "HDD Games", _STR_HDD_GAMES, &hddGetAppsPath, &hddGetLegacyAppsPath, &hddInit, &hddNeedsUpdate, &hddUpdateGameList,
+    HDD_MODE, 0, 0, MODE_FLAG_COMPAT_DMA, MENU_MIN_INACTIVE_FRAMES, HDD_MODE_UPDATE_DELAY, "HDD Games", _STR_HDD_GAMES, &hddGetAppsPath, &hddGetLegacyAppsPath, &hddGetLegacyAppsInfo, &hddInit, &hddNeedsUpdate, &hddUpdateGameList,
     &hddGetGameCount, &hddGetGame, &hddGetGameName, &hddGetGameNameLength, &hddGetGameStartup, &hddDeleteGame, &hddRenameGame,
     &hddLaunchGame, &hddGetConfig, &hddGetImage, &hddCleanUp, &hddShutdown, &hddCheckVMC, HDD_ICON};

--- a/src/opl.c
+++ b/src/opl.c
@@ -482,6 +482,34 @@ config_set_t *oplGetLegacyAppsConfig(void)
     return appConfig;
 }
 
+config_set_t *oplGetLegacyAppsInfo(char *name)
+{
+    int i, fd;
+    item_list_t *listSupport;
+    config_set_t *appConfig;
+    char appsPath[128];
+
+    for (i = MODE_COUNT; i >= 0; i--) {
+        listSupport = list_support[i].support;
+        if ((listSupport != NULL) && (listSupport->enabled) && (listSupport->itemGetLegacyAppsInfo != NULL)) {
+            listSupport->itemGetLegacyAppsInfo(appsPath, sizeof(appsPath), name);
+
+            fd = openFile(appsPath, O_RDONLY);
+            if (fd >= 0) {
+                appConfig = configAlloc(0, NULL, appsPath);
+                close(fd);
+                return appConfig;
+            }
+        }
+    }
+
+    /* Apps config not found on any device, go with last tested device.
+       Does not matter if the config file could be loaded or not */
+    appConfig = configAlloc(0, NULL, appsPath);
+
+    return appConfig;
+}
+
 // ----------------------------------------------------------
 // ----------------------- Updaters -------------------------
 // ----------------------------------------------------------

--- a/src/opl.c
+++ b/src/opl.c
@@ -446,6 +446,42 @@ int oplShouldAppsUpdate(void)
     return result;
 }
 
+config_set_t *oplGetLegacyAppsConfig(void)
+{
+    int i, fd;
+    item_list_t *listSupport;
+    config_set_t *appConfig;
+    char appsPath[128];
+
+    snprintf(appsPath, sizeof(appsPath), "mc?:OPL/conf_apps.cfg");
+    fd = openFile(appsPath, O_RDONLY);
+    if (fd >= 0) {
+        appConfig = configAlloc(CONFIG_APPS, NULL, appsPath);
+        close(fd);
+        return appConfig;
+    }
+
+    for (i = MODE_COUNT; i >= 0; i--) {
+        listSupport = list_support[i].support;
+        if ((listSupport != NULL) && (listSupport->enabled) && (listSupport->itemGetLegacyAppsPath != NULL)) {
+            listSupport->itemGetLegacyAppsPath(appsPath, sizeof(appsPath));
+
+            fd = openFile(appsPath, O_RDONLY);
+            if (fd >= 0) {
+                appConfig = configAlloc(CONFIG_APPS, NULL, appsPath);
+                close(fd);
+                return appConfig;
+            }
+        }
+    }
+
+    /* Apps config not found on any device, go with last tested device.
+       Does not matter if the config file could be loaded or not */
+    appConfig = configAlloc(CONFIG_APPS, NULL, appsPath);
+
+    return appConfig;
+}
+
 // ----------------------------------------------------------
 // ----------------------- Updaters -------------------------
 // ----------------------------------------------------------

--- a/src/usbsupport.c
+++ b/src/usbsupport.c
@@ -443,7 +443,12 @@ static void usbGetLegacyAppsPath(char *path, int max)
     snprintf(path, max, "%sconf_apps.cfg", usbPrefix);
 }
 
+static void usbGetLegacyAppsInfo(char *path, int max, char *name)
+{
+    snprintf(path, max, "%s" OPL_FOLDER "/%s.cfg", usbPrefix, name);
+}
+
 static item_list_t usbGameList = {
-    USB_MODE, 2, 0, 0, MENU_MIN_INACTIVE_FRAMES, USB_MODE_UPDATE_DELAY, "USB Games", _STR_USB_GAMES, &usbGetAppsPath, &usbGetLegacyAppsPath, &usbInit, &usbNeedsUpdate,
+    USB_MODE, 2, 0, 0, MENU_MIN_INACTIVE_FRAMES, USB_MODE_UPDATE_DELAY, "USB Games", _STR_USB_GAMES, &usbGetAppsPath, &usbGetLegacyAppsPath, &usbGetLegacyAppsInfo, &usbInit, &usbNeedsUpdate,
     &usbUpdateGameList, &usbGetGameCount, &usbGetGame, &usbGetGameName, &usbGetGameNameLength, &usbGetGameStartup, &usbDeleteGame, &usbRenameGame,
     &usbLaunchGame, &usbGetConfig, &usbGetImage, &usbCleanUp, &usbShutdown, &usbCheckVMC, USB_ICON};

--- a/src/usbsupport.c
+++ b/src/usbsupport.c
@@ -438,7 +438,12 @@ static void usbGetAppsPath(char *path, int max)
     snprintf(path, max, "%sAPPS", usbPrefix);
 }
 
+static void usbGetLegacyAppsPath(char *path, int max)
+{
+    snprintf(path, max, "%sconf_apps.cfg", usbPrefix);
+}
+
 static item_list_t usbGameList = {
-    USB_MODE, 2, 0, 0, MENU_MIN_INACTIVE_FRAMES, USB_MODE_UPDATE_DELAY, "USB Games", _STR_USB_GAMES, &usbGetAppsPath, &usbInit, &usbNeedsUpdate,
+    USB_MODE, 2, 0, 0, MENU_MIN_INACTIVE_FRAMES, USB_MODE_UPDATE_DELAY, "USB Games", _STR_USB_GAMES, &usbGetAppsPath, &usbGetLegacyAppsPath, &usbInit, &usbNeedsUpdate,
     &usbUpdateGameList, &usbGetGameCount, &usbGetGame, &usbGetGameName, &usbGetGameNameLength, &usbGetGameStartup, &usbDeleteGame, &usbRenameGame,
     &usbLaunchGame, &usbGetConfig, &usbGetImage, &usbCleanUp, &usbShutdown, &usbCheckVMC, USB_ICON};


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
Closes #295 ..This isn't really a 'bug' as legacy apps system works as it is supposed to (being part of the cfg index) but I did this since it seems some people want it.

Legacy apps system will now read conf_apps.cfg from any device regardless of where your main opl cfg is.. additionally you will be able to have "appname.elf.cfg" in your CFG/CFG-DEV folder to display info page stuff (new apps system already does this..better imo).. and I also quickly added getting the app size to both the legacy app system and new app system, cause it looked weird without it.. doing things this way conf_apps.cfg could possibly be removed from the cfg index but I left it as is for now.

What do you guys reckon?
