### PR TITLE
ps2rd hook code detection

### DIFF
--- a/ee_core/src/cheat_api.c
+++ b/ee_core/src/cheat_api.c
@@ -60,7 +60,7 @@ void SetupCheats()
             k++;
         }
         // Discard any false positives from being possible hooks
-        if ((code.addr & 0xf0000000) == 0x40000000 || 0x30000000) {
+        if ((code.addr & 0xf0000000) == 0x40000000 || (code.addr & 0xf0000000) == 0x30000000) {
             nextCodeCanBeHook = 0;
         } else {
             nextCodeCanBeHook = 1;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

The hook code detection is missing a comparison, which leads to the compiler optimizing out the if/else statement and always setting nextCodeCanBeHook to 0. 

This means that only the first code in the cheat list is considered for being a hook code. If the hook code is not the first thing in the cheat list, or there are multiple hook codes in the cheat list they are not considered and added to the hooklist to be passed to the cheat engine.