### PR TITLE
remove `set-output` commands from CI before their deprecation

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Get version
       id: version
-      run: echo "::set-output name=version::$(make oplversion)"
+      run: echo "{version}={$(make oplversion)}" >> $GITHUB_OUTPUT
 
     - name: Compile -> make ${{ matrix.t10k }} ${{ matrix.igs }} ${{ matrix.pademu }} ${{ matrix.rtl }} NOT_PACKED=1
       run: |
@@ -148,7 +148,7 @@ jobs:
 
     - name: Get version
       id: version
-      run: echo "::set-output name=version::$(make oplversion)"
+      run: echo "{version}={$(make oplversion)}" >> $GITHUB_OUTPUT
 
     - name: Compile -> make debug
       run: |
@@ -176,7 +176,7 @@ jobs:
 
     - name: Get version
       id: version
-      run: echo "::set-output name=version::$(make oplversion)"
+      run: echo "{version}={$(make oplversion)}" >> $GITHUB_OUTPUT
 
     - name: Download all artifacts
       uses: actions/download-artifact@v3


### PR DESCRIPTION
more information here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
