### PR TITLE
Improve debugging, fix #339 and workaround #300

### DIFF
--- a/ee_core/include/igs_api.h
+++ b/ee_core/include/igs_api.h
@@ -118,10 +118,10 @@
 //GSM Stuff
 struct GSMSourceSetGsCrt
 {
-    unsigned int interlace;
-    unsigned int mode;
-    unsigned int ffmd;
-};
+    s16 interlace;
+    s16 mode;
+    s16 ffmd;
+} __attribute__((packed));
 
 struct GSMSourceGSRegs
 {
@@ -136,7 +136,7 @@ struct GSMSourceGSRegs
     u64 display1;
     u64 dispfb2;
     u64 display2;
-};
+} __attribute__((packed));
 
 extern struct GSMSourceSetGsCrt GSMSourceSetGsCrt;
 extern struct GSMSourceGSRegs GSMSourceGSRegs;

--- a/ee_core/src/gsm_api.c
+++ b/ee_core/src/gsm_api.c
@@ -34,7 +34,7 @@ struct GSMDestSetGsCrt
     s16 interlace;
     s16 mode;
     s16 ffmd;
-};
+} __attribute__((packed));
 
 struct GSMDestGSRegs
 {
@@ -49,7 +49,7 @@ struct GSMDestGSRegs
     u64 display1;
     u64 dispfb2;
     u64 display2;
-};
+} __attribute__((packed));
 
 struct GSMFlags
 {
@@ -66,7 +66,7 @@ struct GSMFlags
     u8 DISPLAY_fix;
     u8 FIELD_fix;
     u8 gs576P_param;
-};
+} __attribute__((packed));
 
 extern struct GSMDestSetGsCrt GSMDestSetGsCrt;
 extern struct GSMDestGSRegs GSMDestGSRegs;

--- a/ee_core/src/iopmgr.c
+++ b/ee_core/src/iopmgr.c
@@ -80,6 +80,19 @@ static void ResetIopSpecial(const char *args, unsigned int arglen)
     sbv_patch_enable_lmb();
 
     DPRINTF("Loading extra IOP modules...\n");
+
+#ifdef __LOAD_DEBUG_MODULES
+    LoadOPLModule(OPL_MODULE_ID_SMSTCPIP, 0, 0, NULL);
+    LoadOPLModule(OPL_MODULE_ID_SMAP, 0, g_ipconfig_len, g_ipconfig);
+#ifdef __DECI2_DEBUG
+    LoadOPLModule(OPL_MODULE_ID_DRVTIF, 0, 0, NULL);
+    LoadOPLModule(OPL_MODULE_ID_TIFINET, 0, 0, NULL);
+#else
+    LoadOPLModule(OPL_MODULE_ID_UDPTTY, 0, 0, NULL);
+    LoadOPLModule(OPL_MODULE_ID_IOPTRAP, 0, 0, NULL);
+#endif
+#endif
+
 #ifdef PADEMU
 #define PADEMU_ARG || EnablePadEmuOp
 #else
@@ -89,24 +102,12 @@ static void ResetIopSpecial(const char *args, unsigned int arglen)
         LoadOPLModule(OPL_MODULE_ID_USBD, 0, 11, "thpri=2,3");
     }
     if (GameMode == ETH_MODE) {
+#ifndef __LOAD_DEBUG_MODULES
         LoadOPLModule(OPL_MODULE_ID_SMSTCPIP, 0, 0, NULL);
         LoadOPLModule(OPL_MODULE_ID_SMAP, 0, g_ipconfig_len, g_ipconfig);
+#endif
         LoadOPLModule(OPL_MODULE_ID_SMBINIT, 0, 0, NULL);
     }
-
-#ifdef __LOAD_DEBUG_MODULES
-    if (GameMode != ETH_MODE) {
-        LoadOPLModule(OPL_MODULE_ID_SMSTCPIP, 0, 0, NULL);
-        LoadOPLModule(OPL_MODULE_ID_SMAP, 0, g_ipconfig_len, g_ipconfig);
-    }
-#ifdef __DECI2_DEBUG
-    LoadOPLModule(OPL_MODULE_ID_DRVTIF, 0, 0, NULL);
-    LoadOPLModule(OPL_MODULE_ID_TIFINET, 0, 0, NULL);
-#else
-    LoadOPLModule(OPL_MODULE_ID_UDPTTY, 0, 0, NULL);
-    LoadOPLModule(OPL_MODULE_ID_IOPTRAP, 0, 0, NULL);
-#endif
-#endif
 }
 
 /*----------------------------------------------------------------------------------------*/

--- a/include/utf8.h
+++ b/include/utf8.h
@@ -35,8 +35,9 @@ static const uint8_t utf8d[] = {
     1, 3, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // s7..s8
 };
 
-uint32_t static utf8Decode(uint32_t *state, uint32_t *codep, uint32_t byte)
+uint32_t static utf8Decode(uint32_t *state, uint32_t *codep, char c)
 {
+    uint8_t byte = (uint8_t)c;
     uint32_t type = utf8d[byte];
 
     *codep = (*state != UTF8_ACCEPT) ?

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -266,7 +266,7 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
     char fullpath[256], startup[GAME_STARTUP_MAX];
     struct dirent *dirent;
     DIR *dir;
-    struct stat st;
+    //struct stat st;
 
     cache.games = NULL;
     cache.count = 0;
@@ -353,13 +353,13 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
                     }
                 }
 
-                sprintf(fullpath, "%s/%s", path, dirent->d_name);
-                stat(fullpath, &st);
+                //sprintf(fullpath, "%s/%s", path, dirent->d_name);
+                //stat(fullpath, &st);
 
                 game->parts = 1;
                 game->media = type;
                 game->format = format;
-                game->sizeMB = st.st_size >> 20;
+                game->sizeMB = -1; //st.st_size >> 20;
 
                 count++;
             }


### PR DESCRIPTION
1. workaround #300: I've disabled requesting the filesize, as this makes loading the list of games very slow. If we want to have the filesize shown in the info page we need to request it per-game, or even delayed just like the ART.
2. Structures used by assembly code where not packed. This could cause alignment issues it a compiler tries to optimize it (gcc10)
3. All the parameters passed to the ee_core are now printed in debug builds. The results are interesting and usefull ;).
4. fix #339
5. Load debug drivers before loading storage drivers, so they can also be debugged.

**EDIT**: Commit 5. Added