### PR TITLE
Try to make MCEMU/VMC compatible with MX4SIO

### DIFF
--- a/modules/mcemu/mcemu.h
+++ b/modules/mcemu/mcemu.h
@@ -141,6 +141,7 @@ typedef struct _MemoryCard
 
 /* type for a pointer to SIO2MAN's entries */
 typedef void (*Sio2McProc)(Sio2Packet *arg);
+typedef void (*Sio2McProc2)();
 
 int DummySecrAuthCard(int port, int slot, int cnum);
 void Sio2McEmu(Sio2Packet *sd);
@@ -208,6 +209,7 @@ extern void *pFastBuf;
 
 extern PtrRegisterLibraryEntires pRegisterLibraryEntires;
 extern Sio2McProc pSio2man25, pSio2man51;
+extern Sio2McProc2 psio2_mc_transfer_init, psio2_transfer_reset;
 extern void (*pSio2man67)();
 
 extern u8 mceccbuf[MCEMU_PORTS][0x20];

--- a/modules/mcemu/mcemu_var.c
+++ b/modules/mcemu/mcemu_var.c
@@ -55,6 +55,7 @@ void *pFastBuf = NULL;                                                          
 
 PtrRegisterLibraryEntires pRegisterLibraryEntires; /* Pointer to RegisterLibraryEntires routine */
 Sio2McProc pSio2man25, pSio2man51;                 /* Pointers to SIO2MAN routines */
+Sio2McProc2 psio2_mc_transfer_init, psio2_transfer_reset;
 void (*pSio2man67)();
 
 u8 mceccbuf[MCEMU_PORTS][0x20]; /* ECC buffers */


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

SIO2 transfers are by default programmed like:
- sio2_*_transfer_init
- sio2_transfer
- sio2_transfer_reset

To gain exclusive access to the SIO2 port for fast communication these functions are all "hooked" by the mx4sio driver, and locked for exclusive access:
- sio2_*_transfer_init -> **lock1**
- sio2_transfer -> **lock2** / **unlock2**
- sio2_transfer_reset -> **unlock1**

However, MCEMU/VMC will try to read/write to mx4sio while the application thinks it is reading writing to an MC, causing a deadlock.

This PR tries to fix this. During emulating the MC it will first unlock, and when done, lock again.

HOWEVER: We do not know 100% sure in what state the application was locked when trying to read/write to the MC. So there is a slight possibility this PR has a negative effect on the MCEMU compatibility.

Suggestions for improving are welcome.