### PR TITLE
hdd.c null terminate strings copied with strncpy()

### DIFF
--- a/src/hdd.c
+++ b/src/hdd.c
@@ -137,7 +137,7 @@ struct GameDataEntry
 {
     u32 lba, size;
     struct GameDataEntry *next;
-    char id[APA_IDMAX];
+    char id[APA_IDMAX + 1];
 };
 
 static int hddGetHDLGameInfo(struct GameDataEntry *game, hdl_game_info_t *ginfo)
@@ -152,7 +152,9 @@ static int hddGetHDLGameInfo(struct GameDataEntry *game, hdl_game_info_t *ginfo)
         strncpy(ginfo->partition_name, game->id, APA_IDMAX);
         ginfo->partition_name[APA_IDMAX] = '\0';
         strncpy(ginfo->name, hdl_header->gamename, HDL_GAME_NAME_MAX);
+        ginfo->name[HDL_GAME_NAME_MAX] = '\0';
         strncpy(ginfo->startup, hdl_header->startup, sizeof(ginfo->startup) - 1);
+        ginfo->startup[sizeof(ginfo->startup) - 1] = '\0';
         ginfo->hdl_compat_flags = hdl_header->hdl_compat_flags;
         ginfo->ops2l_compat_flags = hdl_header->ops2l_compat_flags;
         ginfo->dma_type = hdl_header->dma_type;
@@ -207,6 +209,7 @@ int hddGetHDLGamelist(hdl_games_list_t *game_list)
                         break;
 
                     strncpy(current->id, dirent.name, APA_IDMAX);
+                    current->id[APA_IDMAX] = '\0';
                     count++;
                     current->next = NULL;
                     current->size = 0;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
Just noticed this when looking at OPL-Launcher since it uses the same code to read partition info.
