### PR TITLE
Correct history record writing

### DIFF
--- a/include/OSDHistory.h
+++ b/include/OSDHistory.h
@@ -97,7 +97,7 @@ struct HistoryEntry
 
 // Functions
 int LoadHistoryFile(const char *path, struct HistoryEntry *HistoryEntries);
-int SaveHistoryFile(const char *path, const struct HistoryEntry *HistoryEntries);
-int AddOldHistoryFileRecord(const char *path, const struct HistoryEntry *OldHistoryEntry);
+int SaveHistoryFile(const char *path, const struct HistoryEntry *HistoryEntries, int mcType);
+int AddOldHistoryFileRecord(const char *path, const struct HistoryEntry *OldHistoryEntry, int mcType);
 int AddHistoryRecord(const char *name);
 int AddHistoryRecordUsingFullPath(const char *path);

--- a/src/OSDHistory.c
+++ b/src/OSDHistory.c
@@ -86,8 +86,11 @@ int LoadHistoryFile(const char *path, struct HistoryEntry *HistoryEntries)
     return result;
 }
 
-int SaveHistoryFile(const char *path, const struct HistoryEntry *HistoryEntries)
+int SaveHistoryFile(const char *path, const struct HistoryEntry *HistoryEntries, int mcType)
 {
+    if (mcType != sceMcTypePS2) //don't write if there is no PS2 MC's 
+        return -1;
+
     char fullpath[64];
     int fd, result;
 
@@ -101,8 +104,11 @@ int SaveHistoryFile(const char *path, const struct HistoryEntry *HistoryEntries)
     return result;
 }
 
-int AddOldHistoryFileRecord(const char *path, const struct HistoryEntry *OldHistoryEntry)
+int AddOldHistoryFileRecord(const char *path, const struct HistoryEntry *OldHistoryEntry, int mcType)
 {
+    if (mcType != sceMcTypePS2) //don't write if there is no PS2 MC's 
+        return -1;
+
     char fullpath[64];
     int fd, result;
 
@@ -249,7 +255,7 @@ int AddHistoryRecord(const char *name)
                 memcpy(&OldHistoryEntry, NewEntry, sizeof(OldHistoryEntry));
 
                 // Unlike the original, add the old history record here.
-                AddOldHistoryFileRecord(path, &OldHistoryEntry);
+                AddOldHistoryFileRecord(path, &OldHistoryEntry, (path[2] == '0') ? mcType : mcType1);
             }
 
             // Initialize the new entry.
@@ -262,14 +268,7 @@ int AddHistoryRecord(const char *name)
     }
 
     // Unlike the original, save here.
-    if (path[2] == '0') {    
-       if(mcType != sceMcTypePS2)
-          return -1;
-    } else {
-       if(mcType1 != sceMcTypePS2)
-          return -1;
-    }
-     return SaveHistoryFile(path, HistoryEntries);
+    return SaveHistoryFile(path, HistoryEntries, (path[2] == '0') ? mcType : mcType1);
 }
 
 static void GetBootFilename(const char *bootpath, char *filename)

--- a/src/OSDHistory.c
+++ b/src/OSDHistory.c
@@ -34,7 +34,7 @@ extern unsigned char icon_sys_C[];
 
 int CreateSystemDataFolder(const char *path, char FolderRegionLetter, int mcType)
 {
-    if (mcType != sceMcTypePS2) //don't write if there is no PS2 MC's 
+    if (mcType != sceMcTypePS2) //don't write if there is no PS2 MC's
         return -1;
 
     char fullpath[64];
@@ -88,7 +88,7 @@ int LoadHistoryFile(const char *path, struct HistoryEntry *HistoryEntries)
 
 int SaveHistoryFile(const char *path, const struct HistoryEntry *HistoryEntries, int mcType)
 {
-    if (mcType != sceMcTypePS2) //don't write if there is no PS2 MC's 
+    if (mcType != sceMcTypePS2) //don't write if there is no PS2 MC's
         return -1;
 
     char fullpath[64];


### PR DESCRIPTION
Previous logic quits writing history if mc0 was a ps1 memcard, negating Saving record if mc1 had a PS2 card

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
