### PR TITLE
Fix matrix to build all variants

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -49,10 +49,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rtl: ["", RTL=1]
-        pademu: ["", PADEMU=1]
-        igs: ["", IGS=1]
-        t10k: ["", DTL_T10000=1]
+        rtl: [RTL=0, RTL=1]
+        pademu: [PADEMU=0, PADEMU=1]
+        igs: [IGS=0, IGS=1]
+        t10k: [DTL_T10000=0, DTL_T10000=1]
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev:latest
     steps:


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK
- [ ] Requires update of the gsKit
- [ ] Others (please specify below)

## Pull Request description

Before, the only variant changes were t10k and rtl, because the other options were enabled by default in Makefile. Now all variants are built.