### PR TITLE
UDNL: Fix to GetFileStatFromImage

### DIFF
--- a/modules/iopcore/udnl/udnl.c
+++ b/modules/iopcore/udnl/udnl.c
@@ -153,7 +153,6 @@ static struct RomdirFileStat *GetFileStatFromImage(const struct RomImgData *Imag
     unsigned int i, offset, ExtInfoOffset;
     unsigned char filename_temp[12];
     const struct RomDirEntry *RomdirEntry;
-    struct RomdirFileStat *result;
 
     offset = 0;
     ExtInfoOffset = 0;
@@ -177,8 +176,6 @@ static struct RomdirFileStat *GetFileStatFromImage(const struct RomImgData *Imag
 
                 if (RomdirEntry->ExtInfoEntrySize > 0) {
                     stat->extinfo = (void *)((unsigned int)ImageStat->RomdirEnd + ExtInfoOffset);
-                    result = stat;
-                    goto end;
                 }
               
                 return stat;
@@ -188,13 +185,9 @@ static struct RomdirFileStat *GetFileStatFromImage(const struct RomImgData *Imag
             ExtInfoOffset += RomdirEntry->ExtInfoEntrySize;
             RomdirEntry++;
         } while (((unsigned int *)RomdirEntry->name)[0] != 0x00000000);
-
-        result = NULL;
-    } else
-        result = NULL;
-
-end:
-    return result;
+    }
+	
+    return NULL;
 }
 
 /* 0x0000055c */

--- a/modules/iopcore/udnl/udnl.c
+++ b/modules/iopcore/udnl/udnl.c
@@ -180,6 +180,8 @@ static struct RomdirFileStat *GetFileStatFromImage(const struct RomImgData *Imag
                     result = stat;
                     goto end;
                 }
+              
+                return stat;
             }
 
             offset += (RomdirEntry->size + 0xF) & 0xFFFFFFF0;


### PR DESCRIPTION
## Pull Request checklist

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

This PR fixes a minor bug in GetFileStatFromImage, where the UDNL clone would reject an image's IOPBTCONF if it had no ext info. However, the boot ROM UDNL will be successful regardless of the presence of any ext info.