### PR TITLE
Parse launch args to auto boot games from HDDOSD

### DIFF
--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -62,7 +62,6 @@ int hddDeleteHDLGame(hdl_game_info_t *ginfo);
 void hddInit();
 item_list_t *hddGetObject(int initOnly);
 void hddLoadModules(void);
-
-extern char gOPLPart[128];
+void hddLaunchGame(int id, config_set_t *configSet);
 
 #endif

--- a/include/opl.h
+++ b/include/opl.h
@@ -38,6 +38,8 @@
 #include <ps2smb.h>
 #include "config.h"
 
+#include "include/hddsupport.h"
+
 // Last Played Auto Start
 #include <time.h>
 
@@ -167,7 +169,6 @@ extern int gDefaultDevice;
 
 extern int gEnableWrite;
 
-extern char *gHDDPrefix;
 // These prefixes are relative to the device's name (meaning that they do not include the device name).
 extern char gBDMPrefix[32];
 extern char gETHPrefix[32];
@@ -184,6 +185,10 @@ extern unsigned char gDefaultBgColor[3];
 extern unsigned char gDefaultTextColor[3];
 extern unsigned char gDefaultSelTextColor[3];
 extern unsigned char gDefaultUITextColor[3];
+
+extern hdl_game_info_t *gAutoLaunchGame;
+extern char *gHDDPrefix;
+extern char gOPLPart[128];
 
 void setDefaultColors(void);
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
This is finally complete so I can stop obsessing about it.

White screen issues were caused by OPL-Launcher which has been fixed..
Black Screen issue 1 was caused by ps2logo calling gui functions which would cause lock up due to gui not being initiated.. this has been fixed so ps2logo will now work..
Black Screen issue 2 was cause by the game simply not being compatible with PADEMU and conf_game.cfg having global pademu enabled..

Thanks to Berion for testing many, many builds until all issues were resolved.
