### PR TITLE
better messages for failed cheat file reading

### DIFF
--- a/src/cheatman.c
+++ b/src/cheatman.c
@@ -341,12 +341,12 @@ end:
 int load_cheats(const char *cheatfile)
 {
     char *buf = NULL;
-    int ret;
+    int ret, text_ret = 0;
 
     memset(gCheatList, 0, sizeof(gCheatList));
 
     LOG("%s: Reading cheat file '%s'...", __FUNCTION__, cheatfile);
-    buf = read_text_file(cheatfile, 0);
+    buf = read_text_file(cheatfile, 0, &text_ret);
     if (buf == NULL) {
         LOG("\n%s: Could not read cheats file '%s'\n", __FUNCTION__, cheatfile);
         return -1;
@@ -355,7 +355,7 @@ int load_cheats(const char *cheatfile)
     ret = parse_buf(buf);
     free(buf);
     if (ret < 0)
-        return -1;
+        return (text_ret == -ENOENT) ? text_ret : -1;
     else
         return 0;
 }

--- a/src/cheatman.c
+++ b/src/cheatman.c
@@ -22,6 +22,7 @@
  * $Id$
  */
 
+#include <errno.h>
 #include <unistd.h>
 #include "include/cheatman.h"
 #include "include/ioman.h"
@@ -290,9 +291,10 @@ static int parse_buf(const char *buf)
  * read_text_file - Reads text from a file into a buffer.
  * @filename: name of text file
  * @maxsize: max file size (0: arbitrary size)
+ * @retcode: integer pointer wich gets the value of errno assigned if an error ocurrs
  * @return: ptr to NULL-terminated text buffer, or NULL if an error occured
  */
-static inline char *read_text_file(const char *filename, int maxsize)
+static inline char *read_text_file(const char *filename, int maxsize, int* retcode)
 {
     char *buf = NULL;
     int fd, filesize;
@@ -300,12 +302,14 @@ static inline char *read_text_file(const char *filename, int maxsize)
     fd = open(filename, O_RDONLY);
     if (fd < 0) {
         LOG("%s: Can't open text file %s\n", __FUNCTION__, filename);
+        retcode = -ENOENT;
         return NULL;
     }
 
     filesize = lseek(fd, 0, SEEK_END);
     if (maxsize && filesize > maxsize) {
         LOG("%s: Text file too large: %i bytes, max: %i bytes\n", __FUNCTION__, filesize, maxsize);
+        retcode = -ERANGE;
         goto end;
     }
 

--- a/src/cheatman.c
+++ b/src/cheatman.c
@@ -355,7 +355,7 @@ int load_cheats(const char *cheatfile)
     ret = parse_buf(buf);
     free(buf);
     if (ret < 0)
-        return (text_ret == -ENOENT) ? text_ret : -1;
+        return text_ret;
     else
         return 0;
 }

--- a/src/cheatman.c
+++ b/src/cheatman.c
@@ -302,7 +302,7 @@ static inline char *read_text_file(const char *filename, int maxsize, int* retco
     fd = open(filename, O_RDONLY);
     if (fd < 0) {
         LOG("%s: Can't open text file %s\n", __FUNCTION__, filename);
-        retcode = -ENOENT;
+        retcode = -errno;
         return NULL;
     }
 

--- a/src/cheatman.c
+++ b/src/cheatman.c
@@ -294,7 +294,7 @@ static int parse_buf(const char *buf)
  * @retcode: integer pointer wich gets the value of errno assigned if an error ocurrs
  * @return: ptr to NULL-terminated text buffer, or NULL if an error occured
  */
-static inline char *read_text_file(const char *filename, int maxsize, int* retcode)
+static inline char *read_text_file(const char *filename, int maxsize, int *retcode)
 {
     char *buf = NULL;
     int fd, filesize;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

making `LoadCheats()` take into consideration the errno arised on `read_text_file()` brings the possibility for better error handling

In this PR, only `ENOENT` has been considered.

before this, if CHT folder had no cheat file for the game, the message displayed was `Error: failed to load cheat file.`.

now, the absence of corresponding cheat file will result in the message: `No cheats found.`