### PR TITLE
Fix an info page bug

### DIFF
--- a/src/lang.c
+++ b/src/lang.c
@@ -3,6 +3,7 @@
 #include "include/util.h"
 #include "include/fntsys.h"
 #include "include/ioman.h"
+#include "include/themes.h"
 
 // Language support
 static char *internalEnglish[LANG_STR_COUNT] = {
@@ -480,6 +481,7 @@ int lngSetGuiValue(int langID)
                 language_t *currLang = &languages[langID - 1];
                 if (lngLoadFromFile(currLang->filePath, currLang->name)) {
                     guiLangID = langID;
+                    thmSetGuiValue(thmGetGuiValue(), 1);
                     return 1;
                 }
             }
@@ -487,6 +489,7 @@ int lngSetGuiValue(int langID)
             guiLangID = 0;
             // lang switched back to internalEnglish, reload default font
             fntLoadDefault(NULL);
+            thmSetGuiValue(thmGetGuiValue(), 1);
         }
     }
     return 0;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
Currently there seem to be multiple bugs related to scrolling through games while on the info page, this fixes one of the bugs. Only down side is that since the keys are translated at init rather than draw; if the language is changed the theme needs to be reloaded in order to translate the strings.

If this gets merged it would be good to also merge into 1.0 since the bug is present there and would be easier to check (I don’t have legacy toolchain atm) if the remaining bug is related to toolchain changes (probably not though).
