### PR TITLE
fix memory cards

### DIFF
--- a/lng/lang_Polish.lng
+++ b/lng/lang_Polish.lng
@@ -1,6 +1,6 @@
 # Wersja 0.26. W większości przetłumaczone przez dragolice. Ponownie tłumaczyć "próbowali" Jolek & KaiQ. Podziękowania dla Haker120, misiozola i innych z Forum CDRinfo.pl ("https://forum.cdrinfo.pl/f30/") za pomoc i sugestie.
 # For Open PS2 Loader v1.0.0 + betas - Official OPL Beta thread @https://www.psx-place.com/threads/open-ps2-loader-language-pack.20547/
-Open PS2 Loader %s
+Polski
 Zapisz Zmiany
 Wróć
 Ustawienia Sieci

--- a/src/gui.c
+++ b/src/gui.c
@@ -1477,7 +1477,7 @@ void guiMainLoop(void)
     guiResetNotifications();
     guiCheckNotifications(1, 1);
 
-    if (gOPLPart[0] != NULL)
+    if (gOPLPart[0] != '\0')
         showPartPopup = 1;
 
     while (!gTerminate) {

--- a/src/util.c
+++ b/src/util.c
@@ -10,7 +10,7 @@
 #include "include/system.h"
 #include <string.h>
 #include <malloc.h>
-#include <osd_config.h>
+#include <rom0_info.h>
 
 #include "include/hdd.h"
 
@@ -35,8 +35,6 @@ int getFileSize(int fd)
     return size;
 }
 
-#define MAX_ENTRY 128
-
 static int checkMC()
 {
     int mc0_is_ps2card, mc1_is_ps2card;
@@ -44,14 +42,14 @@ static int checkMC()
 
     if (mcID == -1) {
         mc0_is_ps2card = 0;
-        DIR *mc0_root_dir = opendir("mc0:");
+        DIR *mc0_root_dir = opendir("mc0:/");
         if (mc0_root_dir != NULL) {
             closedir(mc0_root_dir);
             mc0_is_ps2card = 1;
         }
 
         mc1_is_ps2card = 0;
-        DIR *mc1_root_dir = opendir("mc1:");
+        DIR *mc1_root_dir = opendir("mc1:/");
         if (mc1_root_dir != NULL) {
             closedir(mc1_root_dir);
             mc1_is_ps2card = 1;
@@ -94,23 +92,6 @@ static int checkMC()
     return mcID;
 }
 
-static void writeMCIcon(void)
-{
-    int fd;
-
-    fd = openFile("mc?:OPL/opl.icn", O_WRONLY | O_CREAT | O_TRUNC);
-    if (fd >= 0) {
-        write(fd, &icon_icn, size_icon_icn);
-        close(fd);
-    }
-
-    fd = openFile("mc?:OPL/icon.sys", O_WRONLY | O_CREAT | O_TRUNC);
-    if (fd >= 0) {
-        write(fd, &icon_sys, size_icon_sys);
-        close(fd);
-    }
-}
-
 void checkMCFolder(void)
 {
     char path[32];
@@ -126,7 +107,11 @@ void checkMCFolder(void)
     snprintf(path, sizeof(path), "mc%d:OPL/opl.icn", mcID & 1);
     fd = open(path, O_RDONLY, 0666);
     if (fd < 0) {
-        writeMCIcon();
+        fd = open(path, O_WRONLY | O_CREAT | O_TRUNC);
+        if (fd >= 0) {
+            write(fd, &icon_icn, size_icon_icn);
+            close(fd);
+        }
     } else {
         close(fd);
     }
@@ -134,7 +119,11 @@ void checkMCFolder(void)
     snprintf(path, sizeof(path), "mc%d:OPL/icon.sys", mcID & 1);
     fd = open(path, O_RDONLY, 0666);
     if (fd < 0) {
-        writeMCIcon();
+        fd = open(path, O_WRONLY | O_CREAT | O_TRUNC);
+        if (fd >= 0) {
+            write(fd, &icon_sys, size_icon_sys);
+            close(fd);
+        }
     } else {
         close(fd);
     }
@@ -157,10 +146,16 @@ static int checkFile(char *path, int mode)
 
         // in create mode, we check that the directory exist, or create it
         if (mode & O_CREAT) {
-            int res = mkdir(path, 0777);
-            // Non-standard POSIX check: the error value is supposed to be assigned to errno, not the return value
-            if (res >= 0 || res == -EEXIST) {
-                return 0;
+            char dirPath[256];
+            char *pos = strrchr(path, '/');
+            if (pos) {
+                memcpy(dirPath, path, (pos - path));
+                dirPath[(pos - path)] = '\0';
+                int res = mkdir(dirPath, 0777);
+                // Non-standard POSIX check: the error value is supposed to be assigned to errno, not the return value
+                if (res >= 0 || res == -EEXIST) {
+                    return 0;
+                }
             }
         }
     }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
Fixes #497
Update Include for `GetRomName()`
Remove (now) unused `#define`
Fix mcID failing to resolve when no OPL folder on root of mcs.
Remove `writeMCIcon()`, at the point this is called we've already got the mcID so calling `openFile()` with `mc?` is pointless.
Fix: in create mode we check if file directory exists and if not create just the dir, not the whole file as a dir.
gui.c fix comparison to int.
Fix error in polish lang file.

Best Regards
