### PR TITLE
Fix: Broken DVD9 games with SMB

### DIFF
--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -14,6 +14,7 @@
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioMount("iso:", ***), fileXioUmount("iso:")
 #include <io_common.h>   // FIO_MT_RDONLY
+#include <ps2sdkapi.h>   // lseek64
 
 /// internal linked list used to populate the list from directory listing
 struct game_list_t
@@ -508,7 +509,7 @@ int sbProbeISO9660_64(const char *path, base_game_info_t *game, u32 layer1_offse
     result = -1;
     if (game->media == SCECdPS2DVD) { //Only DVDs can have multiple layers.
         if ((fd = open(path, O_RDONLY, 0666)) >= 0) {
-            if (lseek(fd, (u64)layer1_offset * 2048, SEEK_SET) == (u64)layer1_offset * 2048) {
+            if (lseek64(fd, (u64)layer1_offset * 2048, SEEK_SET) == (u64)layer1_offset * 2048) {
                 if ((read(fd, buffer, sizeof(buffer)) == sizeof(buffer)) &&
                     ((buffer[0x00] == 1) && (!strncmp(&buffer[0x01], "CD001", 5)))) {
                     result = 0;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [x] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

This PR fixes the bug reported in https://github.com/ps2homebrew/Open-PS2-Loader/issues/301, introduced after https://github.com/ps2homebrew/Open-PS2-Loader/commit/4c00bcb2c224b5a79488ef7c0ef72ea3cbc3c4a1

Thanks to @sp193 for finding the cause of the issue.