### PR TITLE
USBExtreme format extended:

### DIFF
--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -27,13 +27,14 @@ typedef struct
 
 typedef struct
 {
-    char name[UL_GAME_NAME_MAX];
-    char startup[15];
-    u8 parts;
-    u8 media; // Disc type
-    u8 unknown[4];
-    u8 Byte08; // Always 0x08
-    u8 unknown2[10];
+    char name[UL_GAME_NAME_MAX];    // it is not a string but character array, terminating NULL is not necessary
+    char magic[3];                  // magic string "ul."
+    char startup[GAME_STARTUP_MAX]; // it is not a string but character array, terminating NULL is not necessary
+    u8 parts;                       // slice count
+    u8 media;                       // Disc type
+    u8 unknown[4];                  // Always zero
+    u8 Byte08;                      // Always 0x08
+    u8 unknown2[10];                // Always zero
 } USBExtreme_game_entry_t;
 
 int sbIsSameSize(const char *prefix, int prevSize);

--- a/src/system.c
+++ b/src/system.c
@@ -288,7 +288,7 @@ unsigned int USBA_crc32(const char *string)
     do {
         byte = string[count++];
         crc = crctab[byte ^ ((crc >> 24) & 0xFF)] ^ ((crc << 8) & 0xFFFFFF00);
-    } while (string[count - 1] != 0);
+    } while ((string[count - 1] != 0) && (count <= 32));
 
     return crc;
 }


### PR DESCRIPTION
-added 2 byte value for game size in MiB in USBExtreme header
-skip non-valid entries in ul.cfg (useful for static size ul.cfg with empty records)

## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

