### PR TITLE
Changed vfat to fatfs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ FRONTEND_OBJS = pad.o fntsys.o renderman.o menusys.o OSDHistory.o system.o lang.
 		appsupport.o gui.o guigame.o textures.o opl.o atlas.o nbns.o httpclient.o gsm.o cheatman.o sound.o ps2cnf.o
 
 IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o bdmevent.o \
-		bdm.o bdmfs_vfat.o usbmass_bd.o iLinkman.o IEEE1394_bd.o mx4sio_bd.o \
+		bdm.o bdmfs_fatfs.o usbmass_bd.o iLinkman.o IEEE1394_bd.o mx4sio_bd.o \
 		ps2atad.o hdpro_atad.o poweroff.o ps2hdd.o xhdd.o genvmc.o lwnbdsvr.o \
 		ps2dev9.o smsutils.o ps2ip.o smap.o isofs.o nbns-iop.o \
 		sio2man.o padman.o mcman.o mcserv.o \
@@ -519,8 +519,8 @@ $(EE_ASM_DIR)usb_pademu.s: modules/pademu/usb_pademu.irx
 $(EE_ASM_DIR)bdm.s: $(PS2SDK)/iop/irx/bdm.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ bdm_irx
 
-$(EE_ASM_DIR)bdmfs_vfat.s: $(PS2SDK)/iop/irx/bdmfs_vfat.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ bdmfs_vfat_irx
+$(EE_ASM_DIR)bdmfs_fatfs.s: $(PS2SDK)/iop/irx/bdmfs_fatfs.irx | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ bdmfs_fatfs_irx
 
 $(EE_ASM_DIR)iLinkman.s: $(PS2SDK)/iop/irx/iLinkman.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ iLinkman_irx

--- a/include/extern_irx.h
+++ b/include/extern_irx.h
@@ -22,8 +22,8 @@ extern int size_bdm_mcemu_irx;
 extern void *bdmevent_irx;
 extern int size_bdmevent_irx;
 
-extern void *bdmfs_vfat_irx;
-extern int size_bdmfs_vfat_irx;
+extern void *bdmfs_fatfs_irx;
+extern int size_bdmfs_fatfs_irx;
 
 extern void *bt_pademu_irx;
 extern int size_bt_pademu_irx;

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -95,8 +95,8 @@ void bdmLoadModules(void)
     // Load Block Device Manager (BDM)
     sysLoadModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL);
 
-    // Load VFAT (mass:) driver
-    sysLoadModuleBuffer(&bdmfs_vfat_irx, size_bdmfs_vfat_irx, 0, NULL);
+    // Load FATFS (mass:) driver
+    sysLoadModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL);
 
     // Load USB Block Device drivers
     sysLoadModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [X] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [X] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Replaced BDM vfat driver with the new fatfs driver.
Requires latest PS2SDK.