### PR TITLE
For ps2h cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,11 +307,11 @@ clean:
 
 rebuild: clean all
 
-run: $(EE_BIN)
-	ps2client -h 192.168.1.10 execee host:$(EE_BIN)
+run: $(EE_BIN_PACKED)
+	ps2client -h 192.168.1.10 execee host:$<
 
-sim: $(EE_BIN)
-	PCSX2 --elf=$(PWD)/$(EE_BIN) --nodisc --nogui
+sim: $(EE_BIN_PACKED)
+	PCSX2 --elf=$(PWD)/$< --nodisc --nogui
 
 pc_tools:
 	echo "Building iso2opl, opl2iso and genvmc..."

--- a/modules/iopcore/cdvdman/device-hdd.c
+++ b/modules/iopcore/cdvdman/device-hdd.c
@@ -55,7 +55,7 @@ void DeviceInit(void)
     hdl_apa_header apaHeader;
     int r;
 
-    DPRINTF("fs_init: apa header LBA = %lu\n", cdvdman_settings.lba_start);
+    DPRINTF("DeviceInit: apa header LBA = %lu\n", cdvdman_settings.lba_start);
 
 #ifdef HD_PRO
     //For HDPro, as its custom ATAD module does not export ata_io_start() and ata_io_finish(). And it also resets the ATA bus.
@@ -66,7 +66,7 @@ void DeviceInit(void)
 #endif
 
     while ((r = ata_device_sector_io(0, &apaHeader, cdvdman_settings.lba_start, 2, ATA_DIR_READ)) != 0) {
-        DPRINTF("fs_init: failed to read apa header %d\n", r);
+        DPRINTF("DeviceInit: failed to read apa header %d\n", r);
         DelayThread(2000);
     }
 

--- a/modules/iopcore/cdvdman/ioops.c
+++ b/modules/iopcore/cdvdman/ioops.c
@@ -250,7 +250,7 @@ static int cdrom_read(iop_file_t *f, void *buf, int size)
 
     WaitSema(cdrom_io_sema);
 
-    DPRINTF("cdrom_read size=%d file_position=%d\n", size, fh->position);
+    DPRINTF("cdrom_read size=%db (%ds) file_position=%d\n", size, size / 2048, fh->position);
 
     if ((fh->position + size) > fh->filesize)
         size = fh->filesize - fh->position;

--- a/modules/iopcore/cdvdman/searchfile.c
+++ b/modules/iopcore/cdvdman/searchfile.c
@@ -52,7 +52,7 @@ static struct dirTocEntry *cdvdman_locatefile(char *name, u32 tocLBA, int tocLen
     struct dirTocEntry *tocEntryPointer;
 
 lbl_startlocate:
-    DPRINTF("cdvdman_locatefile start locating, layer=%d\n", layer);
+    DPRINTF("cdvdman_locatefile start locating %s, layer=%d\n", name, layer);
 
     while (*p == '/')
         p++;

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -266,13 +266,13 @@ static void bdmLaunchGame(int id, config_set_t *configSet)
 
                         // Check VMC cluster chain for fragmentation (write operation can cause damage to the filesystem).
                         if (fileXioIoctl(fd, USBMASS_IOCTL_CHECK_CHAIN, "") == 1) {
-                            LOG("USBSUPPORT Cluster Chain OK\n");
+                            LOG("BDMSUPPORT Cluster Chain OK\n");
                             have_error = 0;
                             bdm_vmc_infos.active = 1;
                             bdm_vmc_infos.start_sector = start;
-                            LOG("USBSUPPORT VMC slot %d start: 0x%X\n", vmc_id, start);
+                            LOG("BDMSUPPORT VMC slot %d start: 0x%X\n", vmc_id, start);
                         } else {
-                            LOG("USBSUPPORT Cluster Chain NG\n");
+                            LOG("BDMSUPPORT Cluster Chain NG\n");
                             have_error = 2;
                         }
                     }
@@ -409,7 +409,7 @@ static int bdmGetImage(char *folder, int isRelative, char *value, char *suffix, 
 static void bdmCleanUp(int exception)
 {
     if (bdmGameList.enabled) {
-        LOG("USBSUPPORT CleanUp\n");
+        LOG("BDMSUPPORT CleanUp\n");
 
         free(bdmGames);
 
@@ -422,7 +422,7 @@ static void bdmCleanUp(int exception)
 static void bdmShutdown(void)
 {
     if (bdmGameList.enabled) {
-        LOG("USBSUPPORT Shutdown\n");
+        LOG("BDMSUPPORT Shutdown\n");
 
         free(bdmGames);
     }

--- a/src/system.c
+++ b/src/system.c
@@ -849,6 +849,8 @@ void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdv
     }
 #endif
 
+    LOG("Leaving OPL GUI, starting eecore...\n");
+
     // Let's go.
     fileXioExit();
     SifExitRpc();


### PR DESCRIPTION
The normal ELF file couses issues when loaded by ps2link and pcsx2. I believe this is caused by the stack size allocated by ps2link (16KiB?). The compressed elf does not have these issues (larger stack, 128KiB?)

Added some debugging info, nothing special.

Cleaned a some typo's. Mostly USB -> BDM renames.