### PR TITLE
hdd: Add option to use partitions other than +OPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ USB modes:
 | "LNG" | for translation support | all |
 | "CHT" | for cheats files | all |
 
-OPL will automatically create the above directory structure the first time
-you launch it and enable your favourite device. For HDD users, a 128Mb +OPL
-partition will be created (you can enlarge it using uLaunchELF if you need to).
+OPL will automatically create the above directory structure the first time you launch it and enable your favourite device.
+
+For HDD users, OPL will read hdd0:__common/OPL/conf_hdd.cfg for the config entry "hdd_partition" to use as your OPL partition.
+If not found a config file and a 128Mb +OPL partition will be created, you can edit the config if you wish to use/create a different partition.
+All partitions created by OPL will be 128Mb (it is not recommended to enlarge partitions as it will break LBAs, instead remove and recreate manually with uLaunchELF at a larger size if needed).
 
 ## USB
 

--- a/elfldr/elfldr.c
+++ b/elfldr/elfldr.c
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <stdio.h>
 
-static inline void _strcpy(char *dst, const char *src)
+/*static inline void _strcpy(char *dst, const char *src)
 {
     memcpy(dst, src, strlen(src) + 1);
 }
@@ -38,7 +38,7 @@ static int _strncmp(const char *s1, const char *s2, int length)
     }
 
     return 0;
-}
+}*/
 
 static inline void BootError(char *filename)
 {
@@ -100,14 +100,6 @@ int main(int argc, char *argv[])
         SifLoadModule("rom0:MCSERV", 0, NULL);
         SifLoadFileExit();
         SifExitRpc();
-
-        if (_strncmp(argv[0], "pfs", 3) == 0) {
-            static char _argv[256];
-            _strcpy(_argv, "hdd0:+OPL:");
-            _strcat(_argv, argv[0]);
-
-            argv[0] = _argv;
-        }
 
         ExecPS2((void *)exd.epc, (void *)exd.gp, argc, argv);
     } else {

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -63,4 +63,6 @@ void hddInit();
 item_list_t *hddGetObject(int initOnly);
 void hddLoadModules(void);
 
+extern char gOPLPart[128];
+
 #endif

--- a/include/opl.h
+++ b/include/opl.h
@@ -164,6 +164,7 @@ extern int gDefaultDevice;
 
 extern int gEnableWrite;
 
+extern char *gHDDPrefix;
 //These prefixes are relative to the device's name (meaning that they do not include the device name).
 extern char gBDMPrefix[32];
 extern char gETHPrefix[32];

--- a/src/opl.c
+++ b/src/opl.c
@@ -125,6 +125,7 @@ static opl_io_module_t list_support[MODE_COUNT];
 
 // Global data
 char *gBaseMCDir;
+char *gHDDPrefix;
 int ps2_ip_use_dhcp;
 int ps2_ip[4];
 int ps2_netmask[4];
@@ -723,13 +724,16 @@ static int checkLoadConfigBDM(int types)
 static int checkLoadConfigHDD(int types)
 {
     int value;
+    char path[64];
 
     hddLoadModules();
-    value = open("pfs0:conf_opl.cfg", O_RDONLY);
+
+    snprintf(path, sizeof(path), "%sconf_opl.cfg", gHDDPrefix);
+    value = open(path, O_RDONLY);
     if (value >= 0) {
         close(value);
         configEnd();
-        configInit("pfs0:");
+        configInit(gHDDPrefix);
         value = configReadMulti(types);
         config_set_t *configOPL = configGetByType(CONFIG_OPL);
         configSetInt(configOPL, CONFIG_OPL_HDD_MODE, START_MODE_AUTO);
@@ -781,11 +785,11 @@ static int tryAlternateDevice(int types)
         configInit("mass0:");
     } else {
         // No? Check if the save location on the HDD is available.
-        dir = opendir("pfs0:");
+        dir = opendir(gHDDPrefix);
         if (dir != NULL) {
             closedir(dir);
             configEnd();
-            configInit("pfs0:");
+            configInit(gHDDPrefix);
         }
     }
     showCfgPopup = 0;
@@ -912,7 +916,7 @@ static int trySaveConfigHDD(int types)
     hddLoadModules();
     //Check that the formatted & usable HDD is connected.
     if (hddCheck() == 0) {
-        configSetMove("pfs0:");
+        configSetMove(gHDDPrefix);
         return configWriteMulti(types);
     }
 
@@ -1525,6 +1529,7 @@ static void setDefaults(void)
     clearIOModuleT(&list_support[APP_MODE]);
 
     gBaseMCDir = "mc?:OPL";
+    gHDDPrefix = "pfs0:";
 
     ps2_ip_use_dhcp = 1;
     gETHOpMode = ETH_OP_MODE_AUTO;

--- a/src/system.c
+++ b/src/system.c
@@ -11,6 +11,7 @@
 #include "include/opl.h"
 #include "include/gui.h"
 #include "include/ethsupport.h"
+#include "include/hddsupport.h"
 #include "include/util.h"
 #include "include/pad.h"
 #include "include/system.h"
@@ -858,7 +859,9 @@ int sysExecElf(const char *path)
     elf_pheader_t *eph;
     void *pdata;
     int i;
-    char *elf_argv[1];
+    char *elf_argv[2];
+    char argv[256];
+    int elf_argc = 1;
 
     // NB: ELFLDR.ELF is embedded
     boot_elf = (u8 *)&elfldr_elf;
@@ -888,10 +891,16 @@ int sysExecElf(const char *path)
 
     elf_argv[0] = (char *)path;
 
+    if (strncmp(path, "pfs", 3) == 0) {
+        snprintf(argv, sizeof(argv), "%s:%s", gOPLPart, elf_argv[0]);
+        elf_argv[1] = argv;
+        elf_argc++;
+    }
+
     FlushCache(0);
     FlushCache(2);
 
-    ExecPS2((void *)eh->entry, NULL, 1, elf_argv);
+    ExecPS2((void *)eh->entry, NULL, elf_argc, elf_argv);
 
     return 0;
 }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
This is simpler than last time, 

Upon hdd init, __common will be mounted and check “conf_hdd.cfg” for eg “hdd_partition=PP.OPL” and mount that partition instead.. if config isn’t found one will be created with +OPL as the default since that’s what it has been for years.. imo it’s better for “advanced users” to just change the cfg entry rather than lots of people not understanding why their hdd suddenly doesn’t work after updating OPL.

If partition in cfg doesn’t exist it will be made, only partitions beginning with + will work on root all others will use an OPL subfolder.
