### PR TITLE
Fix: increase MAX_MODULES to 64

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -55,7 +55,7 @@ extern unsigned int size_IOPRP_img;
 extern unsigned char eesync_irx[];
 extern unsigned int size_eesync_irx;
 
-#define MAX_MODULES 32
+#define MAX_MODULES 64
 static void *g_sysLoadedModBuffer[MAX_MODULES];
 
 #define ELF_MAGIC   0x464c457f


### PR DESCRIPTION
I could not get the NBD server to load while testing, this was caused by 32 modules already loaded. This simple PR increases the limit to 64.
