### PR TITLE
get console region at autoLaunch init for ps2logo decryption

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -1708,6 +1708,7 @@ static void autoLaunchHDDGame(char *argv[])
     LOG_ENABLE();
 
     hddLoadModules();
+    InitConsoleRegionData();
 
     ret = configReadMulti(CONFIG_ALL);
     if (CONFIG_ALL & CONFIG_OPL) {


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description
Fixes an issue reported on discord by LopoTRI; when loading OPL via OPL-Launcher from HDD-OSD ps2logo setting doesn't work.
