### PR TITLE
Update opl2iso.c

### DIFF
--- a/pc/opl2iso/src/opl2iso.c
+++ b/pc/opl2iso/src/opl2iso.c
@@ -192,6 +192,8 @@ int findGame(const char *gameid, cfg_t *item)
 int exportGame(const char *gameid)
 {
     cfg_t grecord;
+    FILE *fdest;
+    FILE *fsrc;
 
     // first try to load the game record with specified code
     if (!findGame(gameid, &grecord)) {
@@ -230,7 +232,7 @@ int exportGame(const char *gameid)
 
     printf("Game found in the ul.cfg. Resulting file name: '%s'\n", rname);
 
-    FILE *fdest = fopen(rname, "wb");
+    fdest = fopen(rname, "wb");
 
     if (!fdest) {
         printf("Could not open destination file '%s', exiting\n", rname);
@@ -245,7 +247,7 @@ int exportGame(const char *gameid)
 
         printf("Processing part %d/%d: '%s'...\n", part + 1, grecord.parts, sname);
 
-        FILE *fsrc = fopen(sname, "rb");
+      fsrc = fopen(sname, "rb");
 
         if (!fsrc) {
             fclose(fdest);


### PR DESCRIPTION
Fixed compile errors by declaring pointers "fdest" and "fsrc" inside the function "int  exportGame(const char *gameid)" before the pointers are used.  

FILE *fdest;
FILE *fsrc;

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
