### PR TITLE
OSD Language configuration

### DIFF
--- a/ee_core/include/ee_core.h
+++ b/ee_core/include/ee_core.h
@@ -40,6 +40,8 @@ extern int iop_reboot_count;
 
 extern int padOpen_hooked;
 
+extern int enforceLanguage;
+
 enum ETH_OP_MODES {
     ETH_OP_MODE_AUTO = 0,
     ETH_OP_MODE_100M_FDX,

--- a/ee_core/include/syshook.h
+++ b/ee_core/include/syshook.h
@@ -11,6 +11,9 @@
 #define SYSHOOK_H
 
 #include <tamtypes.h>
+#include <osd_config.h>
+
+extern ConfigParam CustomOSDConfigParam;
 
 void Install_Kernel_Hooks(void);
 void Remove_Kernel_Hooks(void);
@@ -20,7 +23,8 @@ extern int (*Old_SifSetReg)(u32 register_num, int register_value);
 extern int (*Old_ExecPS2)(void *entry, void *gp, int num_args, char *args[]);
 extern int (*Old_CreateThread)(ee_thread_t *thread_param);
 extern void (*Old_Exit)(s32 exit_code);
-
+extern void (*Old_SetOsdConfigParam)(ConfigParam *config);
+extern void (*Old_GetOsdConfigParam)(ConfigParam *config);
 void sysLoadElf(char *filename, int argc, char **argv);
 void sysExit(s32 exit_code);
 

--- a/ee_core/src/main.c
+++ b/ee_core/src/main.c
@@ -41,6 +41,8 @@ int PadMacroSettings;
 int EnableDebug;
 int *gCheatList; // Store hooks/codes addr+val pairs
 
+int enforceLanguage;
+
 // This function is defined as weak in ps2sdkc, so how
 // we are not using time zone, so we can safe some KB
 void _ps2sdk_timezone_update() {}
@@ -109,7 +111,20 @@ static int eecoreInit(int argc, char **argv)
 
     PadMacroSettings = _strtoi(_strtok(NULL, " "));
 #endif
+    CustomOSDConfigParam.spdifMode = _strtoi(_strtok(NULL, " "));
+    CustomOSDConfigParam.screenType = _strtoi(_strtok(NULL, " "));
+    CustomOSDConfigParam.videoOutput = _strtoi(_strtok(NULL, " "));
+    CustomOSDConfigParam.japLanguage = _strtoi(_strtok(NULL, " "));
+    CustomOSDConfigParam.ps1drvConfig = _strtoi(_strtok(NULL, " "));
+    CustomOSDConfigParam.version = _strtoi(_strtok(NULL, " "));
+    CustomOSDConfigParam.language = _strtoi(_strtok(NULL, " "));
+    CustomOSDConfigParam.timezoneOffset = _strtoi(_strtok(NULL, " "));
+    enforceLanguage = _strtoi(_strtok(NULL, " "));
 
+    if (enforceLanguage)
+        DPRINTF("Enforcing language...\n\tCustomOSDConfig2Param: %d %d %d %d %d %d %d %d\n", PARAM.spdifMode, PARAM.screenType, PARAM.videoOutput, PARAM.japLanguage, PARAM.ps1drvConfig, PARAM.version, PARAM.language, PARAM.timezoneOffset);
+    else
+        DPRINTF("Language will not be manipulated\n");
     i++;
 
     eeloadCopy = (void *)_strtoui(_strtok(argv[i], " "));

--- a/include/config.h
+++ b/include/config.h
@@ -38,6 +38,10 @@ enum CONFIG_INDEX {
 #define CONFIG_ITEM_DNAS         "$DNAS"
 #define CONFIG_ITEM_CONFIGSOURCE "$ConfigSource"
 
+#define CONFIG_ITEM_OSDLNG        "$CustomLanguageValue"
+#define CONFIG_ITEM_OSDLNG_SOURCE "$CustomLanguageSource"
+#define CONFIG_ITEM_OSDLNG_ENABLE "$CustomLanguageEnable"
+
 // Per-Game GSM keys. -Bat-
 #define CONFIG_ITEM_GSMSOURCE   "$GSMSource"
 #define CONFIG_ITEM_ENABLEGSM   "$EnableGSM"

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -134,6 +134,11 @@ enum UI_ITEMS {
     NETUPD_PROGRESS,
     NETUPD_BTN_START,
     NETUPD_BTN_CANCEL,
+
+    OSD_LANGUAGE_SOURCE,
+    OSD_LANGUAGE_ENABLE,
+    OSD_LANGUAGE_VALUE,
+
 #ifdef PADEMU
     PADEMU_GLOBAL_BUTTON,
     PADCFG_PADEMU_SOURCE,
@@ -212,4 +217,5 @@ extern struct UIItem diaNetCompatUpdate[];
 extern struct UIItem diaParentalLockConfig[];
 extern struct UIItem diaBlockDevicesConfig[];
 
+extern struct UIItem diaOSDConfig[];
 #endif

--- a/include/guigame.h
+++ b/include/guigame.h
@@ -19,8 +19,10 @@ void guiGameShowPadEmuConfig(int forceGlobal);
 void guiGameShowPadMacroConfig(int forceGlobal);
 void guiGameSavePadEmuGlobalConfig(config_set_t *configGame);
 void guiGameSavePadMacroGlobalConfig(config_set_t *configGame);
-
 #endif
+
+void guiGameShowOSDLanguageConfig(int forceGlobal);
+void guiGameSaveOSDLanguageGlobalConfig(config_set_t *configGame);
 
 void guiGameLoadConfig(item_list_t *support, config_set_t *configSet);
 int guiGameSaveConfig(config_set_t *configSet, item_list_t *support);

--- a/include/opl.h
+++ b/include/opl.h
@@ -143,6 +143,10 @@ extern int gCheatSource;
 extern int gGSMSource;
 extern int gPadEmuSource;
 
+extern int gOSDLanguageValue;
+extern int gOSDLanguageEnable;
+extern int gOSDLanguageSource;
+
 extern int showCfgPopup;
 
 #ifdef IGS

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -632,3 +632,33 @@ gui_strings:
   string: While button pressed
 - label: ACT_TOGGLED
   string: Toggled by button
+- label: LANGUAGE_JAPANESE
+  string: JAPANESE
+- label: LANGUAGE_ENGLISH
+  string: ENGLISH
+- label: LANGUAGE_FRENCH
+  string: FRENCH
+- label: LANGUAGE_SPANISH
+  string: SPANISH
+- label: LANGUAGE_GERMAN
+  string: GERMAN
+- label: LANGUAGE_ITALIAN
+  string: ITALIAN
+- label: LANGUAGE_DUTCH
+  string: DUTCH
+- label: LANGUAGE_PORTUGUESE
+  string: PORTUGUESE
+- label: LANGUAGE_RUSSIAN
+  string: RUSSIAN
+- label: LANGUAGE_KOREAN
+  string: KOREAN
+- label: LANGUAGE_TRAD_CHINESE
+  string: TRADITIONAL CHINESE
+- label: LANGUAGE_SIMPL_CHINESE
+  string: SIMPLIFIED CHINESE
+- label: OSD_SETTINGS
+  string: OSD settings
+- label: OSD_SETTINGS_LNG
+  string: OSD Language
+- label: ENABLE_LNG
+  string: Change language

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -1012,3 +1012,29 @@ struct UIItem diaControllerConfig[] = {
     {UI_BREAK},
     // end of dialog
     {UI_TERMINATOR}};
+
+struct UIItem diaOSDConfig[] = {
+    {UI_LABEL, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OSD_SETTINGS}}},
+    {UI_SPLITTER},
+
+    {UI_LABEL, 0, 1, 1, -1, -50, 0, {.label = {NULL, _STR_SETTINGS_SOURCE}}},
+    {UI_SPACER},
+    {UI_ENUM, OSD_LANGUAGE_SOURCE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_ENABLE_LNG}}},
+    {UI_SPACER},
+    {UI_BOOL, OSD_LANGUAGE_ENABLE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_OSD_SETTINGS_LNG}}},
+    {UI_SPACER},
+    {UI_ENUM, OSD_LANGUAGE_VALUE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    // buttons
+    {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
+    {UI_BREAK},
+    // end of dialog
+    {UI_TERMINATOR}};

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -24,6 +24,7 @@ enum MENU_IDs {
     MENU_GFX_SETTINGS,
     MENU_AUDIO_SETTINGS,
     MENU_CONTROLLER_SETTINGS,
+    MENU_OSD_LANGUAGE_SETTINGS,
     MENU_PARENTAL_LOCK,
     MENU_NET_CONFIG,
     MENU_NET_UPDATE,
@@ -43,6 +44,7 @@ enum GAME_MENU_IDs {
     GAME_PADEMU_SETTINGS,
     GAME_PADMACRO_SETTINGS,
 #endif
+    GAME_OSD_LANGUAGE_SETTINGS,
     GAME_SAVE_CHANGES,
     GAME_TEST_CHANGES,
     GAME_REMOVE_CHANGES,
@@ -208,6 +210,7 @@ static void menuInitMainMenu(void)
     submenuAppendItem(&mainMenu, -1, NULL, MENU_GFX_SETTINGS, _STR_GFX_SETTINGS);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_AUDIO_SETTINGS, _STR_AUDIO_SETTINGS);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_CONTROLLER_SETTINGS, _STR_CONTROLLER_SETTINGS);
+    submenuAppendItem(&mainMenu, -1, NULL, MENU_OSD_LANGUAGE_SETTINGS, _STR_OSD_SETTINGS);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_PARENTAL_LOCK, _STR_PARENLOCKCONFIG);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_NET_CONFIG, _STR_NETCONFIG);
     submenuAppendItem(&mainMenu, -1, NULL, MENU_NET_UPDATE, _STR_NET_UPDATE);
@@ -240,6 +243,7 @@ void menuInitGameMenu(void)
     submenuAppendItem(&gameMenu, -1, NULL, GAME_PADEMU_SETTINGS, _STR_PADEMUCONFIG);
     submenuAppendItem(&gameMenu, -1, NULL, GAME_PADMACRO_SETTINGS, _STR_PADMACROCONFIG);
 #endif
+    submenuAppendItem(&gameMenu, -1, NULL, GAME_OSD_LANGUAGE_SETTINGS, _STR_OSD_SETTINGS);
     submenuAppendItem(&gameMenu, -1, NULL, GAME_SAVE_CHANGES, _STR_SAVE_CHANGES);
     submenuAppendItem(&gameMenu, -1, NULL, GAME_TEST_CHANGES, _STR_TEST);
     submenuAppendItem(&gameMenu, -1, NULL, GAME_REMOVE_CHANGES, _STR_REMOVE_ALL_SETTINGS);
@@ -834,6 +838,9 @@ void menuHandleInputMenu()
         } else if (id == MENU_CONTROLLER_SETTINGS) {
             if (menuCheckParentalLock() == 0)
                 guiShowControllerConfig();
+        } else if (id == MENU_OSD_LANGUAGE_SETTINGS) {
+            if (menuCheckParentalLock() == 0)
+                guiGameShowOSDLanguageConfig(1);
         } else if (id == MENU_PARENTAL_LOCK) {
             if (menuCheckParentalLock() == 0)
                 guiShowParentalLockConfig();
@@ -850,13 +857,12 @@ void menuHandleInputMenu()
             guiShowAbout();
         } else if (id == MENU_SAVE_CHANGES) {
             if (menuCheckParentalLock() == 0) {
+                guiGameSaveOSDLanguageGlobalConfig(configGetByType(CONFIG_GAME));
 #ifdef PADEMU
                 guiGameSavePadEmuGlobalConfig(configGetByType(CONFIG_GAME));
                 guiGameSavePadMacroGlobalConfig(configGetByType(CONFIG_GAME));
-                saveConfig(CONFIG_OPL | CONFIG_NETWORK | CONFIG_GAME, 1);
-#else
-                saveConfig(CONFIG_OPL | CONFIG_NETWORK, 1);
 #endif
+                saveConfig(CONFIG_OPL | CONFIG_NETWORK | CONFIG_GAME, 1);
                 menuSetParentalLockCheckState(1); // Re-enable parental lock check.
             }
         } else if (id == MENU_EXIT) {
@@ -1071,6 +1077,8 @@ void menuHandleInputGameMenu()
         } else if (menuID == GAME_PADMACRO_SETTINGS) {
             guiGameShowPadMacroConfig(0);
 #endif
+        } else if (menuID == GAME_OSD_LANGUAGE_SETTINGS) {
+            guiGameShowOSDLanguageConfig(0);
         } else if (menuID == GAME_SAVE_CHANGES) {
             if (guiGameSaveConfig(itemConfig, selected_item->item->userdata))
                 configSetInt(itemConfig, CONFIG_ITEM_CONFIGSOURCE, CONFIG_SOURCE_USER);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -736,13 +736,8 @@ void menuRenderMenu()
         // render, advance
         fntRenderString(gTheme->fonts[0], 320, y, ALIGN_CENTER, 0, 0, submenuItemGetText(&it->item), (cp == sitem) ? gTheme->selTextColor : gTheme->textColor);
         y += spacing;
-        if (gHDDStartMode && gEnableWrite) {
-            if (cp == 7)
-                y += spacing / 2;
-        } else {
-            if (cp == 6)
-                y += spacing / 2;
-        }
+        if (cp == (MENU_ABOUT - 1))
+            y += spacing / 2;
     }
 
     // hints
@@ -1023,13 +1018,8 @@ void menuRenderGameMenu()
         // render, advance
         fntRenderString(gTheme->fonts[0], 320, y, ALIGN_CENTER, 0, 0, submenuItemGetText(&it->item), (cp == sitem) ? gTheme->selTextColor : gTheme->textColor);
         y += spacing;
-#ifdef PADEMU
-        if (cp == 5 || cp == 7)
-            y += spacing / 2; // leave a blank space before rendering Save & Remove Settings.
-#else
-        if (cp == 3 || cp == 5)
+        if (cp == (GAME_SAVE_CHANGES - 1) || cp == (GAME_REMOVE_CHANGES - 1))
             y += spacing / 2;
-#endif
     }
 
     // hints

--- a/src/opl.c
+++ b/src/opl.c
@@ -198,6 +198,10 @@ char gOPLPart[128];
 char *gHDDPrefix;
 char gExportName[32];
 
+int gOSDLanguageValue;
+int gOSDLanguageEnable;
+int gOSDLanguageSource;
+
 void moduleUpdateMenu(int mode, int themeChanged, int langChanged)
 {
     if (mode == -1)

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -620,9 +620,9 @@ int sbPrepare(base_game_info_t *game, config_set_t *configSet, int size_cdvdman,
 
     InitCheatsConfig(configSet);
 
-#ifdef PADEMU
     config_set_t *configGame = configGetByType(CONFIG_GAME);
 
+#ifdef PADEMU
     gPadEmuSource = 0;
     gEnablePadEmu = 0;
     gPadEmuSettings = 0;
@@ -647,6 +647,12 @@ int sbPrepare(base_game_info_t *game, config_set_t *configSet, int size_cdvdman,
         settings->fakemodule_flags |= FAKE_MODULE_FLAG_USBD;
     }
 #endif
+
+    if (configGetInt(configSet, CONFIG_ITEM_OSDLNG_SOURCE, &gOSDLanguageSource)) {
+        configGetInt(configSet, CONFIG_ITEM_OSDLNG, &gOSDLanguageValue);
+    } else {
+        configGetInt(configGame, CONFIG_ITEM_OSDLNG, &gOSDLanguageValue);
+    }
 
     *patchindex = i;
 

--- a/src/system.c
+++ b/src/system.c
@@ -22,7 +22,7 @@
 #include "include/renderman.h"
 #include "include/extern_irx.h"
 #include "../ee_core/include/modules.h"
-
+#include <osd_config.h>
 #include "include/pggsm.h"
 #include "include/cheatman.h"
 
@@ -802,15 +802,23 @@ void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdv
 #define PADEMU_ARGUMENT
 #endif
 
+#define CONFIGPARAMDATA " %d %d %d %d %d %d %d %d %d"
+    ConfigParam PARAM;
+    GetOsdConfigParam(&PARAM);                                                  //get system configuration
+    PARAM.language = (gOSDLanguageEnable) ? gOSDLanguageValue : PARAM.language; //patch what we care about
+#define CONFIGPARAMDATA_ARGUMENT , PARAM.spdifMode, PARAM.screenType, PARAM.videoOutput, PARAM.japLanguage, PARAM.ps1drvConfig, PARAM.version, PARAM.language, PARAM.timezoneOffset, gOSDLanguageEnable
+
     argc = 0;
-    sprintf(config_str, "%s %d %s %d %u.%u.%u.%u %u.%u.%u.%u %u.%u.%u.%u %d %u %d" PADEMU_SPECIFIER,
+    sprintf(config_str, "%s %d %s %d %u.%u.%u.%u %u.%u.%u.%u %u.%u.%u.%u %d %u %d" PADEMU_SPECIFIER CONFIGPARAMDATA,
             mode_str, gEnableDebug, gExitPath, gHDDSpindown,
             local_ip_address[0], local_ip_address[1], local_ip_address[2], local_ip_address[3],
             local_netmask[0], local_netmask[1], local_netmask[2], local_netmask[3],
             local_gateway[0], local_gateway[1], local_gateway[2], local_gateway[3],
             gETHOpMode,
             GetCheatsEnabled() ? (unsigned int)GetCheatsList() : 0,
-            GetGSMEnabled() PADEMU_ARGUMENT);
+            GetGSMEnabled() PADEMU_ARGUMENT
+                CONFIGPARAMDATA_ARGUMENT);
+
     argv[argc] = config_str;
     argc++;
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Changes done to the UI:
- Added all necessary code to implement the configurations of the new feature
- the new feature passes to EE_core all the parameters needed to respond to hooked calls of config param getter/setter
- if feature is not enabled, the data is still passed, but no hooking is performed.
- the struct holding the parameters is populated with the actual system configuration before loading EE Core
- when the feature is enabled, the EE Core reports the passed parameters on a separated `DPRINTF()`
-  Changed the code that handles spacing on `GAME_SAVE_CHANGES` & `GAME_REMOVE_CHANGES` ([menusys.c:1028](https://github.com/israpps/Open-PS2-Loader/blob/osd-config/src/menusys.c#L1028))