### PR TITLE
Update lang_Polish.lng

### DIFF
--- a/lng/lang_Polish.lng
+++ b/lng/lang_Polish.lng
@@ -106,7 +106,7 @@ Testuj Zmiany
 Pozostaw puste dla "GOŚCIA".
 Dokładny Odczyt
 Tryb Synchroniczny
-Wymaż OPL Po Uruchomieniu Gry
+Odepnij syscalle
 Pomiń Wstawki Filmowe
 Emuluj DVD-DL
 Wyłącz IGR


### PR DESCRIPTION
This translation doesn't make sense, Wymaż OPL Po Uruchomieniu Gry means wipe OPL after the game starts which isn't what this function does. I prefer to stay with syscall as it has no translation equivalent in Polish also unhook as odpiąć which makes sense in technical aspect.