### PR TITLE
create workflow for discord webhook

### DIFF
--- a/.github/workflows/webhook_release.yml
+++ b/.github/workflows/webhook_release.yml
@@ -20,4 +20,4 @@ jobs:
         uses: tsickert/discord-webhook@v2.0.2
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_NEWS_CHANNEL }}
-          content: "Hey everyone! **OPL**  **${{ env.RELEASE_VERSION }}** has been released!"
+          content: "Hey @everyone! **OPL**  **${{ env.RELEASE_VERSION }}** has been released!"

--- a/.github/workflows/webhook_release.yml
+++ b/.github/workflows/webhook_release.yml
@@ -1,0 +1,23 @@
+name: Discord webhook for Open PS2 Loader releases 
+on:
+  workflow_dispatch:
+  release:
+    types: [released]
+jobs:
+  OPL-Release_webhook:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Test
+        run: |
+          echo $RELEASE_VERSION
+          echo ${{ env.RELEASE_VERSION }}
+      - name: Discord Webhook Action
+        uses: tsickert/discord-webhook@v2.0.2
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_NEWS_CHANNEL }}
+          content: "Hey everyone! **OPL**  **${{ env.RELEASE_VERSION }}** has been released!"


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [x] Others (please specify below)
## Pull Request description
this new workflow file will trigger a discord webhook on every release __(not pre-release)__ whose tag starts with `v`, just like the tagged release system on the main workflow

The webhook will write a message on the ps2 discord server telling everyone about the new version

The only information managed from the workflow side is the message.

The rest is managed from the webhook.



__This PR Isn't functional yet!!!__
To make it work an admin of the PS2 scene discord (like @TnA-Plastic ) must create the discord webhook url, after that, someone with write access to this repo must create a new repo secret called this way: `DISCORD_WEBHOOK_NEWS_CHANNEL` holding the generated webhook url as it's value.

It will look similar to this:
![Captura de pantalla (204)](https://user-images.githubusercontent.com/57065102/124026537-31601880-d9c8-11eb-8526-fa5ee07a0a77.png)
Keep in mind that both the bot name and it's avatar image can be changed any time by anyone with access to webhooks on the PS2 server.
Also, it's worth mentioning that discord webhooks are channel specific! so the repository secret must be updated in order to move the webhook bot to another channel
