### PR TITLE
Fix PADEMU for SMB/HDD with games that use USBD

### DIFF
--- a/ee_core/src/syshook.c
+++ b/ee_core/src/syshook.c
@@ -180,8 +180,8 @@ void Install_Kernel_Hooks(void)
         SetSyscall(__NR__ExecPS2, &Hook_ExecPS2);
     }
 
-    Old_Exit = GetSyscallHandler(__NR__Exit);
-    SetSyscall(__NR__Exit, &Hook_Exit);
+    Old_Exit = GetSyscallHandler(__NR_KExit);
+    SetSyscall(__NR_KExit, &Hook_Exit);
 }
 
 /*----------------------------------------------------------------------------------------------*/
@@ -192,7 +192,7 @@ void Remove_Kernel_Hooks(void)
 {
     SetSyscall(__NR_SifSetDma, Old_SifSetDma);
     SetSyscall(__NR_SifSetReg, Old_SifSetReg);
-    SetSyscall(__NR__Exit, Old_Exit);
+    SetSyscall(__NR_KExit, Old_Exit);
 
     DI();
     ee_kmode_enter();

--- a/modules/iopcore/cdvdman/ioplib_util.c
+++ b/modules/iopcore/cdvdman/ioplib_util.c
@@ -8,8 +8,8 @@
 #include <stdio.h>
 #include <sysclib.h>
 
+#include "internal.h"
 #include "ioplib_util.h"
-
 #include "smsutils.h"
 
 #ifdef __IOPCORE_DEBUG
@@ -49,9 +49,10 @@ struct FakeModule
 {
     const char *fname;
     const char *name;
-    int id; //ID to return to the game.
+    int id; // ID to return to the game.
+    u8 flag;
     u16 version;
-    s16 returnValue; //Typical return value of module. RESIDENT END (0), NO RESIDENT END (1) or REMOVABLE END (2).
+    s16 returnValue; // Typical return value of module. RESIDENT END (0), NO RESIDENT END (1) or REMOVABLE END (2).
 };
 
 enum FAKE_MODULE_ID {
@@ -65,21 +66,20 @@ enum FAKE_MODULE_ID {
 
 static struct FakeModule modulefake_list[] = {
 #ifdef __USE_DEV9
-    {"DEV9.IRX", "dev9", FAKE_MODULE_ID_DEV9, 0x0208, 0},
+    {"DEV9.IRX", "dev9", FAKE_MODULE_ID_DEV9, FAKE_MODULE_FLAG_DEV9, 0x0208, 0},
 #endif
-#ifdef BDM_DRIVER
-    {"USBD.IRX", "USB_driver", FAKE_MODULE_ID_USBD, 0x0204, 2},
-#endif
+    // Faked dynamically for BDM-USB and PADEMU
+    {"USBD.IRX", "USB_driver", FAKE_MODULE_ID_USBD, FAKE_MODULE_FLAG_USBD, 0x0204, 2},
 #ifdef SMB_DRIVER
-    {"SMAP.IRX", "INET_SMAP_driver", FAKE_MODULE_ID_SMAP, 0x0219, 2},
-    {"ENT_SMAP.IRX", "ent_smap", FAKE_MODULE_ID_SMAP, 0x021f, 2},
+    {"SMAP.IRX", "INET_SMAP_driver", FAKE_MODULE_ID_SMAP, FAKE_MODULE_FLAG_SMAP, 0x0219, 2},
+    {"ENT_SMAP.IRX", "ent_smap", FAKE_MODULE_ID_SMAP, FAKE_MODULE_FLAG_SMAP, 0x021f, 2},
 #endif
 #ifdef HDD_DRIVER
-    {"ATAD.IRX", "atad_driver", FAKE_MODULE_ID_ATAD, 0x0207, 0},
+    {"ATAD.IRX", "atad_driver", FAKE_MODULE_ID_ATAD, FAKE_MODULE_FLAG_ATAD, 0x0207, 0},
 #endif
-    {"CDVDSTM.IRX", "cdvd_st_driver", FAKE_MODULE_ID_CDVDSTM, 0x0202, 2},
-    //Games cannot load CDVDFSV, but this exits to prevent games from trying to unload it. Some games like Jak X check if this module can be unloaded, ostensibly as an anti-HDLoader measure.
-    {"CDVDFSV.IRX", "cdvd_ee_driver", FAKE_MODULE_ID_CDVDFSV, 0x0202, 2},
+    {"CDVDSTM.IRX", "cdvd_st_driver", FAKE_MODULE_ID_CDVDSTM, FAKE_MODULE_FLAG_CDVDSTM, 0x0202, 2},
+    // Games cannot load CDVDFSV, but this exits to prevent games from trying to unload it. Some games like Jak X check if this module can be unloaded, ostensibly as an anti-HDLoader measure.
+    {"CDVDFSV.IRX", "cdvd_ee_driver", FAKE_MODULE_ID_CDVDFSV, FAKE_MODULE_FLAG_CDVDFSV, 0x0202, 2},
     {NULL, NULL, 0, 0}};
 
 //--------------------------------------------------------------
@@ -156,7 +156,7 @@ static int Hook_LoadStartModule(char *modpath, int arg_len, char *args, int *mod
     DPRINTF("Hook_LoadStartModule() modpath = %s\n", modpath);
 
     mod = checkFakemodByFile(modpath, modulefake_list);
-    if (mod != NULL) {
+    if (mod != NULL && mod->flag) {
         *modres = mod->returnValue;
         return mod->id;
     }
@@ -172,7 +172,7 @@ static int Hook_StartModule(int id, char *modname, int arg_len, char *args, int 
     DPRINTF("Hook_StartModule() id=%d modname = %s\n", id, modname);
 
     mod = checkFakemodById(id, modulefake_list);
-    if (mod != NULL) {
+    if (mod != NULL && mod->flag) {
         *modres = mod->returnValue;
         return mod->id;
     }
@@ -188,7 +188,7 @@ static int Hook_LoadModuleBuffer(void *ptr)
     DPRINTF("Hook_LoadModuleBuffer() modname = %s\n", ((char *)ptr + 0x8e));
 
     mod = checkFakemodByName(((char *)ptr + 0x8e), modulefake_list);
-    if (mod != NULL)
+    if (mod != NULL && mod->flag)
         return mod->id;
 
     return LoadModuleBuffer(ptr);
@@ -202,8 +202,8 @@ static int Hook_StopModule(int id, int arg_len, char *args, int *modres)
     DPRINTF("Hook_StopModule() id=%d arg_len=%d\n", id, arg_len);
 
     mod = checkFakemodById(id, modulefake_list);
-    if (mod != NULL) {
-        *modres = 1; //Module unloads and returns NO RESIDENT END
+    if (mod != NULL && mod->flag) {
+        *modres = 1; // Module unloads and returns NO RESIDENT END
         return mod->id;
     }
 
@@ -218,7 +218,7 @@ static int Hook_UnloadModule(int id)
     DPRINTF("Hook_UnloadModule() id=%d\n", id);
 
     mod = checkFakemodById(id, modulefake_list);
-    if (mod != NULL)
+    if (mod != NULL && mod->flag)
         return mod->id;
 
     return UnloadModule(id);
@@ -232,7 +232,7 @@ static int Hook_SearchModuleByName(char *modname)
     DPRINTF("Hook_SearchModuleByName() modname = %s\n", modname);
 
     mod = checkFakemodByName(modname, modulefake_list);
-    if (mod != NULL)
+    if (mod != NULL && mod->flag)
         return mod->id;
 
     return SearchModuleByName(modname);
@@ -246,7 +246,7 @@ static int Hook_ReferModuleStatus(int id, ModuleStatus_t *status)
     DPRINTF("Hook_ReferModuleStatus() modid = %d\n", id);
 
     mod = checkFakemodById(id, modulefake_list);
-    if (mod != NULL) {
+    if (mod != NULL && mod->flag) {
         memset(status, 0, sizeof(ModuleStatus_t));
         strcpy(status->name, mod->name);
         status->version = mod->version;
@@ -260,6 +260,8 @@ static int Hook_ReferModuleStatus(int id, ModuleStatus_t *status)
 //--------------------------------------------------------------
 void hookMODLOAD(void)
 {
+    struct FakeModule *modlist;
+
     // get modload export table
     modinfo_t info;
     getModInfo("modload\0", &info);
@@ -275,6 +277,10 @@ void hookMODLOAD(void)
     // hook modload's LoadModuleBuffer
     LoadModuleBuffer = (void *)info.exports[10];
     info.exports[10] = (void *)Hook_LoadModuleBuffer;
+
+    // Clear the flags of unused modules
+    for (modlist = modulefake_list; modlist->fname != NULL; modlist++)
+        modlist->flag &= cdvdman_settings.common.fakemodule_flags;
 
     // check modload version
     if (info.version > 0x102) {
@@ -295,7 +301,6 @@ void hookMODLOAD(void)
         info.exports[22] = (void *)Hook_SearchModuleByName;
     } else {
         // Change all REMOVABLE END values to RESIDENT END, if modload is old.
-        struct FakeModule *modlist;
         for (modlist = modulefake_list; modlist->fname != NULL; modlist++) {
             if (modlist->returnValue == 2)
                 modlist->returnValue = 0;

--- a/modules/iopcore/common/cdvd_config.h
+++ b/modules/iopcore/common/cdvd_config.h
@@ -1,12 +1,22 @@
 
 #ifndef __CDVD_CONFIG__
 #define __CDVD_CONFIG__
+
+// flags
 #define IOPCORE_COMPAT_ALT_READ      0x0001
 #define IOPCORE_COMPAT_0_SKIP_VIDEOS 0x0002
 #define IOPCORE_COMPAT_EMU_DVDDL     0x0004
 #define IOPCORE_COMPAT_ACCU_READS    0x0008
 #define IOPCORE_ENABLE_POFF          0x0100
 #define IOPCORE_SMB_FORMAT_USBLD     0x0200
+
+// fakemodule_flags
+#define FAKE_MODULE_FLAG_DEV9    (1 << 0) // not used, compiled in
+#define FAKE_MODULE_FLAG_USBD    (1 << 1) // Used with BDM-USB or PADEMU
+#define FAKE_MODULE_FLAG_SMAP    (1 << 2) // not used, compiled in
+#define FAKE_MODULE_FLAG_ATAD    (1 << 3) // not used, compiled in
+#define FAKE_MODULE_FLAG_CDVDSTM (1 << 4) // not used, compiled in
+#define FAKE_MODULE_FLAG_CDVDFSV (1 << 5) // not used, compiled in
 
 #define ISO_MAX_PARTS 10
 
@@ -20,6 +30,7 @@ struct cdvdman_settings_common
     u8 bdm_cache;
     u8 hdd_cache;
     u8 smb_cache;
+    u8 fakemodule_flags;
 } __attribute__((packed));
 
 struct cdvdman_settings_hdd

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -391,12 +391,16 @@ static void bdmLaunchGame(int id, config_set_t *configSet)
         strcpy(filename, game->startup);
     deinit(NO_EXCEPTION, BDM_MODE); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
 
-    if (!strcmp(bdmDriver, "usb"))
+    if (!strcmp(bdmDriver, "usb")) {
+        settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_USBD;
         sysLaunchLoaderElf(filename, "BDM_USB_MODE", irx_size, irx, size_mcemu_irx, &bdm_mcemu_irx, EnablePS2Logo, compatmask);
-    else if (!strcmp(bdmDriver, "sd") && strlen(bdmDriver) == 2)
+    } else if (!strcmp(bdmDriver, "sd") && strlen(bdmDriver) == 2) {
+        settings->common.fakemodule_flags |= 0 /* TODO! fake ilinkman ? */;
         sysLaunchLoaderElf(filename, "BDM_ILK_MODE", irx_size, irx, size_mcemu_irx, &bdm_mcemu_irx, EnablePS2Logo, compatmask);
-    else if (!strcmp(bdmDriver, "sdc") && strlen(bdmDriver) == 3)
+    } else if (!strcmp(bdmDriver, "sdc") && strlen(bdmDriver) == 3) {
+        settings->common.fakemodule_flags |= 0;
         sysLaunchLoaderElf(filename, "BDM_M4S_MODE", irx_size, irx, size_mcemu_irx, &bdm_mcemu_irx, EnablePS2Logo, compatmask);
+    }
 }
 
 static config_set_t *bdmGetConfig(int id)

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -699,6 +699,8 @@ static void ethLaunchGame(int id, config_set_t *configSet)
         strcpy(filename, game->startup);
     deinit(NO_EXCEPTION, ETH_MODE); // CAREFUL: deinit will call ethCleanUp, so ethGames/game will be freed
 
+    settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_DEV9;
+    settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_SMAP;
     sysLaunchLoaderElf(filename, "ETH_MODE", size_smb_cdvdman_irx, &smb_cdvdman_irx, size_mcemu_irx, &smb_mcemu_irx, EnablePS2Logo, compatmask);
 }
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -506,6 +506,8 @@ void hddLaunchGame(int id, config_set_t *configSet)
         configEnd();
     }
 
+    settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_DEV9;
+    settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_ATAD;
     sysLaunchLoaderElf(filename, "HDD_MODE", size_irx, irx, size_mcemu_irx, &hdd_mcemu_irx, EnablePS2Logo, compatMode);
 }
 

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -616,6 +616,10 @@ int sbPrepare(base_game_info_t *game, config_set_t *configSet, int size_cdvdman,
     settings->hdd_cache = hddCacheSize;
     settings->smb_cache = smbCacheSize;
 
+    settings->fakemodule_flags = 0;
+    settings->fakemodule_flags |= FAKE_MODULE_FLAG_CDVDFSV;
+    settings->fakemodule_flags |= FAKE_MODULE_FLAG_CDVDSTM;
+
     InitGSMConfig(configSet);
 
     InitCheatsConfig(configSet);
@@ -641,6 +645,10 @@ int sbPrepare(base_game_info_t *game, config_set_t *configSet, int size_cdvdman,
         configGetInt(configSet, CONFIG_ITEM_PADMACROSETTINGS, &gPadMacroSettings);
     } else {
         configGetInt(configGame, CONFIG_ITEM_PADMACROSETTINGS, &gPadMacroSettings);
+    }
+
+    if (gEnablePadEmu) {
+        settings->fakemodule_flags |= FAKE_MODULE_FLAG_USBD;
     }
 #endif
 


### PR DESCRIPTION
The fake modules list has untill now been FIXED to the mode: USB/SMB/HDD. This PR makes the fakelist dynamic at runtime, meaning that when a user selects PADEMU, the GUI can tell the IOPCORE to fake the USBD driver.

Another advantage is that iLink and mx4sio will no longer fake USBD when they do not load the USBD driver. So this fixes the following:

- SMB/HDD mode **with** PADEMU should now work with games using USBD
- iLink/mx4sio **without** PADEMU should now work with games using USBD