### PR TITLE
Fixes for gcc10 and more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,13 @@ ifneq ($(shell test -d .git; echo $$?),0)
 endif
 
 GIT_TAG = $(shell git describe --exact-match --tags 2>/dev/null)
-ifeq ($(GIT_TAG),)
-	# git revision is not tagged
-	OPL_VERSION = v$(VERSION).$(SUBVERSION).$(PATCHLEVEL)$(if $(EXTRAVERSION),-$(EXTRAVERSION))-$(REVISION)$(if $(GIT_HASH),-$(GIT_HASH))$(if $(DIRTY),$(DIRTY))$(if $(LOCALVERSION),-$(LOCALVERSION))
-else
+OPL_VERSION = v$(VERSION).$(SUBVERSION).$(PATCHLEVEL)$(if $(EXTRAVERSION),-$(EXTRAVERSION))-$(REVISION)$(if $(GIT_HASH),-$(GIT_HASH))$(if $(DIRTY),$(DIRTY))$(if $(LOCALVERSION),-$(LOCALVERSION))
+
+ifneq ($(GIT_TAG),)
+ifneq ($(GIT_TAG),latest)
 	# git revision is tagged
 	OPL_VERSION = $(GIT_TAG)$(if $(DIRTY),$(DIRTY))
+endif
 endif
 
 FRONTEND_OBJS = pad.o fntsys.o renderman.o menusys.o OSDHistory.o system.o lang.o config.o hdd.o dialogs.o \

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ EXTRAVERSION = Beta
 RTL ?= 0
 
 #Enables/disables In Game Screenshot (IGS). NB: It depends on GSM and IGR to work
-IGS ?= 0
+IGS ?= 1
 
 #Enables/disables pad emulator
-PADEMU ?= 0
+PADEMU ?= 1
 
 #Enables/disables building of an edition of OPL that will support the DTL-T10000 (SDK v2.3+)
 DTL_T10000 ?= 0
@@ -206,10 +206,7 @@ else
 	$(MAKE) $(EE_BIN)
 endif
 
-release:
-	echo "Building Open PS2 Loader $(OPL_VERSION)..."
-	echo "-Interface"
-	$(MAKE) IGS=1 PADEMU=1 $(EE_VPKD).ZIP
+release: $(EE_VPKD).ZIP
 
 debug:
 	$(MAKE) DEBUG=1 all

--- a/ee_core/Makefile
+++ b/ee_core/Makefile
@@ -53,7 +53,7 @@ ifeq ($(PADEMU),1)
 EE_CFLAGS += -DPADEMU
 endif
 
-EE_LIBS += -lkernel-nopatch
+EE_LIBS += -lkernel-nopatch -lgcc
 
 $(EE_OBJS_DIR)%.o : $(EE_SRC_DIR)%.c
 	@mkdir -p $(EE_OBJS_DIR)

--- a/ee_core/include/util.h
+++ b/ee_core/include/util.h
@@ -25,7 +25,7 @@ int _toupper(int c);
 int _memcmp(const void *s1, const void *s2, unsigned int length);
 unsigned int _strtoui(const char *p);
 int _strtoi(const char *p);
-unsigned long int _strtoul(const char *p);
+u64 _strtoul(const char *p);
 void set_ipconfig(void);
 u32 *find_pattern_with_mask(u32 *buf, unsigned int bufsize, const u32 *pattern, const u32 *mask, unsigned int len);
 void CopyToIop(void *eedata, unsigned int size, void *iopptr);

--- a/ee_core/src/asm.S
+++ b/ee_core/src/asm.S
@@ -387,17 +387,10 @@ InitRegsExecPS2:
 	por $t1, $zero, $zero
 	por $t2, $zero, $zero
 	por $t3, $zero, $zero
-.ifdef .gasversion.
-	por $a4, $zero, $zero
-	por $a5, $zero, $zero
-	por $a6, $zero, $zero
-	por $a7, $zero, $zero
-.else
 	por $t4, $zero, $zero
 	por $t5, $zero, $zero
 	por $t6, $zero, $zero
 	por $t7, $zero, $zero
-.endif
 	por $s0, $zero, $zero
 	por $s1, $zero, $zero
 	por $s2, $zero, $zero

--- a/ee_core/src/asm.S
+++ b/ee_core/src/asm.S
@@ -10,6 +10,9 @@
 #include <ee_cop0_defs.h>
 #include <syscallnr.h>
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
+#include "as_reg_compat.h"
+
 #define COMPAT_MODE_3 	0x04 // Unhook Syscalls
 #define COMPAT_MODE_6 	0x20 // Disable IGR
 

--- a/ee_core/src/cheat_engine.S
+++ b/ee_core/src/cheat_engine.S
@@ -81,17 +81,10 @@ EngineHandler:
 	sd	$t1, 0x48($sp)
 	sd	$t2, 0x50($sp)
 	sd	$t3, 0x58($sp)
-.ifdef .gasversion.
-	sd	$a4, 0x60($sp)
-	sd	$a5, 0x68($sp)
-	sd	$a6, 0x70($sp)
-	sd	$a7, 0x78($sp)
-.else
 	sd	$t4, 0x60($sp)
 	sd	$t5, 0x68($sp)
 	sd	$t6, 0x70($sp)
 	sd	$t7, 0x78($sp)
-.endif
 	sd	$s0, 0x80($sp)
 	sd	$s1, 0x88($sp)
 	sd	$s2, 0x90($sp)
@@ -120,17 +113,10 @@ eh_jal:
 	ld	$s2, 0x90($sp)
 	ld	$s1, 0x88($sp)
 	ld	$s0, 0x80($sp)
-.ifdef .gasversion.
-	ld	$a7, 0x78($sp)
-	ld	$a6, 0x70($sp)
-	ld	$a5, 0x68($sp)
-	ld	$a4, 0x60($sp)
-.else
 	ld	$t7, 0x78($sp)
 	ld	$t6, 0x70($sp)
 	ld	$t5, 0x68($sp)
 	ld	$t4, 0x60($sp)
-.endif
 	ld	$t3, 0x58($sp)
 	ld	$t2, 0x50($sp)
 	ld	$t1, 0x48($sp)
@@ -166,19 +152,11 @@ CodeHandler:
 	 * $t0 - ptr to code list
 	 * $t1 - ptr to jump table for code types
 	 * $t3 - total number of codes
-.ifdef .gasversion.
-	 * $a4 - number of codes done
-.else
 	 * $t4 - number of codes done
-.endif
 	 */
 	lw	$t3, numcodes
 	beqz	$t3, ch_ret
-.ifdef .gasversion.
-	li	$a4, 0
-.else
 	li	$t4, 0
-.endif
 	la	$t0, codelist
 	la	$t1, type_tab
 ch_loop:
@@ -187,33 +165,20 @@ ch_loop:
 	 * $a0 - RAM address
 	 * $a1 - code value
 	 */
-.ifdef .gasversion.
-	sll	$at, $a4, 3
-.else
 	sll	$at, $t4, 3
-.endif
 	addu	$t2, $t0, $at
 	lw	$a0, 0($t2)
 	beqz	$a0, next
 	srl	$a2, $a0, 28
 	sll	$a2, 2
 	addu	$a2, $t1
-.ifdef .gasversion.
-	lw	$a5, 0($a2)
-	beqz	$a5, next
-.else
 	lw	$t5, 0($a2)
 	beqz	$t5, next
-.endif
 	sll	$a0, 7
 	srl	$a0, 7
 
 	/* jump to code type handler */
-.ifdef .gasversion.
-	jr	$a5
-.else
 	jr	$t5
-.endif
 	lw	$a1, 4($t2)
 type_0:
 	/*
@@ -271,70 +236,31 @@ type_3:
 	 *
 	 * It increments/decrements the current value at address @a by value @v.
 	 */
-.ifdef .gasversion.
-	srl	$a6, $a0, 20
-	andi	$at, $a6, 1	/* 0=inc, 1=dec */
-.else
 	srl	$t6, $a0, 20
 	andi	$at, $t6, 1	/* 0=inc, 1=dec */
-.endif
 	andi	$a0, 0xffff
 	sll	$a1, 7
 	srl	$a1, 7
-.ifdef .gasversion.
-	andi	$a6, 6		/* zero for 8 bit */
-	andi	$a2, $a6, 2	/* non-zero for 16 bit */
-	beqzl	$a6, 1f
-	lbu	$a5, 0($a1)
-.else
 	andi	$t6, 6		/* zero for 8 bit */
 	andi	$a2, $t6, 2	/* non-zero for 16 bit */
 	beqzl	$t6, 1f
 	lbu	$t5, 0($a1)
-.endif
 	bnezl	$a2, 1f
-.ifdef .gasversion.
-	lhu	$a5, 0($a1)
-	lw	$a5, 0($a1)
-.else
 	lhu	$t5, 0($a1)
 	lw	$t5, 0($a1)
-.endif
 	lw	$a0, 8($t2)
-.ifdef .gasversion.
-	addiu	$a4, 1
-.else
 	addiu	$t4, 1
-.endif
 1:
 	beqzl	$at, 2f
-.ifdef .gasversion.
-	addu	$a5, $a0
-	subu	$a5, $a0
-.else
 	addu	$t5, $a0
 	subu	$t5, $a0
-.endif
 2:
-.ifdef .gasversion.
-	beqzl	$a6, next
-	sb	$a5, 0($a1)
-.else
 	beqzl	$t6, next
 	sb	$t5, 0($a1)
-.endif
 	bnezl	$a2, next
-.ifdef .gasversion.
-	sh	$a5, 0($a1)
-.else
 	sh	$t5, 0($a1)
-.endif
 	b	next
-.ifdef .gasversion.
-	sw	$a5, 0($a1)
-.else
 	sw	$t5, 0($a1)
-.endif
 type_4:
 	/*
 	 * "32-bit constant serial write"
@@ -348,11 +274,7 @@ type_4:
 	 */
 	lw	$a2, 8($t2)
 	lw	$a3, 12($t2)
-.ifdef .gasversion.
-	srl	$a5, $a1, 16
-.else
 	srl	$t5, $a1, 16
-.endif
 	andi	$a1, 0xffff
 	sll	$a1, 2
 1:
@@ -360,20 +282,11 @@ type_4:
 	nop
 	sw	$a2, 0($a0)
 	addu	$a2, $a3
-.ifdef .gasversion.
-	addiu	$a5, -1
-	bgtz	$a5, 1b
-.else
 	addiu	$t5, -1
 	bgtz	$t5, 1b
-.endif
 	addu	$a0, $a1
 	b	next
-.ifdef .gasversion.
-	addiu	$a4, 1
-.else
 	addiu	$t4, 1
-.endif
 type_5:
 	/*
 	 * "Copy bytes"
@@ -386,27 +299,15 @@ type_5:
 	 */
 	lw	$a2, 8($t2)
 1:
-.ifdef .gasversion.
-	lb	$a5, 0($a0)
-.else
 	lb	$t5, 0($a0)
-.endif
 	nop
-.ifdef .gasversion.
-	sb	$a5, 0($a2)
-.else
 	sb	$t5, 0($a2)
-.endif
 	addiu	$a2, 1
 	addiu	$a1, -1
 	bgtz	$a1, 1b
 	addiu	$a0, 1
 	b	next
-.ifdef .gasversion.
-	addiu	$a4, 1
-.else
 	addiu	$t4, 1
-.endif
 type_6:
 	/*
 	 * "Pointer write"
@@ -426,48 +327,22 @@ type_6:
 	 * Loads 32-bit base address from address @a, adds offset @i to it, and
 	 * constantly writes the value @v to the final address.
 	 */
-.ifdef .gasversion.
-	lw	$a5, 0($a0)
-.else
 	lw	$t5, 0($a0)
-.endif
 	li	$at, 0x3ffffffc
-.ifdef .gasversion.
-	and	$a5, $at
-	beqz	$a5, 1f
-.else
 	and	$t5, $at
 	beqz	$t5, 1f
-.endif
 	lhu	$a2, 10($t2)
 	lw	$a3, 12($t2)
-.ifdef .gasversion.
-	addu	$a5, $a3
-.else
 	addu	$t5, $a3
-.endif
 	beqzl	$a2, 1f
-.ifdef .gasversion.
-	sb	$a1, 0($a5)
-.else
 	sb	$a1, 0($t5)
-.endif
 	addiu	$a2, -1
 	beqzl	$a2, 1f
-.ifdef .gasversion.
-	sh	$a1, 0($a5)
-	sw	$a1, 0($a5)
-.else
 	sh	$a1, 0($t5)
 	sw	$a1, 0($t5)
-.endif
 1:
 	b	next
-.ifdef .gasversion.
-	addiu	$a4, 1
-.else
 	addiu	$t4, 1
-.endif
 type_7:
 	/*
 	 * "Boolean operation"
@@ -493,52 +368,24 @@ type_7:
 	 * Performs a bitwise logical operation between value @v and the value
 	 * stored at address @a.
 	 */
-.ifdef .gasversion.
-	srl	$a6, $a1, 20
-	andi	$at, $a6, 1	/* 0=8 bit, 1=16 bit */
-	andi	$a6, 6		/* 0=OR, 2=AND, 4=XOR */
-.else
 	srl	$t6, $a1, 20
 	andi	$at, $t6, 1	/* 0=8 bit, 1=16 bit */
 	andi	$t6, 6		/* 0=OR, 2=AND, 4=XOR */
-.endif
 	bnezl	$at, 1f
-.ifdef .gasversion.
-	lhu	$a5, 0($a0)
-	lbu	$a5, 0($a0)
-.else
 	lhu	$t5, 0($a0)
 	lbu	$t5, 0($a0)
-.endif
 1:
-.ifdef .gasversion.
-	beqzl	$a6, 2f
-	or	$a5, $a1
-	addiu	$a6, -2
-	beqzl	$a6, 2f
-	and	$a5, $a1
-	xor	$a5, $a1
-.else
 	beqzl	$t6, 2f
 	or	$t5, $a1
 	addiu	$t6, -2
 	beqzl	$t6, 2f
 	and	$t5, $a1
 	xor	$t5, $a1
-.endif
 2:
 	bnezl	$at, next
-.ifdef .gasversion.
-	sh	$a5, 0($a0)
-.else
 	sh	$t5, 0($a0)
-.endif
 	b	next
-.ifdef .gasversion.
-	sb	$a5, 0($a0)
-.else
 	sb	$t5, 0($a0)
-.endif
 type_c:
 	/*
 	 * "32-bit do all following codes if equal to"
@@ -548,13 +395,8 @@ type_c:
 	 * All following codes will be executed only if 32-bit value at address
 	 * @a is equal to value @v.
 	 */
-.ifdef .gasversion.
-	lw	$a5, 0($a0)
-	bne	$a5, $a1, ch_ret
-.else
 	lw	$t5, 0($a0)
 	bne	$t5, $a1, ch_ret
-.endif
 	nop
 	b	next
 	nop
@@ -577,112 +419,50 @@ type_d:
 	 */
 	srl	$a3, $a1, 16
 	andi	$a3, 1
-.ifdef .gasversion.
-	srl	$a6, $a1, 20
-.else
 	srl	$t6, $a1, 20
-.endif
 	srl	$a2, $a1, 24
 	beqzl	$a2, 1f		/* set @n to 1 if 0 for compatibility */
 	li	$a2, 1
 1:
 	beqz	$a3, 2f
-.ifdef .gasversion.
-	andi	$a6, 7
-	lbu	$a5, 0($a0)
-.else
 	andi	$t6, 7
 	lbu	$t5, 0($a0)
-.endif
 	b	3f
 	andi	$a1, 0xff
 2:
-.ifdef .gasversion.
-	lhu	$a5, 0($a0)
-.else
 	lhu	$t5, 0($a0)
-.endif
 	andi	$a1, 0xffff
 3:
-.ifdef .gasversion.
-	beqzl	$a6, 4f		/* equal */
-	subu	$a5, $a1
-.else
 	beqzl	$t6, 4f		/* equal */
 	subu	$t5, $a1
-.endif
 	li	$at, 1		/* not equal */
-.ifdef .gasversion.
-	beql	$a6, $at, 5f
-	subu	$a5, $a1
-.else
 	beql	$t6, $at, 5f
 	subu	$t5, $a1
-.endif
 	li	$at, 2		/* less than */
-.ifdef .gasversion.
-	beql	$a6, $at, 5f
-	sltu	$a5, $a1
-.else
 	beql	$t6, $at, 5f
 	sltu	$t5, $a1
-.endif
 	li	$at, 3		/* greater than */
-.ifdef .gasversion.
-	beql	$a6, $at, 5f
-	sltu	$a5, $a1, $a5
-.else
 	beql	$t6, $at, 5f
 	sltu	$t5, $a1, $t5
-.endif
 	li	$at, 4		/* NAND */
-.ifdef .gasversion.
-	beql	$a6, $at, 4f
-	and	$a5, $a1
-.else
 	beql	$t6, $at, 4f
 	and	$t5, $a1
-.endif
 	li	$at, 5		/* AND */
-.ifdef .gasversion.
-	beql	$a6, $at, 5f
-	and	$a5, $a1
-.else
 	beql	$t6, $at, 5f
 	and	$t5, $a1
-.endif
 	li	$at, 6		/* NOR */
-.ifdef .gasversion.
-	beql	$a6, $at, 4f
-	or	$a5, $a1
-.else
 	beql	$t6, $at, 4f
 	or	$t5, $a1
-.endif
 	b	5f		/* OR */
-.ifdef .gasversion.
-	or	$a5, $a1
-.else
 	or	$t5, $a1
-.endif
 4:				/* skip if non-zero */
-.ifdef .gasversion.
-	bnezl	$a5, next
-	addu	$a4, $a2
-.else
 	bnezl	$t5, next
 	addu	$t4, $a2
-.endif
 	b	next
 	nop
 5:				/* skip if zero */
-.ifdef .gasversion.
-	beqzl	$a5, next
-	addu	$a4, $a2
-.else
 	beqzl	$t5, next
 	addu	$t4, $a2
-.endif
 	b	next
 	nop
 type_e:
@@ -709,30 +489,16 @@ type_e:
 	or	$a2, $at
 	sll	$a0, $a1, 7
 	srl	$a0, 7
-.ifdef .gasversion.
-	li	$a5, 0xd0000000
-	or	$a5, $a0
-.else
 	li	$t5, 0xd0000000
 	or	$t5, $a0
-.endif
 	move	$a1, $a2
-.ifdef .gasversion.
-	sw	$a5, 0($t2)	/* store converted address */
-.else
 	sw	$t5, 0($t2)	/* store converted address */
-.endif
 	b	type_d
 	sw	$a1, 4($t2)	/* store converted value */
 next:
 	/* next code */
-.ifdef .gasversion.
-	addiu	$a4, 1
-	sltu	$at, $a4, $t3
-.else
 	addiu	$t4, 1
 	sltu	$at, $t4, $t3
-.endif
 	bnez	$at, ch_loop
 	nop
 ch_ret:

--- a/ee_core/src/cheat_engine.S
+++ b/ee_core/src/cheat_engine.S
@@ -21,6 +21,9 @@
  * $Id$
  */
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
+#include "as_reg_compat.h"
+
 #define F_EngineHandler
 #define F_CodeHandler
 

--- a/ee_core/src/dve_reg.S
+++ b/ee_core/src/dve_reg.S
@@ -9,6 +9,9 @@
 #
 */
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
+#include "as_reg_compat.h"
+
 .global dveStat1
 .global dveStat2
 

--- a/ee_core/src/gsm_engine.S
+++ b/ee_core/src/gsm_engine.S
@@ -219,17 +219,10 @@ addiu	$sp, $sp, 0x0010			# Restore sp during return
 # $t1 = rt
 # $t2 = value in rt
 # $t3 = base
-.ifdef .gasversion.
-# $a4 = address
-# $a5 = address holding rt within array
-# $a6 = address holding base within array
-# $a7 = new value for rt
-.else
 # $t4 = address
 # $t5 = address holding rt within array
 # $t6 = address holding base within array
 # $t7 = new value for rt
-.endif
 #
 
 .globl GSHandler
@@ -250,17 +243,10 @@ sq $t0, 0x080($k1)
 sq $t1, 0x090($k1)
 sq $t2, 0x0A0($k1)
 sq $t3, 0x0B0($k1)
-.ifdef .gasversion.
-sq $a4, 0x0C0($k1)
-sq $a5, 0x0D0($k1)
-sq $a6, 0x0E0($k1)
-sq $a7, 0x0F0($k1)
-.else
 sq $t4, 0x0C0($k1)
 sq $t5, 0x0D0($k1)
 sq $t6, 0x0E0($k1)
 sq $t7, 0x0F0($k1)
-.endif
 sq $s0, 0x100($k1)
 sq $s1, 0x110($k1)
 sq $s2, 0x120($k1)
@@ -663,29 +649,16 @@ andi	$t1,$t1,0x0FFF
 addi	$t1,$t1,1		# t1 = Source_Width = Source_DW + 1
 divu	$t1,$t0		# LO = Source_Pixels_Width = Source_Width / Source_Width_Scale
 dsrl32	$t0,$v1,0
-.ifdef .gasversion.
-andi	$a5,$t0,0x0FFF
-mflo	$a4				# t4 = LO = Source_Pixels_Width
-addi	$a6,$a5,1		# t6 = Target_Width = Target_DW + 1
-divu	$a6,$a4		# LO = Target_Width_Scale = Target_Width / Source_Pixels_Width
-.else
 andi	$t5,$t0,0x0FFF
 mflo	$t4				# t4 = LO = Source_Pixels_Width
 addi	$t6,$t5,1		# t6 = Target_Width = Target_DW + 1
 divu	$t6,$t4		# LO = Target_Width_Scale = Target_Width / Source_Pixels_Width
-.endif
 mflo	$t0				# t0 = LO = Target_Width_Scale
 bne	$t0,$zero,have_DISPLAY_write_2		# in case of (!Target_Width_Scale)
 nop						# {
-.ifdef .gasversion.
-or	$a7,$zero,$a5		# t7 = Target_DW = Target_Width - 1
-sub	$t0,$a6,$a4			# t0 = Target_Width - Source_Pixels_Width
-li	$a4,0				# t4 = Target_MAGH = 0
-.else
 or	$t7,$zero,$t5		# t7 = Target_DW = Target_Width - 1
 sub	$t0,$t6,$t4			# t0 = Target_Width - Source_Pixels_Width
 li	$t4,0				# t4 = Target_MAGH = 0
-.endif
 beql	$zero,$zero,have_DISPLAY_write_4		# }
 nop						# otherwise
 						# Target_Width_Scale nonzero
@@ -696,17 +669,10 @@ bgtzl	$t1,have_DISPLAY_write_3			# in case of (Target_Width_Scale > 16)
 or	$t0,$zero,16		# 	t0 = Target_Width_Scale = 16;
 
 have_DISPLAY_write_3:
-.ifdef .gasversion.
-mult	$t1,$a4,$t0			# LO = Calculated_Width = (Source_Pixels_Width * Target_Width_Scale)
-addi	$a7,$t1,-1		# t7 = Calculated_DW = Calculated_Width - 1
-addi	$a4,$t0,-1		# t4 = Calculated_MAGH = Target_Width_Scale - 1
-sub	$t0,$a5,$a7			# t0 = Target_DW - Calculated_DW
-.else
 mult	$t1,$t4,$t0			# LO = Calculated_Width = (Source_Pixels_Width * Target_Width_Scale)
 addi	$t7,$t1,-1		# t7 = Calculated_DW = Calculated_Width - 1
 addi	$t4,$t0,-1		# t4 = Calculated_MAGH = Target_Width_Scale - 1
 sub	$t0,$t5,$t7			# t0 = Target_DW - Calculated_DW
-.endif
 
 have_DISPLAY_write_4:                     # }
 dsra $t0,$t0,1			# t0 = t0 / 2 = Half_Excess_Width (can be negative)
@@ -717,71 +683,32 @@ dsra $t0,$t0,1			# t0 = t0 / 2 = Half_Excess_Width (can be negative)
 # | DX   | 11:0  | int 0:12:0 | x pos in display area (VCK units)     | 0xFFF |
 # '------^-------^------------^---------------------------------------^-------^
 andi	$t1,$v1,0x0FFF	# t1 = Target_DX
-.ifdef .gasversion.
-add	$a6,$t0,$t1			# t6 = Calculated_DX = Target_DX + Half_Excess_Width
-bltzl	$a6,have_DISPLAY_write_5			# in case of (Calculated_DX < 0)
-and	$a6,$a6,$zero		# 	Calculated_DX = 0;
-.else
 add	$t6,$t0,$t1			# t6 = Calculated_DX = Target_DX + Half_Excess_Width
 bltzl	$t6,have_DISPLAY_write_5			# in case of (Calculated_DX < 0)
 and	$t6,$t6,$zero		# 	Calculated_DX = 0;
-.endif
 
 have_DISPLAY_write_5:
-.ifdef .gasversion.
-sub	$t0,$t1,$a6			# t0 = Target_DX - Calculated_DX
-.else
 sub	$t0,$t1,$t6			# t0 = Target_DX - Calculated_DX
-.endif
 bgtzl	$t0,have_DISPLAY_write_6			# in case of (Target_DX > Calculated_DX)
-.ifdef .gasversion.
-add	$a7,$a7,$t0			# 	t7 = Calculated_DW = Calculated_DW + Target_DX - Calculated_DX  # Target DW adjusted
-.else
 add	$t7,$t7,$t0			# 	t7 = Calculated_DW = Calculated_DW + Target_DX - Calculated_DX  # Target DW adjusted
-.endif
 
 have_DISPLAY_write_6:
-.ifdef .gasversion.
-andi	$a7,$a7,0x0FFF
-andi	$a4,$a4,0x000F
-andi	$a6,$a6,0x0FFF
-dsll32	$t0,$a7,0		# t0 = Calculated_DW
-.else
 andi	$t7,$t7,0x0FFF
 andi	$t4,$t4,0x000F
 andi	$t6,$t6,0x0FFF
 dsll32	$t0,$t7,0		# t0 = Calculated_DW
-.endif
 or	$v0,$v0,$t0			# v0 = Adapted_DISPLAY = (Adapted_DISPLAY) OR (Calculated_DW)
-.ifdef .gasversion.
-dsll	$t0,$a4,23
-.else
 dsll	$t0,$t4,23
-.endif
 or	$v0,$v0,$t0			# v0 = Adapted_DISPLAY = (Adapted_DISPLAY) OR (Calculated_MAGH)
 
 lw	$t1, X_offset($s2)	# t1 = X_offset (signed)
-.ifdef .gasversion.
-add	$a6, $a6, $t1		# t6 = Calculated_DX = Calculated_DX + X_offset
-bltzl	$a6, have_DISPLAY_write_7		# Is the result not greater or equal to zero?
-move	$a6, $zero		# t6 = Calculated_DX = 0
-.else
 add	$t6, $t6, $t1		# t6 = Calculated_DX = Calculated_DX + X_offset
 bltzl	$t6, have_DISPLAY_write_7		# Is the result not greater or equal to zero?
 move	$t6, $zero		# t6 = Calculated_DX = 0
-.endif
 have_DISPLAY_write_7:
-.ifdef .gasversion.
-andi	$a6,$a6,0x0FFF
-.else
 andi	$t6,$t6,0x0FFF
-.endif
 
-.ifdef .gasversion.
-or	$v0,$v0,$a6			# v0 = Adapted_DISPLAY = (Adapted_DISPLAY) OR (Calculated_DX)
-.else
 or	$v0,$v0,$t6			# v0 = Adapted_DISPLAY = (Adapted_DISPLAY) OR (Calculated_DX)
-.endif
 
 # ----- VERTICAL FIELDS -------
 # .------.-------.------------.---------------------------------------.-------.
@@ -804,33 +731,17 @@ andi	$t1,$t1,0x07FF
 addi	$t1,$t1,1		# Source_Height = Source_DH + 1
 divu	$t1,$t0		# LO = Source_Pixels_Height = Source_Height / Source_Height_Scale
 dsrl32	$t0,$v1,12
-.ifdef .gasversion.
-andi	$a5,$t0,0x07FF
-mflo	$a4				# t4 = LO = Source_Pixels_Height
-addi	$a6,$a5,1		# t6 = Target_Height = Target_DH + 1
-divu	$a6,$a4		# LO = Target_Height_Scale = Target_Height / Source_Pixels_Height
-.else
 andi	$t5,$t0,0x07FF
 mflo	$t4				# t4 = LO = Source_Pixels_Height
 addi	$t6,$t5,1		# t6 = Target_Height = Target_DH + 1
 divu	$t6,$t4		# LO = Target_Height_Scale = Target_Height / Source_Pixels_Height
-.endif
 mflo	$t0				# t0 = LO = Target_Height_Scale
 bne	$t0,$zero,have_DISPLAY_write_8		# in case of (!Target_Height_Scale)
 nop						# {
-.ifdef .gasversion.
-or	$a7,$zero,$a5		# t7 = Target_DH = Target_Height - 1
-sub	$t0,$a6,$a4			# t0 = Target_Height - Source_Pixels_Height
-.else
 or	$t7,$zero,$t5		# t7 = Target_DH = Target_Height - 1
 sub	$t0,$t6,$t4			# t0 = Target_Height - Source_Pixels_Height
-.endif
 b	have_DISPLAY_write_10		# }
-.ifdef .gasversion.
-move	$a4, $zero			# t4 = Target_MAGV = 0
-.else
 move	$t4, $zero			# t4 = Target_MAGV = 0
-.endif
 					# otherwise, Target_Height_Scale nonzero
 
 have_DISPLAY_write_8:						# {
@@ -839,17 +750,10 @@ bgtzl	$t1,have_DISPLAY_write_9			# in case of (Target_Height_Scale > 4)
 or	$t0,$zero,4			# 	t0 = Target_Height_Scale = 4;
 
 have_DISPLAY_write_9:
-.ifdef .gasversion.
-mult	$t1,$a4,$t0			# t1 = Calculated_Height = (Source_Pixels_Height * Target_Height_Scale)
-addi	$a7,$t1,-1		# t7 = Calculated_DH = Calculated_Height - 1
-addi	$a4,$t0,-1		# t4 = Calculated_MAGV = Target_Height_Scale - 1
-sub	$t0,$a5,$a7			# t0 = Target_DH - Calculated_DH
-.else
 mult	$t1,$t4,$t0			# t1 = Calculated_Height = (Source_Pixels_Height * Target_Height_Scale)
 addi	$t7,$t1,-1		# t7 = Calculated_DH = Calculated_Height - 1
 addi	$t4,$t0,-1		# t4 = Calculated_MAGV = Target_Height_Scale - 1
 sub	$t0,$t5,$t7			# t0 = Target_DH - Calculated_DH
-.endif
 
 have_DISPLAY_write_10:						# }
 dsra $t0,$t0,1			# t0 = t0 / 2 = Half_Excess_Height (can be negative)
@@ -861,28 +765,14 @@ dsra $t0,$t0,1			# t0 = t0 / 2 = Half_Excess_Height (can be negative)
 # '------^-------^------------^---------------------------------------^-------^
 dsrl	$t1,$v1,12
 andi	$t1,$t1,0x07FF	# t1 = Target_DY
-.ifdef .gasversion.
-add	$a6,$t0,$t1			# t6 = Calculated_DY = Target_DY + Half_Excess_Height
-bltzl	$a6,have_DISPLAY_write_11			# in case of (Calculated_DY < 0)
-and	$a6,$a6,$zero		#	Calculated_DY = 0;
-.else
 add	$t6,$t0,$t1			# t6 = Calculated_DY = Target_DY + Half_Excess_Height
 bltzl	$t6,have_DISPLAY_write_11			# in case of (Calculated_DY < 0)
 and	$t6,$t6,$zero		#	Calculated_DY = 0;
-.endif
 
 have_DISPLAY_write_11:
-.ifdef .gasversion.
-sub	$t0,$t1,$a6			# t0 = Target_DY - Calculated_DY
-.else
 sub	$t0,$t1,$t6			# t0 = Target_DY - Calculated_DY
-.endif
 bgtzl	$t0,have_DISPLAY_write_12			# in case of (Target_DY > Calculated_DY)
-.ifdef .gasversion.
-add	$a7,$a7,$t0			# 	t7 = Calculated_DH = Calculated_DH + Target_DY - Calculated_DY # Target DH adjusted
-.else
 add	$t7,$t7,$t0			# 	t7 = Calculated_DH = Calculated_DH + Target_DY - Calculated_DY # Target DH adjusted
-.endif
 
 have_DISPLAY_write_12:
 lb	$t0, Interlace_FRAME_Mode_Flag($s3)	# in case of Double Height not needed
@@ -893,66 +783,30 @@ ld	$t0, Target_SMODE2($s1)
 andi	$t0,$t0,1							# in case of Target_SMODE2.INT = 1 (Interlace Mode)
 bne	$t0,$zero,have_DISPLAY_write_13							# 	Calculation is complete
 nop
-.ifdef .gasversion.
-beql	$a4,$zero,have_DISPLAY_write_13	# in case of Calculated_MAGV = 0
-addi	$a4,$a4,1		# 	go use Calculated_MAGV = Calculated_MAGV + 1
-addi	$a4,$a4,2		# Calculated_MAGV = Calculated_MAGV + 2 (Because scale was 2 or larger)
-addi	$t0,$a4,-4		# Compare Calculated_MAGV with 4 (too large ?)
-.else
 beql	$t4,$zero,have_DISPLAY_write_13	# in case of Calculated_MAGV = 0
 addi	$t4,$t4,1		# 	go use Calculated_MAGV = Calculated_MAGV + 1
 addi	$t4,$t4,2		# Calculated_MAGV = Calculated_MAGV + 2 (Because scale was 2 or larger)
 addi	$t0,$t4,-4		# Compare Calculated_MAGV with 4 (too large ?)
-.endif
 bgezl	$t0,have_DISPLAY_write_13			# in case of  Calculated_MAGV too large
-.ifdef .gasversion.
-ori	$a4,$zero,3			# 	go use Calculated_MAGV = 3
-.else
 ori	$t4,$zero,3			# 	go use Calculated_MAGV = 3
-.endif
 
 have_DISPLAY_write_13:
-.ifdef .gasversion.
-andi	$a7,$a7,0x07FF
-andi	$a4,$a4,0x0003
-andi	$a6,$a6,0x07FF
-dsll32	$t0,$a7,12
-.else
 andi	$t7,$t7,0x07FF
 andi	$t4,$t4,0x0003
 andi	$t6,$t6,0x07FF
 dsll32	$t0,$t7,12
-.endif
 or	$v0,$v0,$t0			# v0 = Adapted_DISPLAY = (Adapted_DISPLAY) OR (Calculated_DH)
-.ifdef .gasversion.
-dsll	$t0,$a4,27
-.else
 dsll	$t0,$t4,27
-.endif
 or	$v0,$v0,$t0			# v0 = Adapted_DISPLAY = (Adapted_DISPLAY) OR (Calculated_MAGV)
 
 lw	$t1, Y_offset($s2)		# t1 = Y_offset (signed)
-.ifdef .gasversion.
-add	$a6, $a6, $t1		# t6 = Calculated_DY = Calculated_DY + Y_offset
-bltzl	$a6, have_DISPLAY_write_14		# Is the result not greater or equal to zero?
-move	$a6, $zero
-.else
 add	$t6, $t6, $t1		# t6 = Calculated_DY = Calculated_DY + Y_offset
 bltzl	$t6, have_DISPLAY_write_14		# Is the result not greater or equal to zero?
 move	$t6, $zero
-.endif
 have_DISPLAY_write_14:
-.ifdef .gasversion.
-andi	$a6,$a6,0x07FF
-.else
 andi	$t6,$t6,0x07FF
-.endif
 
-.ifdef .gasversion.
-dsll	$t0,$a6,12
-.else
 dsll	$t0,$t6,12
-.endif
 
 jr $ra
 or	$v0,$v0,$t0        # v0 = Adapted_DISPLAY = (Adapted_DISPLAY) OR (Calculated_DY)
@@ -1045,17 +899,10 @@ lq $a3, 0x070($k0)
 # lq $t1, 0x090($k0)
 # lq $t2, 0x0A0($k0)
 lq $t3, 0x0B0($k0)
-.ifdef .gasversion.
-lq $a4, 0x0C0($k0)
-lq $a5, 0x0D0($k0)
-lq $a6, 0x0E0($k0)
-lq $a7, 0x0F0($k0)
-.else
 lq $t4, 0x0C0($k0)
 lq $t5, 0x0D0($k0)
 lq $t6, 0x0E0($k0)
 lq $t7, 0x0F0($k0)
-.endif
 lq $s0, 0x100($k0)
 lq $s1, 0x110($k0)
 lq $s2, 0x120($k0)

--- a/ee_core/src/gsm_engine.S
+++ b/ee_core/src/gsm_engine.S
@@ -11,6 +11,9 @@
 #include <ee_cop0_defs.h>
 #include <syscallnr.h>
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
+#include "as_reg_compat.h"
+
 #include "gsm_defines.h"
 
 # -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/ee_core/src/gsm_engine_adv.S
+++ b/ee_core/src/gsm_engine_adv.S
@@ -11,6 +11,9 @@
 # This file is included by gsm_engine.S
 #
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
+#include "as_reg_compat.h"
+
 .extern setdve_576P
 .extern dveStat1
 .extern dveStat2

--- a/ee_core/src/main.c
+++ b/ee_core/src/main.c
@@ -42,28 +42,31 @@ int *gCheatList; //Store hooks/codes addr+val pairs
 
 static int eecoreInit(int argc, char **argv)
 {
+    int i = 0;
+    char *p;
+
     SifInitRpc(0);
 
     DINIT();
     DPRINTF("OPL EE core start!\n");
 
-    int i = 0;
-
-    if (!_strncmp(argv[i], "USB_MODE", 8))
+    p = _strtok(argv[i], " ");
+    if (!_strncmp(p, "USB_MODE", 8))
         GameMode = USB_MODE;
-    else if (!_strncmp(argv[i], "ETH_MODE", 8))
+    else if (!_strncmp(p, "ETH_MODE", 8))
         GameMode = ETH_MODE;
-    else if (!_strncmp(argv[i], "HDD_MODE", 8))
+    else if (!_strncmp(p, "HDD_MODE", 8))
         GameMode = HDD_MODE;
     DPRINTF("Game Mode = %d\n", GameMode);
 
+    p = _strtok(NULL, " ");
     DisableDebug = 0;
-    if (!_strncmp(&argv[i][9], "1", 1)) {
+    if (!_strncmp(p, "1", 1)) {
         DisableDebug = 1;
         DPRINTF("Debug Colors disabled\n");
     }
 
-    char *p = _strtok(&argv[i][11], " ");
+    p = _strtok(NULL, " ");
     if (!_strncmp(p, "Browser", 7))
         ExitPath[0] = '\0';
     else
@@ -74,12 +77,9 @@ static int eecoreInit(int argc, char **argv)
     HDDSpindown = _strtoui(p);
     DPRINTF("HDD Spindown = %d\n", HDDSpindown);
 
-    p = _strtok(NULL, " ");
-    _strcpy(g_ps2_ip, p);
-    p = _strtok(NULL, " ");
-    _strcpy(g_ps2_netmask, p);
-    p = _strtok(NULL, " ");
-    _strcpy(g_ps2_gateway, p);
+    _strcpy(g_ps2_ip, _strtok(NULL, " "));
+    _strcpy(g_ps2_netmask, _strtok(NULL, " "));
+    _strcpy(g_ps2_gateway, _strtok(NULL, " "));
     g_ps2_ETHOpMode = _strtoui(_strtok(NULL, " "));
     DPRINTF("IP=%s NM=%s GW=%s mode: %d\n", g_ps2_ip, g_ps2_netmask, g_ps2_gateway, g_ps2_ETHOpMode);
 

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -50,7 +50,7 @@ static int IGR_Thread_ID = -1;
 static int IGR_Intc_ID = -1;
 
 /* IGR thread stack & stack size */
-#define IGR_STACK_SIZE (16 * 192)
+#define IGR_STACK_SIZE (4 * 1024)
 static u8 IGR_Stack[IGR_STACK_SIZE] __attribute__((aligned(16)));
 
 /* Extern symbol */

--- a/ee_core/src/patches_asm.S
+++ b/ee_core/src/patches_asm.S
@@ -7,6 +7,9 @@
 #include <ee_cop0_defs.h>
 #include <syscallnr.h>
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
+#include "as_reg_compat.h"
+
 .set push
 .set noreorder
 .set noat

--- a/ee_core/src/util.c
+++ b/ee_core/src/util.c
@@ -261,16 +261,16 @@ int _strtoi(const char *p)
 }
 
 /*----------------------------------------------------------------------------------------*/
-/* This function converts string to unsigned long integer. Stops on illegal characters.   */
+/* This function converts string to u64. Stops on illegal characters.                     */
 /* Put here because including atoi rises the size of loader.elf by another kilobyte       */
 /* and that causes some games to stop working.                                            */
 /*----------------------------------------------------------------------------------------*/
-unsigned long int _strtoul(const char *p)
+u64 _strtoul(const char *p)
 {
     if (!p)
         return 0;
 
-    unsigned long int r = 0;
+    u64 r = 0;
 
     while (*p) {
         if ((*p < '0') || (*p > '9'))

--- a/elfldr/crt0.S
+++ b/elfldr/crt0.S
@@ -10,6 +10,9 @@
 # Modified crt0.s
 # Remove _ps2sdk_args_parse, _ps2sdk_libc_init and _ps2sdk_libc_deinit weak functions for size optimization
 
+#define ABI_EABI64 // force all register names to EABI64 (legacy toolchain)
+#include "as_reg_compat.h"
+
 	.weak  _init
 	.type  _init, @function
 

--- a/include/integers.h
+++ b/include/integers.h
@@ -1,7 +1,0 @@
-#ifndef __INTEGERS_H
-#define __INTEGERS_H
-
-typedef unsigned char uint8_t;
-typedef unsigned long int uint32_t;
-
-#endif

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -42,6 +42,7 @@ int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gam
 int sbPrepare(base_game_info_t *game, config_set_t *configSet, int size_cdvdman, void **cdvdman_irx, int *patchindex);
 void sbUnprepare(void *pCommon);
 void sbRebuildULCfg(base_game_info_t **list, const char *prefix, int gamecount, int excludeID);
+void sbCreatePath(const base_game_info_t *game, char *path, const char *prefix, const char *sep, int part);
 void sbDelete(base_game_info_t **list, const char *prefix, const char *sep, int gamecount, int id);
 void sbRename(base_game_info_t **list, const char *prefix, const char *sep, int gamecount, int id, char *newname);
 config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const char *sep);

--- a/include/system.h
+++ b/include/system.h
@@ -7,7 +7,7 @@
 #define SYS_LOAD_USB_MODULES 0x02
 #define SYS_LOAD_ISOFS_MODULE 0x04
 
-unsigned int USBA_crc32(char *string);
+unsigned int USBA_crc32(const char *string);
 int sysGetDiscID(char *discID);
 void sysInitDev9(void);
 void sysShutdownDev9(void);

--- a/include/utf8.h
+++ b/include/utf8.h
@@ -13,7 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 // Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
 // See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
 
-#include "integers.h"
+#include <sys/types.h>
 
 #define UTF8_ACCEPT 0
 #define UTF8_REJECT 1

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -665,13 +665,7 @@ static void ethLaunchGame(int id, config_set_t *configSet)
     strcpy(settings->smb_password, gPCPassword);
 
     //Initialize layer 1 information.
-    switch (game->format) {
-        case GAME_FORMAT_USBLD:
-            sprintf(partname, "%s%s.00", ethPrefix, settings->filename);
-            break;
-        default: //Raw ISO9660 disc image; one part.
-            sprintf(partname, "%s%s\\%s", ethPrefix, game->media == SCECdPS2CD ? "CD" : "DVD", settings->filename);
-    }
+    sbCreatePath(game, partname, ethPrefix, "\\", 0);
 
     if (gPS2Logo) {
         int fd = open(partname, O_RDONLY, 0666);
@@ -687,7 +681,7 @@ static void ethLaunchGame(int id, config_set_t *configSet)
         case GAME_FORMAT_USBLD:
             layer1_part = layer1_start / 0x80000;
             layer1_offset = layer1_start % 0x80000;
-            sprintf(partname, "%s%s.%02x", ethPrefix, settings->filename, layer1_part);
+            sbCreatePath(game, partname, ethPrefix, "\\", layer1_part);
             break;
         default: //Raw ISO9660 disc image; one part.
             layer1_part = 0;

--- a/src/fntsys.c
+++ b/src/fntsys.c
@@ -4,7 +4,6 @@
  Review OpenUsbLd README & LICENSE files for further details.
  */
 
-#include "include/integers.h"
 #include "include/opl.h"
 #include "include/fntsys.h"
 #include "include/renderman.h"
@@ -13,6 +12,7 @@
 #include "include/util.h"
 #include "include/atlas.h"
 
+#include <sys/types.h>
 #include <ft2build.h>
 
 #include FT_FREETYPE_H

--- a/src/gsm.c
+++ b/src/gsm.c
@@ -138,7 +138,7 @@ void PrepareGSM(char *cmdline)
 
     FIELD_fix = gGSMFIELDFix != 0 ? 1 : 0;
 
-    sprintf(cmdline, "%d %d %d %lu %lu %u %u %u %d %d %d", predef_vmode[gGSMVMode].interlace,
+    sprintf(cmdline, "%d %d %d %llu %llu %u %u %u %d %d %d", predef_vmode[gGSMVMode].interlace,
             predef_vmode[gGSMVMode].mode,
             predef_vmode[gGSMVMode].ffmd,
             predef_vmode[gGSMVMode].display,

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -266,7 +266,6 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
     char fullpath[256], startup[GAME_STARTUP_MAX];
     struct dirent *dirent;
     DIR *dir;
-    //struct stat st;
 
     cache.games = NULL;
     cache.count = 0;
@@ -353,13 +352,10 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
                     }
                 }
 
-                //sprintf(fullpath, "%s/%s", path, dirent->d_name);
-                //stat(fullpath, &st);
-
                 game->parts = 1;
                 game->media = type;
                 game->format = format;
-                game->sizeMB = -1; //st.st_size >> 20;
+                game->sizeMB = dirent->d_stat.st_size >> 20;
 
                 count++;
             }

--- a/src/system.c
+++ b/src/system.c
@@ -268,7 +268,7 @@ void sysPowerOff(void)
 
 static unsigned int crctab[0x400];
 
-unsigned int USBA_crc32(char *string)
+unsigned int USBA_crc32(const char *string)
 {
     int crc, table, count, byte;
 


### PR DESCRIPTION
Since yesterday the EE toolchain on ps2dev has been updated to gcc10. This has **broken** the 'latest' builds.

These commits will:
- FIX: most issues with gcc10
- FIX: the filesize issue (unfortunately not backwards compatible to v1.0.0 / v1.0.1)
- FIX: CI rebuilds (triggered from ps2dev) to be called 'latest'
- Change: enable IGS and PADEMU by default (just like `make release` already does, see commit for more info)

Closes #345 