### PR TITLE
Use packed attribute in structs in cdvd_config.h

### DIFF
--- a/modules/iopcore/common/cdvd_config.h
+++ b/modules/iopcore/common/cdvd_config.h
@@ -15,13 +15,13 @@ struct cdvdman_settings_common
     u32 layer1_start;
     u8 DiscID[5];
     u8 padding[3];
-};
+} __attribute__((packed));
 
 struct cdvdman_settings_hdd
 {
     struct cdvdman_settings_common common;
     u32 lba_start;
-};
+} __attribute__((packed));
 
 struct cdvdman_settings_smb
 {
@@ -41,10 +41,10 @@ struct cdvdman_settings_smb
         };
         u16 FIDs[ISO_MAX_PARTS];
     };
-};
+} __attribute__((packed));
 
 struct cdvdman_settings_bdm
 {
     struct cdvdman_settings_common common;
     u32 LBAs[ISO_MAX_PARTS];
-};
+} __attribute__((packed));


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

n32 and o32 ABIs have different alignment, so use `packed` attribute to ensure structures are same size.
