### PR TITLE
[OSDHistory]: Remove PS1 memcard check

### DIFF
--- a/src/OSDHistory.c
+++ b/src/OSDHistory.c
@@ -126,19 +126,13 @@ static u16 GetTimestamp(void)
 int AddHistoryRecord(const char *name)
 {
     struct HistoryEntry HistoryEntries[MAX_HISTORY_ENTRIES], *NewEntry, OldHistoryEntry;
-    int i, value, LeastUsedRecord, LeastUsedRecordLaunchCount, LeastUsedRecordTimestamp, NewLaunchCount, result, mcType;
+    int i, value, LeastUsedRecord, LeastUsedRecordLaunchCount, LeastUsedRecordTimestamp, NewLaunchCount, result;
     u8 BlankSlotList[MAX_HISTORY_ENTRIES];
     int NumBlankSlots, NumSlotsUsed, IsNewRecord;
     char SystemRegionLetter;
     char path[32];
 
     DEBUG_PRINTF("Adding history record: %s\n", name);
-
-    // Don't write history for ps1 cards
-    mcGetInfo(0, 0, &mcType, 0, 0);
-    mcSync(0, NULL, &result);
-    if (mcType == sceMcTypePS1)
-        return -1;
 
     // For simplicity, create the data folder immediately if the history file does not exist (unlike the original).
     sprintf(path, "mc0:/%s", GetSystemDataPath());


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Since `mcGetInfo()` is fucked up, having a check like this is kida the same as not having osd history enabled (`mcGetInfo()` on it's current state only trows 0 or 1 for mc format type)