### PR TITLE
Add in support for using PS3 Guitars as PS2 Guitars in PADEMU

### DIFF
--- a/include/ds34common.h
+++ b/include/ds34common.h
@@ -179,10 +179,10 @@ struct ds3guitarreport
         };
         struct
         {
-            uint16_t Yellow    : 1;
+            uint16_t Blue      : 1;
             uint16_t Green     : 1;
             uint16_t Red       : 1;
-            uint16_t Blue      : 1;
+            uint16_t Yellow    : 1;
             uint16_t Orange    : 1;
             uint16_t StarPower : 1;
             uint16_t           : 1;

--- a/include/ds34common.h
+++ b/include/ds34common.h
@@ -12,6 +12,7 @@
 #define DS4_PID             0x05C4 // PS4 Controller
 #define DS4_PID_SLIM        0x09CC // PS4 Slim Controller
 #define GUITAR_HERO_PS3_PID 0x0100 // PS3 Guitar Hero Guitar
+#define ROCK_BAND_PS3_PID   0x0200 // PS3 Rock Band Guitar
 
 // NOTE: struct member prefixed with "n" means it's active-low (i.e. value of 0 indicates button is pressed, value 1 is released)
 enum DS2ButtonBitNumber {
@@ -294,8 +295,9 @@ void translate_pad_ds3(const struct ds3report *in, struct ds2report *out, uint8_
  * Translate PS3 Guitar pad data into DS2 Guitar pad data.
  * @param in PS3 Guitar report
  * @param out PS2 Guitar report
+ * @param guitar_hero_format set to 1 if this is a guitar hero guitar, set to 0 if this is a rock band guitar
  */
-void translate_pad_guitar(const struct ds3guitarreport *in, struct ds2report *out);
+void translate_pad_guitar(const struct ds3guitarreport *in, struct ds2report *out, uint8_t guitar_hero_format);
 
 /**
  * Translate DS3 pad data into DS2 pad data.

--- a/include/ds34common.h
+++ b/include/ds34common.h
@@ -201,27 +201,16 @@ struct ds3guitarreport
     uint8_t : 8;
     uint8_t Whammy; // Whammy axis 0 - 255, 128 is mid
     uint8_t : 8;
-    uint8_t Reserved2[4];     // Unknown
-    uint8_t PressureUp;       // digital Pad Up button Pressure 0 - 255
-    uint8_t PressureRight;    // digital Pad Right button Pressure 0 - 255
-    uint8_t PressureDown;     // digital Pad Down button Pressure 0 - 255
-    uint8_t PressureLeft;     // digital Pad Left button Pressure 0 - 255
-    uint8_t PressureL2;       // digital Pad L2 button Pressure 0 - 255
-    uint8_t PressureR2;       // digital Pad R2 button Pressure 0 - 255
-    uint8_t PressureL1;       // digital Pad L1 button Pressure 0 - 255
-    uint8_t PressureR1;       // digital Pad R1 button Pressure 0 - 255
-    uint8_t PressureTriangle; // digital Pad Triangle button Pressure 0 - 255
-    uint8_t PressureCircle;   // digital Pad Circle button Pressure 0 - 255
-    uint8_t PressureCross;    // digital Pad Cross button Pressure 0 - 255
-    uint8_t PressureSquare;   // digital Pad Square button Pressure 0 - 255
-    uint8_t Reserved3[3];     // Unknown
-    uint8_t Charge;           // charging status ? 02 = charge, 03 = normal
-    uint8_t Power;            // Battery status ? 05=full - 02=dying, 01=just before shutdown, EE=charging
-    uint8_t Connection;       // Connection Type ? 14 when operating by bluetooth, 10 when operating by bluetooth with cable plugged in, 16 when bluetooh and rumble
-    uint8_t Reserved4[9];     // Unknown
+    uint8_t PressureRightYellow; // digital Pad Right + Yellow button Pressure 0 - 255 (if both are pressed, then they cancel eachother out)
+    uint8_t PressureLeft;        // digital Pad Left button Pressure 0 - 255
+    uint8_t PressureUpGreen;     // digital Pad Up + Green button Pressure 0 - 255 (if both are pressed, then they cancel eachother out)
+    uint8_t PressureDownOrange;  // digital Pad Down + Orange button Pressure 0 - 255 (if both are pressed, then they cancel eachother out)
+    uint8_t PressureBlue;        // digital Pad Blue button Pressure 0 - 255
+    uint8_t PressureRed;         // digital Pad Red button Pressure 0 - 255
+    uint8_t Reserved3[6];        // Unknown
     int16_t AccelX;
-    int16_t AccelY;
     int16_t AccelZ;
+    int16_t AccelY;
     int16_t GyroZ;
 
 } __attribute__((packed));

--- a/include/ds34common.h
+++ b/include/ds34common.h
@@ -6,10 +6,12 @@
 #define USB_SUBCLASS_RF_CONTROLLER    0x01
 #define USB_PROTOCOL_BLUETOOTH_PROG   0x01
 
-#define DS34_VID     0x054C // Sony Corporation
-#define DS3_PID      0x0268 // PS3 Controller
-#define DS4_PID      0x05C4 // PS4 Controller
-#define DS4_PID_SLIM 0x09CC // PS4 Slim Controller
+#define SONY_VID            0x12ba // Sony
+#define DS34_VID            0x054C // Sony Corporation
+#define DS3_PID             0x0268 // PS3 Controller
+#define DS4_PID             0x05C4 // PS4 Controller
+#define DS4_PID_SLIM        0x09CC // PS4 Slim Controller
+#define GUITAR_HERO_PS3_PID 0x0100 // PS3 Guitar Hero Guitar
 
 // NOTE: struct member prefixed with "n" means it's active-low (i.e. value of 0 indicates button is pressed, value 1 is released)
 enum DS2ButtonBitNumber {
@@ -164,6 +166,66 @@ struct ds3report
 
 } __attribute__((packed));
 
+struct ds3guitarreport
+{
+    union
+    {
+        uint16_t ButtonState;
+        struct
+        {
+            uint8_t ButtonStateL; // Main buttons low byte
+            uint8_t ButtonStateH; // Main buttons high byte
+        };
+        struct
+        {
+            uint16_t Yellow    : 1;
+            uint16_t Green     : 1;
+            uint16_t Red       : 1;
+            uint16_t Blue      : 1;
+            uint16_t Orange    : 1;
+            uint16_t StarPower : 1;
+            uint16_t           : 1;
+            uint16_t           : 1;
+            uint16_t Select    : 1;
+            uint16_t Start     : 1;
+            uint16_t           : 1;
+            uint16_t           : 1;
+            uint16_t PSButton  : 1;
+            uint16_t           : 1;
+            uint16_t           : 1;
+            uint16_t           : 1;
+        };
+    };
+    uint8_t Dpad; // hat format, 0x08 is released, 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW
+    uint8_t : 8;
+    uint8_t : 8;
+    uint8_t Whammy; // Whammy axis 0 - 255, 128 is mid
+    uint8_t : 8;
+    uint8_t Reserved2[4];     // Unknown
+    uint8_t PressureUp;       // digital Pad Up button Pressure 0 - 255
+    uint8_t PressureRight;    // digital Pad Right button Pressure 0 - 255
+    uint8_t PressureDown;     // digital Pad Down button Pressure 0 - 255
+    uint8_t PressureLeft;     // digital Pad Left button Pressure 0 - 255
+    uint8_t PressureL2;       // digital Pad L2 button Pressure 0 - 255
+    uint8_t PressureR2;       // digital Pad R2 button Pressure 0 - 255
+    uint8_t PressureL1;       // digital Pad L1 button Pressure 0 - 255
+    uint8_t PressureR1;       // digital Pad R1 button Pressure 0 - 255
+    uint8_t PressureTriangle; // digital Pad Triangle button Pressure 0 - 255
+    uint8_t PressureCircle;   // digital Pad Circle button Pressure 0 - 255
+    uint8_t PressureCross;    // digital Pad Cross button Pressure 0 - 255
+    uint8_t PressureSquare;   // digital Pad Square button Pressure 0 - 255
+    uint8_t Reserved3[3];     // Unknown
+    uint8_t Charge;           // charging status ? 02 = charge, 03 = normal
+    uint8_t Power;            // Battery status ? 05=full - 02=dying, 01=just before shutdown, EE=charging
+    uint8_t Connection;       // Connection Type ? 14 when operating by bluetooth, 10 when operating by bluetooth with cable plugged in, 16 when bluetooh and rumble
+    uint8_t Reserved4[9];     // Unknown
+    int16_t AccelX;
+    int16_t AccelY;
+    int16_t AccelZ;
+    int16_t GyroZ;
+
+} __attribute__((packed));
+
 enum DS4DpadDirections {
     DS4DpadDirectionN = 0,
     DS4DpadDirectionNE,
@@ -238,6 +300,13 @@ struct ds4report
  * NOTE: if set to 0, ds3report must be large enough for that data to be read!
  */
 void translate_pad_ds3(const struct ds3report *in, struct ds2report *out, uint8_t pressure_emu);
+
+/**
+ * Translate PS3 Guitar pad data into DS2 Guitar pad data.
+ * @param in PS3 Guitar report
+ * @param out PS2 Guitar report
+ */
+void translate_pad_guitar(const struct ds3guitarreport *in, struct ds2report *out);
 
 /**
  * Translate DS3 pad data into DS2 pad data.

--- a/modules/pademu/ds34common.c
+++ b/modules/pademu/ds34common.c
@@ -31,12 +31,13 @@ void translate_pad_guitar(const struct ds3guitarreport *in, struct ds2report *ou
 
     if (guitar_hero_format) {
         // GH PS3 Guitars swap Yellow and Blue
-        out->nButtonStateH = ~(in->Green << 1 | in->Yellow << 4 | in->Red << 5 | in->Blue << 6 | in->Orange << 7);
+        // Interestingly, it is only GH PS3 Guitars that do this, all the other instruments including GH Drums don't have this swapped.
+        out->nButtonStateH = ~(in->Green << 1 | in->Blue << 4 | in->Red << 5 | in->Yellow << 6 | in->Orange << 7);
         if (in->AccelX > 512 || in->AccelX < 432) {
             out->nL2 = 0;
         }
     } else {
-        out->nButtonStateH = ~(in->StarPower | in->Green << 1 | in->Blue << 4 | in->Red << 5 | in->Yellow << 6 | in->Orange << 7);
+        out->nButtonStateH = ~(in->StarPower | in->Green << 1 | in->Yellow << 4 | in->Red << 5 | in->Blue << 6 | in->Orange << 7);
     }
 }
 

--- a/modules/pademu/ds34common.c
+++ b/modules/pademu/ds34common.c
@@ -3,6 +3,53 @@
 #include "loadcore.h"
 #include "sysclib.h"
 
+void translate_pad_guitar(const struct ds3guitarreport *in, struct ds2report *out)
+{
+    out->RightStickX = 0x7F;
+    out->RightStickY = 0x7F;
+    out->LeftStickX = 0x7F;
+    out->LeftStickY = -(in->Whammy);
+
+    static const u8 dpad_mapping[] = {
+        (DS2ButtonUp),
+        (DS2ButtonUp | DS2ButtonRight),
+        (DS2ButtonRight),
+        (DS2ButtonDown | DS2ButtonRight),
+        (DS2ButtonDown),
+        (DS2ButtonDown | DS2ButtonLeft),
+        (DS2ButtonLeft),
+        (DS2ButtonUp | DS2ButtonLeft),
+        0,
+    };
+
+    u8 dpad = in->Dpad > DS4DpadDirectionReleased ? DS4DpadDirectionReleased : in->Dpad;
+
+    out->nButtonStateL = ~(in->Select | in->Start << 3 | dpad_mapping[dpad]);
+    out->nButtonStateH = ~(in->Green << 1 | in->Yellow << 4 | in->Red << 5 | in->Blue << 6 | in->Orange << 7);
+
+    out->PressureRight = in->PressureRight;
+    out->PressureLeft = in->PressureLeft;
+    out->PressureUp = in->PressureUp;
+    out->PressureDown = in->PressureDown;
+
+    out->PressureTriangle = in->PressureTriangle;
+    out->PressureCircle = in->PressureCircle;
+    out->PressureCross = in->PressureCross;
+    out->PressureSquare = in->PressureSquare;
+
+    out->PressureL1 = in->PressureL1;
+    out->PressureR1 = in->PressureR1;
+    out->PressureL2 = in->PressureL2;
+    out->PressureR2 = in->PressureR2;
+
+    out->nLeft = 0;
+    out->nL2 = 1;
+
+    if (in->AccelX > 512 || in->AccelX < 432) {
+        out->nL2 = 0;
+    }
+}
+
 void translate_pad_ds3(const struct ds3report *in, struct ds2report *out, u8 pressure_emu)
 {
     out->nButtonStateL = ~in->ButtonStateL;

--- a/modules/pademu/ds34common.c
+++ b/modules/pademu/ds34common.c
@@ -3,7 +3,7 @@
 #include "loadcore.h"
 #include "sysclib.h"
 
-void translate_pad_guitar(const struct ds3guitarreport *in, struct ds2report *out)
+void translate_pad_guitar(const struct ds3guitarreport *in, struct ds2report *out, uint8_t guitar_hero_format)
 {
     out->RightStickX = 0x7F;
     out->RightStickY = 0x7F;
@@ -25,13 +25,18 @@ void translate_pad_guitar(const struct ds3guitarreport *in, struct ds2report *ou
     u8 dpad = in->Dpad > DS4DpadDirectionReleased ? DS4DpadDirectionReleased : in->Dpad;
 
     out->nButtonStateL = ~(in->Select | in->Start << 3 | dpad_mapping[dpad]);
-    out->nButtonStateH = ~(in->Green << 1 | in->Yellow << 4 | in->Red << 5 | in->Blue << 6 | in->Orange << 7);
 
     out->nLeft = 0;
     out->nL2 = 1;
 
-    if (in->AccelX > 512 || in->AccelX < 432) {
-        out->nL2 = 0;
+    if (guitar_hero_format) {
+        // GH PS3 Guitars swap Yellow and Blue
+        out->nButtonStateH = ~(in->Green << 1 | in->Yellow << 4 | in->Red << 5 | in->Blue << 6 | in->Orange << 7);
+        if (in->AccelX > 512 || in->AccelX < 432) {
+            out->nL2 = 0;
+        }
+    } else {
+        out->nButtonStateH = ~(in->StarPower | in->Green << 1 | in->Blue << 4 | in->Red << 5 | in->Yellow << 6 | in->Orange << 7);
     }
 }
 

--- a/modules/pademu/ds34common.c
+++ b/modules/pademu/ds34common.c
@@ -27,21 +27,6 @@ void translate_pad_guitar(const struct ds3guitarreport *in, struct ds2report *ou
     out->nButtonStateL = ~(in->Select | in->Start << 3 | dpad_mapping[dpad]);
     out->nButtonStateH = ~(in->Green << 1 | in->Yellow << 4 | in->Red << 5 | in->Blue << 6 | in->Orange << 7);
 
-    out->PressureRight = in->PressureRight;
-    out->PressureLeft = in->PressureLeft;
-    out->PressureUp = in->PressureUp;
-    out->PressureDown = in->PressureDown;
-
-    out->PressureTriangle = in->PressureTriangle;
-    out->PressureCircle = in->PressureCircle;
-    out->PressureCross = in->PressureCross;
-    out->PressureSquare = in->PressureSquare;
-
-    out->PressureL1 = in->PressureL1;
-    out->PressureR1 = in->PressureR1;
-    out->PressureL2 = in->PressureL2;
-    out->PressureR2 = in->PressureR2;
-
     out->nLeft = 0;
     out->nL2 = 1;
 

--- a/modules/pademu/ds34usb.c
+++ b/modules/pademu/ds34usb.c
@@ -83,7 +83,7 @@ int usb_probe(int devId)
         return 0;
     }
 
-    if (device->idVendor == SONY_VID && device->idProduct == GUITAR_HERO_PS3_PID) {
+    if (device->idVendor == SONY_VID && (device->idProduct == GUITAR_HERO_PS3_PID || device->idProduct == ROCK_BAND_PS3_PID)) {
         return 1;
     }
 

--- a/modules/pademu/ds34usb.c
+++ b/modules/pademu/ds34usb.c
@@ -129,7 +129,10 @@ int usb_connect(int devId)
         ds34pad[pad].type = DS3;
         epCount = interface->bNumEndpoints - 1;
     } else if (device->idProduct == GUITAR_HERO_PS3_PID) {
-        ds34pad[pad].type = GUITAR;
+        ds34pad[pad].type = GUITAR_GH;
+        epCount = interface->bNumEndpoints - 1;
+    } else if (device->idProduct == ROCK_BAND_PS3_PID) {
+        ds34pad[pad].type = GUITAR_RB;
         epCount = interface->bNumEndpoints - 1;
     } else {
         ds34pad[pad].type = DS4;
@@ -268,12 +271,12 @@ static void DS3USB_init(int pad)
 static void readReport(u8 *data, int pad_idx)
 {
     ds34usb_device *pad = &ds34pad[pad_idx];
-    if (pad->type == GUITAR) {
+    if (pad->type == GUITAR_GH || pad->type == GUITAR_RB) {
         struct ds3guitarreport *report;
 
         report = (struct ds3guitarreport *)data;
 
-        translate_pad_guitar(report, &pad->ds2);
+        translate_pad_guitar(report, &pad->ds2, pad->type == GUITAR_GH);
         padMacroPerform(&pad->ds2, report->PSButton);
     }
     if (data[0]) {
@@ -516,7 +519,7 @@ int ds34usb_get_model(int port)
     int ret;
 
     WaitSema(ds34pad[port].sema);
-    if (ds34pad[port].type == GUITAR) {
+    if (ds34pad[port].type == GUITAR_GH || ds34pad[port].type == GUITAR_RB) {
         ret = MODEL_GUITAR;
     } else {
         ret = MODEL_PS2;

--- a/modules/pademu/ds34usb.h
+++ b/modules/pademu/ds34usb.h
@@ -5,8 +5,12 @@
 
 #include <ds34common.h>
 
-#define DS3 0
-#define DS4 1
+#define DS3    0
+#define DS4    1
+#define GUITAR 2
+
+#define MODEL_GUITAR 1
+#define MODEL_PS2    3
 
 #define MAX_BUFFER_SIZE 64 // Size of general purpose data buffer
 
@@ -70,6 +74,7 @@ enum eHID {
 
 int ds34usb_init(u8 pads, u8 options);
 int ds34usb_get_status(int port);
+int ds34usb_get_model(int port);
 void ds34usb_reset();
 int ds34usb_get_data(u8 *dst, int size, int port);
 void ds34usb_set_rumble(u8 lrum, u8 rrum, int port);

--- a/modules/pademu/ds34usb.h
+++ b/modules/pademu/ds34usb.h
@@ -8,7 +8,7 @@
 #define DS3       0
 #define DS4       1
 #define GUITAR_GH 2
-#define GUITAR_RB 2
+#define GUITAR_RB 3
 
 #define MODEL_GUITAR 1
 #define MODEL_PS2    3
@@ -25,7 +25,7 @@ typedef struct _usb_ds34
     int outEndp;
     u8 enabled;
     u8 status;
-    u8 type;      // 0 - ds3, 1 - ds4
+    u8 type;      // 0 - ds3, 1 - ds4, 2 - guitar hero guitar, 3 - rock band guitar
     u8 oldled[4]; // rgb for ds4 and blink
     u8 lrum;
     u8 rrum;

--- a/modules/pademu/ds34usb.h
+++ b/modules/pademu/ds34usb.h
@@ -5,9 +5,10 @@
 
 #include <ds34common.h>
 
-#define DS3    0
-#define DS4    1
-#define GUITAR 2
+#define DS3       0
+#define DS4       1
+#define GUITAR_GH 2
+#define GUITAR_RB 2
 
 #define MODEL_GUITAR 1
 #define MODEL_PS2    3

--- a/modules/pademu/pademu.c
+++ b/modules/pademu/pademu.c
@@ -13,12 +13,13 @@
 
 #include "ds34bt.h"
 
-#define PAD_INIT       ds34bt_init
-#define PAD_GET_STATUS ds34bt_get_status
-#define PAD_RESET      ds34bt_reset
-#define PAD_GET_DATA   ds34bt_get_data
-#define PAD_SET_RUMBLE ds34bt_set_rumble
-#define PAD_SET_MODE   ds34bt_set_mode
+#define PAD_INIT            ds34bt_init
+#define PAD_GET_STATUS      ds34bt_get_status
+#define PAD_RESET           ds34bt_reset
+#define PAD_GET_DATA        ds34bt_get_data
+#define PAD_SET_RUMBLE      ds34bt_set_rumble
+#define PAD_SET_MODE        ds34bt_set_mode
+#define PAD_GET_MODEL(port) 3
 
 #elif defined(USB)
 
@@ -28,6 +29,7 @@
 #define PAD_GET_STATUS ds34usb_get_status
 #define PAD_RESET      ds34usb_reset
 #define PAD_GET_DATA   ds34usb_get_data
+#define PAD_GET_MODEL  ds34usb_get_model
 #define PAD_SET_RUMBLE ds34usb_set_rumble
 #define PAD_SET_MODE   ds34usb_set_mode
 
@@ -463,6 +465,7 @@ void pademu_cmd(int port, u8 *in, u8 *out, u8 out_size)
         case 0x45: // query model and mode
             mips_memcpy(&out[3], &pademu_data[1], 6);
             out[5] = pad[port].mode;
+            out[3] = PAD_GET_MODEL(port);
             break;
 
         case 0x46: // query act


### PR DESCRIPTION
To do this, I added in support for parsing the PS3 Guitar reports, as the hid report format for PS3 Instruments differs from the standard controller. I also added in support for PADEMU to support different models, as PS2 guitars use a different model in the `query model and mode` command. I also force hold dpad left, as this is another thing the games use for detecting guitars.

For PS3 Guitar Hero Guitars, I map the accelerometer once it hits certain ranges, while for RB Guitars i just map the tilt bit directly as it is still digital on those.

For the frets, I use the RB style mappings as most other instruments except for the PS3 Guitar Hero Guitar use that format, and then when translating the pad I swap yellow and blue for guitar hero guitars.

## Pull Request checklist

Note: these are not necessarily requirements

- [X] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
