### PR TITLE
fix argumments of SIOCookie init

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -48,7 +48,7 @@ int configGetStat(config_set_t *configSet, iox_stat_t *stat);
 
 #ifdef __EESIO_DEBUG
 #include "SIOCookie.h"
-#define LOG_INIT() ee_sio_start(38400, 0, 0, 0, 0)
+#define LOG_INIT() ee_sio_start(38400, 0, 0, 0, 0, 1)
 #define LOG_ENABLE() \
     do {             \
     } while (0)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

this updates the argumments for the initialization function of my SIOCookie library. fixing compilation of the `ee_sio` debug build