### PR TITLE
Optimize strncmp with a constant string to strcmp

### DIFF
--- a/modules/mcemu/imports.lst
+++ b/modules/mcemu/imports.lst
@@ -59,7 +59,7 @@ stdio_IMPORTS_end
 
 sysclib_IMPORTS_start
 I_prnt
-I_strncmp
+I_strcmp
 sysclib_IMPORTS_end
 
 sysmem_IMPORTS_start

--- a/modules/mcemu/mcemu.c
+++ b/modules/mcemu/mcemu.c
@@ -242,7 +242,7 @@ int hookRegisterLibraryEntires(iop_library_t *lib)
 {
     register int ret;
 
-    if (!strncmp(lib->name, "sio2man", 8)) {
+    if (!strcmp(lib->name, "sio2man")) {
         ret = pRegisterLibraryEntires(lib);
         if (ret == 0) {
             ReleaseLibraryEntries((struct irx_export_table *)lib);
@@ -252,7 +252,7 @@ int hookRegisterLibraryEntires(iop_library_t *lib)
             DPRINTF("registering library %s failed, error %d\n", lib->name, ret);
             return ret;
         }
-    } else if (!strncmp(lib->name, "secrman", 8)) {
+    } else if (!strcmp(lib->name, "secrman")) {
         ret = pRegisterLibraryEntires(lib);
         if (ret == 0) {
             ReleaseLibraryEntries((struct irx_export_table *)lib);
@@ -262,7 +262,7 @@ int hookRegisterLibraryEntires(iop_library_t *lib)
             DPRINTF("registering library %s failed, error %d\n", lib->name, ret);
             return ret;
         }
-    } else if (!strncmp(lib->name, "mcman", 8)) {
+    } else if (!strcmp(lib->name, "mcman")) {
         ret = pRegisterLibraryEntires(lib);
         if (ret == 0) {
             ReleaseLibraryEntries((struct irx_export_table *)lib);
@@ -274,7 +274,7 @@ int hookRegisterLibraryEntires(iop_library_t *lib)
             return ret;
         }
 #ifdef PADEMU
-    } else if (!strncmp(lib->name, "pademu", 8)) {
+    } else if (!strcmp(lib->name, "pademu")) {
         pademu_hookSio2man = GetExportEntry(&lib[1], 4);
 #endif
     }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Checking length is useless when one of the strings is already fixed width

I fixed this while seeing if GCC builtins can be enabled.