### PR TITLE
parse launch args to auto launch bdm games

### DIFF
--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -21,5 +21,7 @@ void bdmInit();
 item_list_t *bdmGetObject(int initOnly);
 int bdmFindPartition(char *target, const char *name, int write);
 void bdmLoadModules(void);
+void bdmLaunchGame(int id, config_set_t *configSet);
+void bdmSetPrefix(void);
 
 #endif

--- a/include/opl.h
+++ b/include/opl.h
@@ -79,6 +79,9 @@ void moduleUpdateMenu(int mode, int themeChanged, int langChanged);
 void handleLwnbdSrv();
 void deinit(int exception, int modeSelected);
 
+// Shutdown minimal services initiated for auto loading.
+void miniDeinit(config_set_t *configSet);
+
 extern char *gBaseMCDir;
 
 enum ETH_OP_MODES {

--- a/include/opl.h
+++ b/include/opl.h
@@ -39,6 +39,7 @@
 #include "config.h"
 
 #include "include/hddsupport.h"
+#include "include/supportbase.h"
 
 // Last Played Auto Start
 #include <time.h>
@@ -199,6 +200,7 @@ extern unsigned char gDefaultSelTextColor[3];
 extern unsigned char gDefaultUITextColor[3];
 
 extern hdl_game_info_t *gAutoLaunchGame;
+extern base_game_info_t *gAutoLaunchBDMGame;
 extern char *gHDDPrefix;
 extern char gOPLPart[128];
 

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -37,6 +37,7 @@ typedef struct
     u8 unknown2[10];                // Always zero
 } USBExtreme_game_entry_t;
 
+int isValidIsoName(char *name, int *pNameLen);
 int sbIsSameSize(const char *prefix, int prevSize);
 int sbCreateSemaphore(void);
 int sbReadList(base_game_info_t **list, const char *prefix, int *fsize, int *gamecount);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -14,11 +14,6 @@
 
 #include <usbhdfsd-common.h>
 
-#ifdef PADEMU
-#include <libds34bt.h>
-#include <libds34usb.h>
-#endif
-
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioIoctl, fileXioDevctl
 
@@ -431,21 +426,13 @@ void bdmLaunchGame(int id, config_set_t *configSet)
     if (configGetStrCopy(configSet, CONFIG_ITEM_ALTSTARTUP, filename, sizeof(filename)) == 0)
         strcpy(filename, game->startup);
 
-    if (gAutoLaunchBDMGame == NULL) {
+    if (gAutoLaunchBDMGame == NULL)
         deinit(NO_EXCEPTION, BDM_MODE); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
-    } else {
-        ioBlockOps(1);
-#ifdef PADEMU
-        ds34usb_reset();
-        ds34bt_reset();
-#endif
-        configFree(configSet);
+    else {
+        miniDeinit(configSet);
 
         free(gAutoLaunchBDMGame);
         gAutoLaunchBDMGame = NULL;
-
-        ioEnd();
-        configEnd();
     }
 
     if (!strcmp(bdmDriver, "usb")) {

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -13,11 +13,6 @@
 #include "include/cheatman.h"
 #include "modules/iopcore/common/cdvd_config.h"
 
-#ifdef PADEMU
-#include <libds34bt.h>
-#include <libds34usb.h>
-#endif
-
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioFormat, fileXioMount, fileXioUmount, fileXioDevctl
 #include <io_common.h>   // FIO_MT_RDWR
@@ -506,24 +501,16 @@ void hddLaunchGame(int id, config_set_t *configSet)
         }
     }
 
-    if (gAutoLaunchGame == NULL) {
+    if (gAutoLaunchGame == NULL)
         deinit(NO_EXCEPTION, HDD_MODE); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
-    } else {
-        ioBlockOps(1);
-#ifdef PADEMU
-        ds34usb_reset();
-        ds34bt_reset();
-#endif
-        configFree(configSet);
+    else {
+        miniDeinit(configSet);
 
         free(gAutoLaunchGame);
         gAutoLaunchGame = NULL;
 
         fileXioUmount("pfs0:");
         fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
-
-        ioEnd();
-        configEnd();
     }
 
     settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_DEV9;

--- a/src/opl.c
+++ b/src/opl.c
@@ -32,7 +32,6 @@
 #include "include/appsupport.h"
 
 #include "include/cheatman.h"
-
 #include "include/sound.h"
 
 // FIXME: We should not need this function.
@@ -197,6 +196,7 @@ unsigned char gDefaultTextColor[3];
 unsigned char gDefaultSelTextColor[3];
 unsigned char gDefaultUITextColor[3];
 hdl_game_info_t *gAutoLaunchGame;
+base_game_info_t *gAutoLaunchBDMGame;
 char gOPLPart[128];
 char *gHDDPrefix;
 char gExportName[32];
@@ -1579,6 +1579,7 @@ static void setDefaults(void)
     clearIOModuleT(&list_support[APP_MODE]);
 
     gAutoLaunchGame = NULL;
+    gAutoLaunchBDMGame = NULL;
     gOPLPart[0] = '\0';
     gHDDPrefix = "pfs0:";
     gBaseMCDir = "mc?:OPL";
@@ -1775,6 +1776,80 @@ static void autoLaunchHDDGame(char *argv[])
     hddLaunchGame(-1, configSet);
 }
 
+static void autoLaunchBDMGame(char *argv[])
+{
+    int ret;
+    char path[256];
+    config_set_t *configSet;
+
+    setDefaults();
+    configInit(NULL);
+
+    ioInit();
+    LOG_ENABLE();
+
+    // Force load iLink & mx4sio modules.. we aren't using the gui so this is fine.
+    gEnableILK = 1;
+    gEnableMX4SIO = 1;
+    bdmLoadModules();
+    InitConsoleRegionData();
+
+    ret = configReadMulti(CONFIG_ALL);
+    if (CONFIG_ALL & CONFIG_OPL) {
+        if (!(ret & CONFIG_OPL))
+            ret = checkLoadConfigBDM(CONFIG_ALL);
+
+        if (ret & CONFIG_OPL) {
+            config_set_t *configOPL = configGetByType(CONFIG_OPL);
+
+            configGetInt(configOPL, CONFIG_OPL_PS2LOGO, &gPS2Logo);
+            configGetStrCopy(configOPL, CONFIG_OPL_EXIT_PATH, gExitPath, sizeof(gExitPath));
+            configGetStrCopy(configOPL, CONFIG_OPL_BDM_PREFIX, gBDMPrefix, sizeof(gBDMPrefix));
+            configGetInt(configOPL, CONFIG_OPL_BDM_CACHE, &bdmCacheSize);
+        }
+    }
+
+    bdmSetPrefix();
+    delay(3); // Wait for the device to be detected.
+
+    gAutoLaunchBDMGame = malloc(sizeof(base_game_info_t));
+    memset(gAutoLaunchBDMGame, 0, sizeof(base_game_info_t));
+
+    int nameLen;
+    int format = isValidIsoName(argv[1], &nameLen);
+    if (format == GAME_FORMAT_OLD_ISO) {
+        strncpy(gAutoLaunchBDMGame->name, &argv[1][GAME_STARTUP_MAX], nameLen);
+        gAutoLaunchBDMGame->name[nameLen] = '\0';
+        strncpy(gAutoLaunchBDMGame->extension, &argv[1][GAME_STARTUP_MAX + nameLen], sizeof(gAutoLaunchBDMGame->extension));
+        gAutoLaunchBDMGame->extension[sizeof(gAutoLaunchBDMGame->extension) - 1] = '\0';
+    } else {
+        strncpy(gAutoLaunchBDMGame->name, argv[1], nameLen);
+        gAutoLaunchBDMGame->name[nameLen] = '\0';
+        strncpy(gAutoLaunchBDMGame->extension, &argv[1][nameLen], sizeof(gAutoLaunchBDMGame->extension));
+        gAutoLaunchBDMGame->extension[sizeof(gAutoLaunchBDMGame->extension) - 1] = '\0';
+    }
+
+    snprintf(gAutoLaunchBDMGame->startup, sizeof(gAutoLaunchBDMGame->startup), argv[2]);
+
+    if (strcasecmp("DVD", argv[3]) == 0)
+        gAutoLaunchBDMGame->media = SCECdPS2DVD;
+    else if (strcasecmp("CD", argv[3]) == 0)
+        gAutoLaunchBDMGame->media = SCECdPS2CD;
+
+    gAutoLaunchBDMGame->format = format;
+    gAutoLaunchBDMGame->parts = 1; // ul not supported.
+
+    if (gBDMPrefix[0] != '\0')
+        snprintf(path, sizeof(path), "mass0:%s/CFG/%s.cfg", gBDMPrefix, gAutoLaunchBDMGame->startup);
+    else
+        snprintf(path, sizeof(path), "mass0:CFG/%s.cfg", gAutoLaunchBDMGame->startup);
+
+    configSet = configAlloc(0, NULL, path);
+    configRead(configSet);
+
+    bdmLaunchGame(-1, configSet);
+}
+
 // --------------------- Main --------------------
 int main(int argc, char *argv[])
 {
@@ -1790,14 +1865,21 @@ int main(int argc, char *argv[])
     // reset, load modules
     reset();
 
-    /* argv[0] boot path
-       argv[1] game->startup
-       argv[2] str to u32 game->start_sector
-       argv[3] opl partition read from hdd0:__common/OPL/conf_hdd.cfg
-       argv[4] "mini" */
     if (argc >= 5) {
+        /* argv[0] boot path
+           argv[1] game->startup
+           argv[2] str to u32 game->start_sector
+           argv[3] opl partition read from hdd0:__common/OPL/conf_hdd.cfg
+           argv[4] "mini" */
         if (!strcmp(argv[4], "mini"))
             autoLaunchHDDGame(argv);
+        /* argv[0] boot path
+           argv[1] file name (including extention)
+           argv[2] game->startup
+           argv[3] game->media ("CD" / "DVD") 
+           argv[4] "bdm" */
+        if (!strcmp(argv[4], "bdm"))
+            autoLaunchBDMGame(argv);
     }
 
     init();

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -57,7 +57,7 @@ int sbCreateSemaphore(void)
 }
 
 // 0 = Not ISO disc image, GAME_FORMAT_OLD_ISO = legacy ISO disc image (filename follows old naming requirement), GAME_FORMAT_ISO = plain ISO image.
-static int isValidIsoName(char *name, int *pNameLen)
+int isValidIsoName(char *name, int *pNameLen)
 {
     // Old ISO image naming format: SCUS_XXX.XX.ABCDEFGHIJKLMNOP.iso
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
This will allow auto launching BDM games by sending a few args:

```
 argv[1] file name (including extension)
 argv[2] game->startup
 argv[3] game->media ("CD" / "DVD")
 argv[4] “bdm”
```
I could only test the USB side of BDM since I don’t have an iLink drive or an MX4SIO but in theory they should also work fine… not sure if I should squash commits either.