### PR TITLE
Parse launch args to auto boot games from HDDOSD

### DIFF
--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -62,7 +62,6 @@ int hddDeleteHDLGame(hdl_game_info_t *ginfo);
 void hddInit();
 item_list_t *hddGetObject(int initOnly);
 void hddLoadModules(void);
-
-extern char gOPLPart[128];
+void hddLaunchGame(int id, config_set_t *configSet);
 
 #endif

--- a/include/opl.h
+++ b/include/opl.h
@@ -38,6 +38,8 @@
 #include <ps2smb.h>
 #include "config.h"
 
+#include "include/hddsupport.h"
+
 // Last Played Auto Start
 #include <time.h>
 
@@ -166,7 +168,6 @@ extern int gDefaultDevice;
 
 extern int gEnableWrite;
 
-extern char *gHDDPrefix;
 // These prefixes are relative to the device's name (meaning that they do not include the device name).
 extern char gBDMPrefix[32];
 extern char gETHPrefix[32];
@@ -183,6 +184,10 @@ extern unsigned char gDefaultBgColor[3];
 extern unsigned char gDefaultTextColor[3];
 extern unsigned char gDefaultSelTextColor[3];
 extern unsigned char gDefaultUITextColor[3];
+
+extern hdl_game_info_t *gAutoLaunchGame;
+extern char *gHDDPrefix;
+extern char gOPLPart[128];
 
 void setDefaultColors(void);
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -125,7 +125,6 @@ static opl_io_module_t list_support[MODE_COUNT];
 
 // Global data
 char *gBaseMCDir;
-char *gHDDPrefix;
 int ps2_ip_use_dhcp;
 int ps2_ip[4];
 int ps2_netmask[4];
@@ -188,6 +187,9 @@ unsigned char gDefaultBgColor[3];
 unsigned char gDefaultTextColor[3];
 unsigned char gDefaultSelTextColor[3];
 unsigned char gDefaultUITextColor[3];
+hdl_game_info_t *gAutoLaunchGame;
+char gOPLPart[128];
+char *gHDDPrefix;
 
 void moduleUpdateMenu(int mode, int themeChanged, int langChanged)
 {
@@ -1531,8 +1533,10 @@ static void setDefaults(void)
     clearIOModuleT(&list_support[HDD_MODE]);
     clearIOModuleT(&list_support[APP_MODE]);
 
-    gBaseMCDir = "mc?:OPL";
+    gAutoLaunchGame = NULL;
+    gOPLPart[0] = '\0';
     gHDDPrefix = "pfs0:";
+    gBaseMCDir = "mc?:OPL";
 
     ps2_ip_use_dhcp = 1;
     gETHOpMode = ETH_OP_MODE_AUTO;
@@ -1667,6 +1671,56 @@ static void deferredAudioInit(void)
         LOG("sfxInit: %d samples loaded.\n", ret);
 }
 
+static void autoLaunchHDDGame(char *argv[])
+{
+    int ret;
+    char path[256];
+    config_set_t *configSet;
+
+    gAutoLaunchGame = malloc(sizeof(hdl_game_info_t));
+    if (gAutoLaunchGame == NULL) {
+        PREINIT_LOG("Failed to allocate memory. Loading GUI\n");
+        return;
+    }
+
+    memset(gAutoLaunchGame, 0, sizeof(hdl_game_info_t));
+
+    snprintf(gAutoLaunchGame->startup, sizeof(gAutoLaunchGame->startup), argv[1]);
+    gAutoLaunchGame->start_sector = strtoul(argv[2], NULL, 0);
+    snprintf(gOPLPart, sizeof(gOPLPart), "hdd0:%s", argv[3]);
+
+    gETHOpMode = 0;
+    gRememberLastPlayed = 0;
+    gDisableDebug = 1;
+    gPS2Logo = 0;
+    gExitPath[0] = '\0';
+    gHDDSpindown = 20;
+    gHDDPrefix = "pfs0:";
+
+    ioInit();
+    LOG_ENABLE();
+
+    ret = checkLoadConfigHDD(CONFIG_ALL);
+    if (ret >= 0) {
+        ret = configReadMulti(CONFIG_ALL);
+
+        if (CONFIG_ALL & CONFIG_OPL && ret & CONFIG_OPL) {
+            config_set_t *configOPL = configGetByType(CONFIG_OPL);
+
+            configGetInt(configOPL, CONFIG_OPL_DISABLE_DEBUG, &gDisableDebug);
+            configGetInt(configOPL, CONFIG_OPL_PS2LOGO, &gPS2Logo);
+            configGetStrCopy(configOPL, CONFIG_OPL_EXIT_PATH, gExitPath, sizeof(gExitPath));
+            configGetInt(configOPL, CONFIG_OPL_HDD_SPINDOWN, &gHDDSpindown);
+        }
+    }
+
+    snprintf(path, sizeof(path), "%sCFG/%s.cfg", gHDDPrefix, gAutoLaunchGame->startup);
+    configSet = configAlloc(0, NULL, path);
+    configRead(configSet);
+
+    hddLaunchGame(-1, configSet);
+}
+
 // --------------------- Main --------------------
 int main(int argc, char *argv[])
 {
@@ -1681,6 +1735,17 @@ int main(int argc, char *argv[])
 
     // reset, load modules
     reset();
+
+    /* argv[0] boot path
+       argv[1] game->startup
+       argv[2] str to u32 game->start_sector
+       argv[3] opl partition read from hdd0:__common/OPL/conf_hdd.cfg
+       argv[4] "mini" (this is probably unnecessary.. how many args would there be typically?) */
+    if (argc >= 5) {
+        if (argv[4][0] == 'm' && argv[4][1] == 'i' && argv[4][2] == 'n' && argv[4][3] == 'i')
+            autoLaunchHDDGame(argv);
+    }
+
     init();
 
     // until this point in the code is reached, only PREINIT_LOG macro should be used

--- a/src/opl.c
+++ b/src/opl.c
@@ -1741,7 +1741,7 @@ int main(int argc, char *argv[])
        argv[3] opl partition read from hdd0:__common/OPL/conf_hdd.cfg
        argv[4] "mini" (this is probably unnecessary.. how many args would there be typically?) */
     if (argc >= 5) {
-        if (!strcmp(argv[4], "mini");
+        if (!strcmp(argv[4], "mini")
             autoLaunchHDDGame(argv);
     }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -1708,7 +1708,6 @@ static void autoLaunchHDDGame(char *argv[])
             config_set_t *configOPL = configGetByType(CONFIG_OPL);
 
             configGetInt(configOPL, CONFIG_OPL_DISABLE_DEBUG, &gDisableDebug);
-            configGetInt(configOPL, CONFIG_OPL_PS2LOGO, &gPS2Logo);
             configGetStrCopy(configOPL, CONFIG_OPL_EXIT_PATH, gExitPath, sizeof(gExitPath));
             configGetInt(configOPL, CONFIG_OPL_HDD_SPINDOWN, &gHDDSpindown);
         }
@@ -1742,7 +1741,7 @@ int main(int argc, char *argv[])
        argv[3] opl partition read from hdd0:__common/OPL/conf_hdd.cfg
        argv[4] "mini" (this is probably unnecessary.. how many args would there be typically?) */
     if (argc >= 5) {
-        if (argv[4][0] == 'm' && argv[4][1] == 'i' && argv[4][2] == 'n' && argv[4][3] == 'i')
+        if (!strcmp(argv[4], "mini");
             autoLaunchHDDGame(argv);
     }
 

--- a/src/opl.c
+++ b/src/opl.c
@@ -1741,7 +1741,7 @@ int main(int argc, char *argv[])
        argv[3] opl partition read from hdd0:__common/OPL/conf_hdd.cfg
        argv[4] "mini" (this is probably unnecessary.. how many args would there be typically?) */
     if (argc >= 5) {
-        if (!strcmp(argv[4], "mini")
+        if (!strcmp(argv[4], "mini"))
             autoLaunchHDDGame(argv);
     }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
The purpose of this is using [OPL-Launcher](https://github.com/ps2homebrew/OPL-Launcher) to send args to any future versions of OPL will allow games to be booted from HDDOSD ala miniOPL style .. more info [here](https://www.psx-place.com/threads/mini-opl-v1-0.33897/page-4#post-302922) .. looks like its working for @parrado and myself but not a couple others, I don't think their issue is related to the OPL code though.

Thanks to all involved.
