### PR TITLE
Add fat32/exfat fragmentation tolerance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,8 +241,6 @@ clean:
 	echo "Cleaning..."
 	echo "-Interface"
 	rm -fr $(MAPFILE) $(EE_BIN) $(EE_BIN_PACKED) $(EE_BIN_STRIPPED) $(EE_VPKD).* $(EE_OBJS_DIR) $(EE_ASM_DIR)
-	echo "-Language"
-	rm -fr $(LNG_SRC_DIR) $(LNG_DIR)lang_*.lng $(INTERNAL_LANGUAGE_C) $(INTERNAL_LANGUAGE_H)
 	echo "-EE core"
 	$(MAKE) -C ee_core clean
 	echo "-IOP core"
@@ -313,6 +311,10 @@ clean:
 	$(MAKE) -C modules/pademu USE_USB=1 clean
 	echo "-pc tools"
 	$(MAKE) -C pc clean
+
+realclean: clean
+	echo "-Language"
+	rm -fr $(LNG_SRC_DIR) $(LNG_DIR)lang_*.lng $(INTERNAL_LANGUAGE_C) $(INTERNAL_LANGUAGE_H)
 
 rebuild: clean all
 

--- a/modules/iopcore/cdvdman/Makefile
+++ b/modules/iopcore/cdvdman/Makefile
@@ -33,6 +33,7 @@ IOP_BIN  = bdm_cdvdman.irx
 IOP_OBJS_DIR = obj.bdm/
 IOP_OBJS += device-bdm.o
 IOP_CFLAGS += -DBDM_DRIVER
+IOP_LIBS += -L$(PS2SDK)/iop/lib -lbdm
 ifeq ($(IOPCORE_DEBUG),1)
 USE_DEV9 = 1
 endif

--- a/modules/iopcore/cdvdman/device-bdm.c
+++ b/modules/iopcore/cdvdman/device-bdm.c
@@ -114,7 +114,7 @@ int DeviceReadSectors(u32 lsn, void *buffer, unsigned int sectors)
         return SCECdErTRMOPN;
 
     WaitSema(bdm_io_sema);
-    if (bd_defrag(g_bd, &cdvdman_settings.frags, lsn * 4, buffer, sectors * 4) != (sectors * 4))
+    if (bd_defrag(g_bd, cdvdman_settings.fragfile[0].frag_count, &cdvdman_settings.frags[cdvdman_settings.fragfile[0].frag_start], lsn * 4, buffer, sectors * 4) != (sectors * 4))
         rv = SCECdErREAD;
     SignalSema(bdm_io_sema);
 

--- a/modules/iopcore/cdvdman/internal.h
+++ b/modules/iopcore/cdvdman/internal.h
@@ -122,7 +122,13 @@ extern void cdvdman_initdev(void);
 
 extern struct CDVDMAN_SETTINGS_TYPE cdvdman_settings;
 
+#ifdef HDD_DRIVER
+// HDD driver also uses this buffer, for aligning unaligned reads.
 #define CDVDMAN_BUF_SECTORS 2
+#else
+// Normally this buffer is only used by 'searchfile', only 1 sector used
+#define CDVDMAN_BUF_SECTORS 1
+#endif
 extern u8 cdvdman_buf[CDVDMAN_BUF_SECTORS * 2048];
 
 extern int cdrom_io_sema;

--- a/modules/iopcore/cdvdman/ioplib_util.c
+++ b/modules/iopcore/cdvdman/ioplib_util.c
@@ -12,14 +12,6 @@
 #include "ioplib_util.h"
 #include "smsutils.h"
 
-#ifdef __IOPCORE_DEBUG
-#define DPRINTF(args...) printf(args)
-#else
-#define DPRINTF(args...) \
-    do {                 \
-    } while (0)
-#endif
-
 typedef struct ModuleStatus
 {
     char name[56];

--- a/modules/iopcore/common/cdvd_config.h
+++ b/modules/iopcore/common/cdvd_config.h
@@ -2,6 +2,9 @@
 #ifndef __CDVD_CONFIG__
 #define __CDVD_CONFIG__
 
+#include <tamtypes.h>
+#include <usbhdfsd-common.h>
+
 // flags
 #define IOPCORE_COMPAT_ALT_READ      0x0001
 #define IOPCORE_COMPAT_0_SKIP_VIDEOS 0x0002
@@ -13,7 +16,7 @@
 // fakemodule_flags
 #define FAKE_MODULE_FLAG_DEV9    (1 << 0) // not used, compiled in
 #define FAKE_MODULE_FLAG_USBD    (1 << 1) // Used with BDM-USB or PADEMU
-#define FAKE_MODULE_FLAG_SMAP    (1 << 2) // not used, compiled in
+#define FAKE_MODULE_FLAG_SMAP    (1 << 2) // Used with SMB or BDM-UDPBD
 #define FAKE_MODULE_FLAG_ATAD    (1 << 3) // not used, compiled in
 #define FAKE_MODULE_FLAG_CDVDSTM (1 << 4) // not used, compiled in
 #define FAKE_MODULE_FLAG_CDVDFSV (1 << 5) // not used, compiled in
@@ -61,7 +64,7 @@ struct cdvdman_settings_smb
 struct cdvdman_settings_bdm
 {
     struct cdvdman_settings_common common;
-    u32 LBAs[ISO_MAX_PARTS];
+    bd_fraglist_t frags;
 } __attribute__((packed));
 
 #endif

--- a/modules/iopcore/common/cdvd_config.h
+++ b/modules/iopcore/common/cdvd_config.h
@@ -61,10 +61,25 @@ struct cdvdman_settings_smb
     };
 } __attribute__((packed));
 
+#define BDM_MAX_FILES 1  // ISO
+#define BDM_MAX_FRAGS 64 // 64 * 8bytes = 512bytes
+
+struct cdvdman_fragfile
+{
+    u8 frag_start; /// First fragment in the fragment table
+    u8 frag_count; /// Munber of fragments in the fragment table
+} __attribute__((packed));
+
 struct cdvdman_settings_bdm
 {
     struct cdvdman_settings_common common;
-    bd_fraglist_t frags;
+
+    // Fragmented files:
+    // 0 = ISO
+    struct cdvdman_fragfile fragfile[BDM_MAX_FILES];
+
+    // Fragment table, containing the fragments of all files
+    bd_fragment_t frags[BDM_MAX_FRAGS];
 } __attribute__((packed));
 
 #endif


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [X] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [X] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

This PR adds fragmentation support to the ingame / iopcore. This applies to all BDM devices using fat32/exFat. Up to 10 fragments will be possible. If there's more fragments then the same old fragmentation message should appear.

Also in this PR I made the cloning of the lang folder a little less aggressive. 'make clean all' will no longer remove the lang folder, and only update the lang folder. 'make realclean all' will also delete the lang folder, and re-clone it.