### PR TITLE
IGR poweroff bug fixed

### DIFF
--- a/ee_core/src/cd_igr_rpc.c
+++ b/ee_core/src/cd_igr_rpc.c
@@ -9,7 +9,7 @@ int oplIGRShutdown(int poff)
 {
     SifRpcClientData_t _igr_cd;
     int r;
-    s32 poffData;
+    s32 poffData  __attribute__ ((aligned(64)));
 
     _igr_cd.server = NULL;
     while ((r = SifBindRpc(&_igr_cd, 0x80000598, 0)) >= 0 && (!_igr_cd.server))

--- a/ee_core/src/cd_igr_rpc.c
+++ b/ee_core/src/cd_igr_rpc.c
@@ -9,7 +9,7 @@ int oplIGRShutdown(int poff)
 {
     SifRpcClientData_t _igr_cd;
     int r;
-    s32 poffData  __attribute__ ((aligned(64)));
+    s32 poffData __attribute__ ((aligned(64)));
 
     _igr_cd.server = NULL;
     while ((r = SifBindRpc(&_igr_cd, 0x80000598, 0)) >= 0 && (!_igr_cd.server))

--- a/ee_core/src/cd_igr_rpc.c
+++ b/ee_core/src/cd_igr_rpc.c
@@ -9,7 +9,7 @@ int oplIGRShutdown(int poff)
 {
     SifRpcClientData_t _igr_cd;
     int r;
-    s32 poffData __attribute__ ((aligned(64)));
+    s32 poffData __attribute__((aligned(64)));
 
     _igr_cd.server = NULL;
     while ((r = SifBindRpc(&_igr_cd, 0x80000598, 0)) >= 0 && (!_igr_cd.server))


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [X] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

This PR aims to fix #446  issue first reported by @J013k. Issue wasn't related to stack as I first stated. I solved it by aligning the RPC buffer at EE side to a 64-byte boundary.

