### PR TITLE
Force usage of GitHub markdown processor on GitHub pages

### DIFF
--- a/Build_types.md
+++ b/Build_types.md
@@ -1,0 +1,19 @@
+## Open PS2 Loader offers the next build types:
+
+| Type (can be a combination) | Description                                                                             |
+| --------------------------- | --------------------------------------------------------------------------------------- |
+| `Release`                   | Regular OPL release with GSM, IGS, PADEMU, VMC, PS2RD Cheat Engine & Parental Controls. |
+| `DTL_T10000`                | OPL for [TOOLs](https://images.app.goo.gl/8ZpK5gjJsWCb6EtJ9) (DevKit PS2)                                                              |
+| `IGS`                       | OPL with InGame Screenshot feature.                                                     |
+| `PADEMU`                    | OPL with Pad Emulation for DS3 & DS4.                                                   |
+| `RTL`                       | OPL with the right to left language support.                                            |
+
+> These build types are bundled by the release workflow Into the file called `OPNPS2LD-VARIANTS.7z`
+
+# Debug builds
+
+OPL can be built on 4 different debug build types.
+
+These builds aren't bundled on release, however you can download them from the [__*workflow run summary*__](https://github.com/ps2homebrew/Open-PS2-Loader/actions/workflows/compilation.yml) (you must have a Github account to see and download the build artifacts)
+
+##### [Go back](./)

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+markdown: GFM

--- a/links.md
+++ b/links.md
@@ -1,0 +1,19 @@
+# Related links:
+
+
++ [__*PSX-Place Forum*__](https://www.psx-place.com/forums/77/)
++ [__*Compatibility List*__](http://sx.sytes.net/oplcl/games.aspx)
+
+
+## Download links:
+
++ [__*Latest Stable Release*__](https://github.com/ps2homebrew/Open-PS2-Loader/releases/latest)
++ [__*Latest BETA Build*__](https://github.com/ps2homebrew/Open-PS2-Loader/releases/tag/latest)
++ [__*OPL Archive*__](https://mega.nz/folder/Ndwi1bAK#oLWNhH_g-h0p4BoT4c556A)
+----
++ [__*Source Code*__](https://github.com/ps2homebrew/Open-PS2-Loader/archive/refs/heads/master.zip)
+
+### Found an Issue?
+__Report it on:__ 
+- [__*GitHub*__](https://github.com/ps2homebrew/Open-PS2-Loader/issues/new?assignees=&labels=bug&template=issue-report.yml&title=%5BISSUE%5D%3A+)
+- [__*PSX-Place*__](https://www.psx-place.com/threads/open-ps2-loader-game-bug-reports.19401/)


### PR DESCRIPTION

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

This will force the use of GitHub markdown processor.

GitHub-pages uses another markdown processor by default that might cause issues with some markdown elements (like tables)

Using this new processor on gh-pages is the best option, since you can use markdown like if you where on GitHub, while you can still benefit from HTML
