### PR TITLE
Move memcpy/memset redefinition to smsutils.h

### DIFF
--- a/modules/iopcore/cdvdfsv/cdvdfsv-internal.h
+++ b/modules/iopcore/cdvdfsv/cdvdfsv-internal.h
@@ -21,8 +21,6 @@
 #include "cdvdman_opl.h"
 
 #include "smsutils.h"
-#define memcpy mips_memcpy
-#define memset mips_memset
 
 extern void cdvdfsv_register_scmd_rpc(SifRpcDataQueue_t *rpc_DQ);
 extern void cdvdfsv_register_ncmd_rpc(SifRpcDataQueue_t *rpc_DQ);

--- a/modules/iopcore/cdvdman/internal.h
+++ b/modules/iopcore/cdvdman/internal.h
@@ -30,8 +30,6 @@
 #include <defs.h>
 
 #include "smsutils.h"
-#define memcpy mips_memcpy
-#define memset mips_memset
 
 #ifdef __IOPCORE_DEBUG
 #define DPRINTF(args...)  printf(args)

--- a/modules/iopcore/cdvdman/ioplib_util.c
+++ b/modules/iopcore/cdvdman/ioplib_util.c
@@ -11,8 +11,6 @@
 #include "ioplib_util.h"
 
 #include "smsutils.h"
-#define memcpy mips_memcpy
-#define memset mips_memset
 
 #ifdef __IOPCORE_DEBUG
 #define DPRINTF(args...) printf(args)

--- a/modules/iopcore/cdvdman/smb.c
+++ b/modules/iopcore/cdvdman/smb.c
@@ -19,8 +19,6 @@
 #include "cdvd_config.h"
 
 #include "smsutils.h"
-#define memcpy mips_memcpy
-#define memset mips_memset
 
 #define USE_CUSTOM_RECV 1
 

--- a/modules/iopcore/common/smsutils.h
+++ b/modules/iopcore/common/smsutils.h
@@ -15,12 +15,21 @@
 
 #define smsutils_IMPORTS_start DECLARE_IMPORT_TABLE(smsutils, 1, 1)
 
-extern void mips_memcpy(void *, const void *, unsigned);
+extern void *mips_memcpy(void *, const void *, size_t);
 #define I_mips_memcpy DECLARE_IMPORT(4, mips_memcpy)
 
-extern void mips_memset(void *, int, unsigned);
+extern void *mips_memset(void *, int, size_t);
 #define I_mips_memset DECLARE_IMPORT(5, mips_memset)
 
 #define smsutils_IMPORTS_end END_IMPORT_TABLE
+
+#ifdef memcpy
+#undef memcpy
+#endif
+#define memcpy mips_memcpy
+#ifdef memset
+#undef memset
+#endif
+#define memset mips_memset
 
 #endif /* __SMSUTILS_H */


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Move memcpy/memset redefinition to smsutils.h. This is in preparation for the ps2sdk updates regarding function builtins.