### PR TITLE
cdvdman: allow BDM devices to be ejected and inserted

### DIFF
--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -147,11 +147,7 @@ static int cdvdman_read_sectors(u32 lsn, unsigned int sectors, void *buf)
     DPRINTF("cdvdman_read lsn=%lu sectors=%u buf=%p\n", lsn, sectors, buf);
 
     cdvdman_stat.err = SCECdErNO;
-
     for (ptr = buf, remaining = sectors; remaining > 0;) {
-        if (cdvdman_stat.err != SCECdErNO)
-            break;
-
         SectorsToRead = remaining;
 
         if (cdvdman_settings.common.flags & IOPCORE_COMPAT_ACCU_READS) {
@@ -167,8 +163,8 @@ static int cdvdman_read_sectors(u32 lsn, unsigned int sectors, void *buf)
             SetAlarm(&TargetTime, &cdvdemu_read_end_cb, NULL);
         }
 
-        if (DeviceReadSectors(lsn, ptr, SectorsToRead) != 0) {
-            cdvdman_stat.err = SCECdErREAD;
+        cdvdman_stat.err = DeviceReadSectors(lsn, ptr, SectorsToRead);
+        if (cdvdman_stat.err != SCECdErNO) {
             if (cdvdman_settings.common.flags & IOPCORE_COMPAT_ACCU_READS)
                 CancelAlarm(&cdvdemu_read_end_cb, NULL);
             break;

--- a/modules/iopcore/cdvdman/device-bdm.c
+++ b/modules/iopcore/cdvdman/device-bdm.c
@@ -68,6 +68,13 @@ void DeviceDeinit(void)
     DPRINTF("%s\n", __func__);
 }
 
+int DeviceReady(void)
+{
+    //DPRINTF("%s\n", __func__);
+
+    return (g_bd == NULL) ? SCECdNotReady : SCECdComplete;
+}
+
 void DeviceStop(void)
 {
     DPRINTF("%s\n", __func__);
@@ -108,8 +115,12 @@ int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
     register u32 r, sectors_to_read, lbound, ubound, nlsn, offslsn;
     register int i, esc_flag = 0;
     u8 *p = (u8 *)buffer;
+    int rv = SCECdErNO;
 
     //DPRINTF("%s(%u, 0x%p, %u)\n", __func__, (unsigned int)lsn, buffer, sectors);
+
+    if (g_bd == NULL)
+        return SCECdErTRMOPN;
 
     lbound = 0;
     ubound = (cdvdman_settings.common.NumParts > 1) ? 0x80000 : 0xFFFFFFFF;
@@ -130,7 +141,10 @@ int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
 
             sector = cdvdman_settings.LBAs[i] + (offslsn * g_bd_sectors_per_sector);
             count = sectors_to_read * g_bd_sectors_per_sector;
-            g_bd->read(g_bd, sector, &p[r], count);
+            if (g_bd->read(g_bd, sector, &p[r], count) != count) {
+                rv = SCECdErREAD;
+                break;
+            }
 
             r += sectors_to_read * 2048;
             offslsn += sectors_to_read;
@@ -143,7 +157,7 @@ int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
     }
     SignalSema(usb_io_sema);
 
-    return 0;
+    return rv;
 }
 
 //

--- a/modules/iopcore/cdvdman/device-hdd.c
+++ b/modules/iopcore/cdvdman/device-hdd.c
@@ -81,6 +81,11 @@ void DeviceDeinit(void)
 {
 }
 
+int DeviceReady(void)
+{
+    return SCECdComplete;
+}
+
 void DeviceFSInit(void)
 {
 }
@@ -106,7 +111,7 @@ int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
     while (sectors) {
         if (!((lsn >= cdvdman_partspecs[CurrentPart].part_offset) && (lsn < (cdvdman_partspecs[CurrentPart].part_offset + (cdvdman_partspecs[CurrentPart].part_size / 2048)))))
             if (cdvdman_get_part_specs(lsn) != 0)
-                return -ENXIO;
+                return SCECdErTRMOPN;
 
         u32 nsectors = (cdvdman_partspecs[CurrentPart].part_offset + (cdvdman_partspecs[CurrentPart].part_size / 2048)) - lsn;
         if (sectors < nsectors)
@@ -114,12 +119,12 @@ int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
 
         u32 lba = cdvdman_partspecs[CurrentPart].data_start + ((lsn - cdvdman_partspecs[CurrentPart].part_offset) << 2);
         if (ata_device_sector_io(0, (void *)(buffer + offset), lba, nsectors << 2, ATA_DIR_READ) != 0) {
-            return -EIO;
+            return SCECdErREAD;
         }
         offset += nsectors * 2048;
         sectors -= nsectors;
         lsn += nsectors;
     }
 
-    return 0;
+    return SCECdErNO;
 }

--- a/modules/iopcore/cdvdman/device-smb.c
+++ b/modules/iopcore/cdvdman/device-smb.c
@@ -62,6 +62,11 @@ void DeviceDeinit(void)
     DeviceUnmount();
 }
 
+int DeviceReady(void)
+{
+    return SCECdComplete;
+}
+
 void DeviceFSInit(void)
 {
     int i = 0;
@@ -115,6 +120,7 @@ int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
     register u32 r, sectors_to_read, lbound, ubound, nlsn, offslsn;
     register int i, esc_flag = 0;
     u8 *p = (u8 *)buffer;
+    int rv = SCECdErNO;
 
     lbound = 0;
     ubound = (cdvdman_settings.common.NumParts > 1) ? 0x80000 : 0xFFFFFFFF;
@@ -132,7 +138,10 @@ int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
             } else
                 esc_flag = 1;
 
-            smb_ReadCD(offslsn, sectors_to_read, &p[r], i);
+            if (smb_ReadCD(offslsn, sectors_to_read, &p[r], i) <= 0) {
+                rv = SCECdErREAD;
+                break;
+            }
 
             r += sectors_to_read * 2048;
             offslsn += sectors_to_read;
@@ -144,5 +153,5 @@ int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
             break;
     }
 
-    return 0;
+    return rv;
 }

--- a/modules/iopcore/cdvdman/device.h
+++ b/modules/iopcore/cdvdman/device.h
@@ -1,5 +1,6 @@
 void DeviceInit(void);   //Called in _start()
 void DeviceDeinit(void); //Called in _exit(). Interrupts are disabled.
+int DeviceReady(void);   //Check if device is ready
 
 void DeviceFSInit(void);  //Called when the filesystem layer is initialized
 void DeviceLock(void);    //Prevents further accesses to the device.

--- a/modules/iopcore/cdvdman/ncmd.c
+++ b/modules/iopcore/cdvdman/ncmd.c
@@ -127,7 +127,7 @@ int sceCdDiskReady(int mode)
         }
 
         if (!sync_flag)
-            return SCECdComplete;
+            return DeviceReady();
     }
 
     return SCECdNotReady;


### PR DESCRIPTION
With this change BDM devices can be "hotplugged". Meaning you can remove and re-insert a usb stick, and the game will not crash.

Fun fact: with a modified build I can now start a game from usb (with a uSD to usb adapter). And then eject the usb and insert the the uSD card with mx4sio and continue the game.
