### PR TITLE
use usbd_mini.irx instead of usbd.irx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,7 @@ modules/isofs/isofs.irx: modules/isofs
 $(EE_ASM_DIR)isofs.s: modules/isofs/isofs.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ isofs_irx
 
-$(EE_ASM_DIR)usbd.s: $(PS2SDK)/iop/irx/usbd.irx | $(EE_ASM_DIR)
+$(EE_ASM_DIR)usbd.s: $(PS2SDK)/iop/irx/usbd_mini.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ usbd_irx
 
 $(EE_ASM_DIR)libsd.s: $(PS2SDK)/iop/irx/libsd.irx | $(EE_ASM_DIR)


### PR DESCRIPTION
This replaces the usbd.irx driver with the usbd_mini driver.irx driver. It's the same driver, but with resources trimmed down. As a result this change saves over **42KiB** of IOP RAM. This improves game compatibility, and allows more games to use things like PADEMU and MCEMU that consume memory.

More information here:
https://github.com/ps2dev/ps2sdk/pull/293
https://github.com/ps2dev/ps2sdk/commit/90253c175004e1d7a596a40304acd4a4ff696b6b

Note that this PR changes both the ingame usbd driver and the GUI usbd driver.

For reference, the currently tested IOP memory usage (without PADEMU/MCEMU) of OPL's iopcore is:
- USB: **357KiB** (before this PR)
- SMB: **333KiB**
- USB: **314KiB** (after this PR)
- MX4: **264KiB**
- HDD: **260KiB**