### PR TITLE
Always use "CFG" folder (no more "CFG-DEV")

### DIFF
--- a/include/compatupd.h
+++ b/include/compatupd.h
@@ -5,11 +5,7 @@
 #define OPL_COMPAT_HTTP_HOST "sx.sytes.net"
 #define OPL_COMPAT_HTTP_PORT 80
 #define OPL_COMPAT_HTTP_RETRIES 3
-#if OPL_IS_DEV_BUILD
-#define OPL_COMPAT_HTTP_URI "/oplcl/sync.ashx?code=%s&device=%d&dev=1"
-#else
 #define OPL_COMPAT_HTTP_URI "/oplcl/sync.ashx?code=%s&device=%d"
-#endif
 
 void oplUpdateGameCompat(int UpdateAll);
 int oplGetUpdateGameCompatStatus(unsigned int *done, unsigned int *total);

--- a/include/opl.h
+++ b/include/opl.h
@@ -41,14 +41,6 @@
 // Last Played Auto Start
 #include <time.h>
 
-#define OPL_IS_DEV_BUILD 1 //Define if this build is a development build.
-
-#ifdef OPL_IS_DEV_BUILD
-#define OPL_FOLDER "CFG-DEV"
-#else
-#define OPL_FOLDER "CFG"
-#endif
-
 //Master password for disabling the parental lock.
 #define OPL_PARENTAL_LOCK_MASTER_PASS "989765"
 

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -779,7 +779,7 @@ static void ethGetLegacyAppsPath(char *path, int max)
 
 static void ethGetLegacyAppsInfo(char *path, int max, char *name)
 {
-    snprintf(path, max, "%s" OPL_FOLDER "\\%s.cfg", ethPrefix, name);
+    snprintf(path, max, "%sCFG\\%s.cfg", ethPrefix, name);
 }
 
 static item_list_t ethGameList = {

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -414,7 +414,7 @@ static config_set_t *hddGetConfig(int id)
     char path[256];
     hdl_game_info_t *game = &hddGames.games[id];
 
-    snprintf(path, sizeof(path), "%s" OPL_FOLDER "/%s.cfg", hddPrefix, game->startup);
+    snprintf(path, sizeof(path), "%sCFG/%s.cfg", hddPrefix, game->startup);
     config_set_t *config = configAlloc(0, NULL, path);
     configRead(config); //Does not matter if the config file exists or not.
 
@@ -603,7 +603,7 @@ static void hddGetLegacyAppsPath(char *path, int max)
 
 static void hddGetLegacyAppsInfo(char *path, int max, char *name)
 {
-    snprintf(path, max, "%s" OPL_FOLDER "/%s.cfg", hddPrefix, name);
+    snprintf(path, max, "%sCFG/%s.cfg", hddPrefix, name);
 }
 
 static item_list_t hddGameList = {

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -719,7 +719,7 @@ void sbRename(base_game_info_t **list, const char *prefix, const char *sep, int 
 config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const char *sep)
 {
     char path[256];
-    snprintf(path, sizeof(path), "%s" OPL_FOLDER "%s%s.cfg", prefix, sep, game->startup);
+    snprintf(path, sizeof(path), "%sCFG%s%s.cfg", prefix, sep, game->startup);
     config_set_t *config = configAlloc(0, NULL, path);
     configRead(config); //Does not matter if the config file could be loaded or not.
 
@@ -748,7 +748,7 @@ static void sbCreateFoldersFromList(const char *path, const char **folders)
 
 void sbCreateFolders(const char *path, int createDiscImgFolders)
 {
-    const char *basicFolders[] = {OPL_FOLDER, "THM", "LNG", "ART", "VMC", "CHT", "APPS", NULL};
+    const char *basicFolders[] = {"CFG", "THM", "LNG", "ART", "VMC", "CHT", "APPS", NULL};
     const char *discImgFolders[] = {"CD", "DVD", NULL};
 
     sbCreateFoldersFromList(path, basicFolders);

--- a/src/usbsupport.c
+++ b/src/usbsupport.c
@@ -445,7 +445,7 @@ static void usbGetLegacyAppsPath(char *path, int max)
 
 static void usbGetLegacyAppsInfo(char *path, int max, char *name)
 {
-    snprintf(path, max, "%s" OPL_FOLDER "/%s.cfg", usbPrefix, name);
+    snprintf(path, max, "%sCFG/%s.cfg", usbPrefix, name);
 }
 
 static item_list_t usbGameList = {


### PR DESCRIPTION
As also discussed in #343 .

For the past 5 years everyone has been using development builds. These builds differ from releases in the following:
- They store the game config in the folder "CFG-DEV"
- When downloading 'compat' configs from http://sx.sytes.net/oplcl an extra parameter 'dev=1' is sent

I don't think there should be any difference between development builds and release builds for the name of the 'CFG' folder. Just like all the other folders don't have special 'DEV' versions. So this removes the option, and always uses the 'CFG' folder.

For the 'dev=1' parameter sent to http://sx.sytes.net/oplcl I could not find any reason. To test the difference I created 2 OPL builds, 1 with the parameter, and 1 without. Then had them download the configs for all games in my catalog. Then I used a compare tool to compare all configs: they are exactly the same. So I think this should be removed as well.

Test build can be downloaded here:
https://github.com/rickgaiser/Open-PS2-Loader/suites/1770659249/artifacts/33794362