### PR TITLE
Language and MC fix

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -354,9 +354,7 @@ static int lngLoadFromFile(char *path, char *name)
 
         LOG("LANG Loaded %d entries\n", strId);
 
-        // remember how many entries were read from the file (for the free later)
-        nValidEntries = strId;
-
+        int newEntries = strId;
         // if necessary complete lang with default internal
         while (strId < LANG_STR_COUNT) {
             LOG("LANG Default entry added: %s\n", internalEnglish[strId]);
@@ -365,6 +363,9 @@ static int lngLoadFromFile(char *path, char *name)
         }
         lang_strs = newL;
         lngFreeFromFile(curL);
+
+        // remember how many entries were read from the file (for the free later)
+        nValidEntries = newEntries;
 
         int len = strlen(path) - strlen(name) - 9; //-4 for extension,  -5 for prefix
         memcpy(dir, path, len);

--- a/src/util.c
+++ b/src/util.c
@@ -50,12 +50,12 @@ static int checkMC()
 
         mcGetInfo(0, 0, &memcardtype, &dummy, &dummy);
         mcSync(0, NULL, &ret);
-        mc0_is_ps2card = (ret == 0 && memcardtype == 2);
+        mc0_is_ps2card = (ret == -1 && memcardtype == 2);
         mc0_has_folder = 0;
 
         mcGetInfo(1, 0, &memcardtype, &dummy, &dummy);
         mcSync(0, NULL, &ret);
-        mc1_is_ps2card = (ret == 0 && memcardtype == 2);
+        mc1_is_ps2card = (ret == -1 && memcardtype == 2);
         mc1_has_folder = 0;
 
         if (mc0_is_ps2card) {


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
fixes #321 as seen [here](https://github.com/ps2dev/ps2sdk/blob/3c4e3ef0df01c49bdb4620c32d3496eeab5f7f81/ee/rpc/memorycard/samples/mc_example.c#L70) the first call to mcGetInfo() returns a value of -1 if a formatted mc is found.

Languages were freeing based on number of valid entries for the newly selected language rather than the one being freed.
