### PR TITLE
Improve texture loading

### DIFF
--- a/include/textures.h
+++ b/include/textures.h
@@ -92,10 +92,8 @@ enum INTERNAL_TEXTURE {
 #define ERR_BAD_DEPTH     -7
 
 int texLookupInternalTexId(const char *name);
-int texPngLoad(GSTEXTURE *texture, const char *path, int texId, short psm);
-int texJpgLoad(GSTEXTURE *texture, const char *path, int texId, short psm);
-int texBmpLoad(GSTEXTURE *texture, const char *path, int texId, short psm);
-void texPrepare(GSTEXTURE *texture, short psm);
-int texDiscoverLoad(GSTEXTURE *texture, const char *path, int texId, short psm);
+int texLoadInternal(GSTEXTURE *texture, int texId);
+int texDiscoverLoad(GSTEXTURE *texture, const char *path, int texId);
+void texFree(GSTEXTURE *texture);
 
 #endif

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -402,7 +402,7 @@ static int bdmGetImage(char *folder, int isRelative, char *value, char *suffix, 
         snprintf(path, sizeof(path), "%s%s/%s_%s", bdmPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
-    return texDiscoverLoad(resultTex, path, -1, psm);
+    return texDiscoverLoad(resultTex, path, -1);
 }
 
 // This may be called, even if bdmInit() was not.

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -716,7 +716,7 @@ static int ethGetImage(char *folder, int isRelative, char *value, char *suffix, 
         snprintf(path, sizeof(path), "%s%s\\%s_%s", ethPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
-    return texDiscoverLoad(resultTex, path, -1, psm);
+    return texDiscoverLoad(resultTex, path, -1);
 }
 
 // This may be called, even if ethInit() was not.

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -501,7 +501,7 @@ static int hddGetImage(char *folder, int isRelative, char *value, char *suffix, 
         snprintf(path, sizeof(path), "%s%s/%s_%s", gHDDPrefix, folder, value, suffix);
     else
         snprintf(path, sizeof(path), "%s%s_%s", folder, value, suffix);
-    return texDiscoverLoad(resultTex, path, -1, psm);
+    return texDiscoverLoad(resultTex, path, -1);
 }
 
 // This may be called, even if hddInit() was not.

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -1,5 +1,6 @@
 #include "include/opl.h"
 #include "include/texcache.h"
+#include "include/textures.h"
 #include "include/ioman.h"
 #include "include/gui.h"
 #include "include/util.h"
@@ -34,16 +35,7 @@ static void cacheLoadImage(void *data)
 
     // seems okay. we can proceed
     GSTEXTURE *texture = &req->entry->texture;
-    if (texture->Mem != NULL) {
-        free(texture->Mem);
-        texture->Mem = NULL;
-        texture->ClutPSM = 0;
-        if (texture->Clut != NULL)
-            free(texture->Clut);
-        texture->Clut = NULL;
-        texture->Vram = 0;
-        texture->VramClut = 0;
-    }
+    texFree(texture);
 
     if (handler->itemGetImage(req->cache->prefix, req->cache->isPrefixRelative, req->value, req->cache->suffix, texture, GS_PSM_CT24) < 0)
         req->entry->lastUsed = 0;


### PR DESCRIPTION
It's now more readable and easy to add new file extensions or loaders for certain file types:
```
static struct STexLoader texLoader[] = {
    {"png", texPngLoad},
    {"jpg", texJpgLoad},
    {"bmp", texBmpLoad},
    {NULL, NULL}};
```

Add `texFree` function for deleting a texture. This solves some memory leaks, where for instance the texture clut was not freed.

Remove the 'psm' argument from most functions. the argument was mostly ignored and confusing. When a file exists, it is loaded, and the psm is set in the texture struct.
