### PR TITLE
Fix alignment of variables in IOP modules to be max 16 bytes

### DIFF
--- a/modules/network/lwnbdsvr/nbd_protocol.c
+++ b/modules/network/lwnbdsvr/nbd_protocol.c
@@ -42,7 +42,7 @@
 #include <stddef.h>
 #include <lwnbd.h>
 
-uint8_t nbd_buffer[NBD_BUFFER_LEN] __attribute__((aligned(64)));
+uint8_t nbd_buffer[NBD_BUFFER_LEN] __attribute__((aligned(16)));
 
 /** @ingroup nbd
  * Fixed newstyle negotiation.

--- a/modules/vmc/genvmc/genvmc.c
+++ b/modules/vmc/genvmc/genvmc.c
@@ -119,8 +119,8 @@ typedef struct
 
 #define BLOCKKB 16
 
-static MCDevInfo devinfo __attribute__((aligned(64)));
-static u8 cluster_buf[(BLOCKKB * 1024) + 16] __attribute__((aligned(64)));
+static MCDevInfo devinfo __attribute__((aligned(16)));
+static u8 cluster_buf[(BLOCKKB * 1024) + 16] __attribute__((aligned(16)));
 
 static int genvmc_io_sema = -1;
 static int genvmc_thread_sema = -1;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

The IRX loader can only handle max alignment of 16 bytes.  
Future updates to the toolchain will make this a hard requirement.