### PR TITLE
krat0s: EutechNyx patches for various games

### DIFF
--- a/ee_core/src/patches.c
+++ b/ee_core/src/patches.c
@@ -132,6 +132,12 @@ static const patchlist_t patch_list[] = {
     {"SLPS_732.22", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000000, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-J) (PlayStation 2 The Best)
     {"SLUS_211.71", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000001, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-U/C)
     {"SLES_534.80", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000002, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-PAL)
+    {"SLUS_214.38", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0034c944, 0x00000000}},   // Cartoon Network Racing (NTSC-U/C)
+    {"SLES_543.06", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0034c8A4, 0x00000000}},   // Cartoon Network Racing (PAL)
+    {"SLUS_216.28", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0023cbc8, 0x00000000}},   // Hot Wheels - Beat That! (NTSC-U/C)
+    {"SLES_549.71", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0023d7b8, 0x00000000}},   // Hot Wheels - Beat That! (PAL)
+    {"SLUS_213.57", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00386b14, 0x00000000}},   // Hummer Badlands (NTSC-U/C)
+    {"SLES_541.58", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00388a84, 0x00000000}},   // Hummer Badlands (PAL)
     {NULL, 0, {0x00000000, 0x00000000, 0x00000000}}                                // terminater
 };
 

--- a/ee_core/src/patches.c
+++ b/ee_core/src/patches.c
@@ -83,6 +83,8 @@ static const patchlist_t patch_list[] = {
     {"SLES_528.22", ETH_MODE, {PATCH_GENERIC_SLOW_READS, 0x000c0000, 0x0060f4dc}}, // Prince of Persia: Warrior Within PAL - slow down cdvd reads
     {"SLES_528.22", HDD_MODE, {PATCH_GENERIC_SLOW_READS, 0x00040000, 0x0060f4dc}}, // Prince of Persia: Warrior Within PAL - slow down cdvd reads
     {"SLUS_214.32", ALL_MODE, {PATCH_GENERIC_SLOW_READS, 0x00080000, 0x002baf34}}, // NRA Gun Club NTSC U
+    {"SLUS_209.77", ALL_MODE, {PATCH_VIRTUA_QUEST, 0x00000000, 0x00000000}},       // Virtua Quest
+    {"SLPM_656.32", ALL_MODE, {PATCH_VIRTUA_QUEST, 0x00000000, 0x00000000}},       // Virtua Fighter Cyber Generation: Judgment Six No Yabou
     {"SLPM_654.05", HDD_MODE, {PATCH_SDF_MACROSS, 0x00200000, 0x00249b84}},        // Super Dimensional Fortress Macross JPN
     {"SLUS_202.30", ALL_MODE, {0x00132d14, 0x10000018, 0x0c046744}},               // Max Payne NTSC U - skip IOP reset before to exec demo elfs
     {"SLES_503.25", ALL_MODE, {0x00132ce4, 0x10000018, 0x0c046744}},               // Max Payne PAL - skip IOP reset before to exec demo elfs
@@ -108,11 +110,21 @@ static const patchlist_t patch_list[] = {
     {"SLUS_205.61", ALL_MODE, {PATCH_SOS, 0x00000001, 0x00000000}},                // Disaster Report
     {"SLES_513.01", ALL_MODE, {PATCH_SOS, 0x00000002, 0x00000000}},                // SOS: The Final Escape
     {"SLPS_251.13", ALL_MODE, {PATCH_SOS, 0x00000000, 0x00000000}},                // Zettai Zetsumei Toshi
-    {"SLUS_209.77", ALL_MODE, {PATCH_VIRTUA_QUEST, 0x00000000, 0x00000000}},       // Virtua Quest
-    {"SLPM_656.32", ALL_MODE, {PATCH_VIRTUA_QUEST, 0x00000000, 0x00000000}},       // Virtua Fighter Cyber Generation: Judgment Six No Yabou
     {"SLES_535.08", ALL_MODE, {PATCH_ULT_PRO_PINBALL, 0x00000000, 0x00000000}},    // Ultimate Pro Pinball
+    {"SLUS_200.02", BDM_MODE, {0x002c7758, 0x0000182d, 0x8c436d18}},               // Ridge Racer V (NTSC-U/C) - workaround disabling (bugged?) streaming code in favour of processing all data at once, for USB devices.
+    {"SCES_500.00", BDM_MODE, {0x002c9760, 0x0000182d, 0x8c43a2f8}},               // Ridge Racer V (PAL) - workaround by disabling (bugged?) streaming code in favour of processing all data at once, for USB devices.
     {"SLES_552.94", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0012fcc8, 0x00000000}},   // Ferrari Challenge: Trofeo Pirelli (PAL)
     {"SLUS_217.80", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0012fcb0, 0x00000000}},   // Ferrari Challenge: Trofeo Pirelli (NTSC-U/C)
+    {"SLUS_205.82", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0033b534, 0x00000000}},   // SRS: Street Racing Syndicate (NTSC-U/C)
+    {"SLES_530.45", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0033fbfc, 0x00000000}},   // SRS: Street Racing Syndicate (PAL)
+    {"SLUS_214.49", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00361dfc, 0x00000000}},   // The Fast and the Furious (NTSC-U/C)
+    {"SLES_544.83", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00363c4c, 0x00000000}},   // The Fast and the Furious (PAL)
+    {"SLUS_214.38", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0034c944, 0x00000000}},   // Cartoon Network Racing (NTSC-U/C)
+    {"SLES_543.06", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0034c8A4, 0x00000000}},   // Cartoon Network Racing (PAL)
+    {"SLUS_216.28", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0023cbc8, 0x00000000}},   // Hot Wheels - Beat That! (NTSC-U/C)
+    {"SLES_549.71", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0023d7b8, 0x00000000}},   // Hot Wheels - Beat That! (PAL)
+    {"SLUS_213.57", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00386b14, 0x00000000}},   // Hummer Badlands (NTSC-U/C)
+    {"SLES_541.58", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00388a84, 0x00000000}},   // Hummer Badlands (PAL)
     {"SLUS_201.99", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (NTSC-U/C)
     {"SLES_504.00", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (PAL)
     {"SLES_504.01", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (PAL French)
@@ -121,24 +133,12 @@ static const patchlist_t patch_list[] = {
     {"SLUS_204.13", ALL_MODE, {PATCH_SHADOW_MAN_2, 0x00000001, 0x00000000}},       // Shadow Man: 2econd Coming (NTSC-U/C)
     {"SLES_504.46", ALL_MODE, {PATCH_SHADOW_MAN_2, 0x00000002, 0x00000000}},       // Shadow Man: 2econd Coming (PAL)
     {"SLES_506.08", ALL_MODE, {PATCH_SHADOW_MAN_2, 0x00000003, 0x00000000}},       // Shadow Man: 2econd Coming (PAL German)
-    {"SLUS_200.02", BDM_MODE, {0x002c7758, 0x0000182d, 0x8c436d18}},               // Ridge Racer V (NTSC-U/C) - workaround disabling (bugged?) streaming code in favour of processing all data at once, for USB devices.
-    {"SCES_500.00", BDM_MODE, {0x002c9760, 0x0000182d, 0x8c43a2f8}},               // Ridge Racer V (PAL) - workaround by disabling (bugged?) streaming code in favour of processing all data at once, for USB devices.
-    {"SLUS_205.82", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0033b534, 0x00000000}},   // SRS: Street Racing Syndicate (NTSC-U/C)
-    {"SLES_530.45", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0033fbfc, 0x00000000}},   // SRS: Street Racing Syndicate (PAL)
-    {"SLUS_214.49", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00361dfc, 0x00000000}},   // The Fast and the Furious (NTSC-U/C)
-    {"SLES_544.83", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00363c4c, 0x00000000}},   // The Fast and the Furious (PAL)
     {"SLPS_254.21", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000000, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-J) (First Print Edition)
     {"SLPS_254.31", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000000, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-J)
     {"SLPS_732.22", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000000, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-J) (PlayStation 2 The Best)
     {"SLUS_211.71", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000001, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-U/C)
     {"SLES_534.80", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000002, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-PAL)
-    {"SLUS_214.38", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0034c944, 0x00000000}},   // Cartoon Network Racing (NTSC-U/C)
-    {"SLES_543.06", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0034c8A4, 0x00000000}},   // Cartoon Network Racing (PAL)
-    {"SLUS_216.28", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0023cbc8, 0x00000000}},   // Hot Wheels - Beat That! (NTSC-U/C)
-    {"SLES_549.71", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0023d7b8, 0x00000000}},   // Hot Wheels - Beat That! (PAL)
-    {"SLUS_213.57", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00386b14, 0x00000000}},   // Hummer Badlands (NTSC-U/C)
-    {"SLES_541.58", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00388a84, 0x00000000}},   // Hummer Badlands (PAL)
-    {NULL, 0, {0x00000000, 0x00000000, 0x00000000}}                                // terminater
+    {NULL, 0, {0x00000000, 0x00000000, 0x00000000}}                                // terminator
 };
 
 #define JAL(addr)      (0x0c000000 | (((addr)&0x03ffffff) >> 2))

--- a/ee_core/src/patches.c
+++ b/ee_core/src/patches.c
@@ -127,6 +127,8 @@ static const patchlist_t patch_list[] = {
     {"SLES_541.58", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00388a84, 0x00000000}},   // Hummer Badlands (PAL)
     {"SLUS_211.62", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00144bcc, 0x00000000}},   // Ford Mustang - The Legend Lives (NTSC-U/C)
     {"SLES_532.96", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00144cc4, 0x00000000}},   // Ford Mustang - The Legend Lives (PAL)
+    {"SLUS_212.76", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00332814, 0x00000000}},   // Ford vs. Chevy (NTSC-U/C)
+    {"SLES_536.98", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00335674, 0x00000000}},   // Ford vs. Chevy  (PAL)
     {"SLUS_201.99", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (NTSC-U/C)
     {"SLES_504.00", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (PAL)
     {"SLES_504.01", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (PAL French)

--- a/ee_core/src/patches.c
+++ b/ee_core/src/patches.c
@@ -131,6 +131,8 @@ static const patchlist_t patch_list[] = {
     {"SLES_536.98", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00335674, 0x00000000}},   // Ford vs. Chevy  (PAL)
     {"SLUS_210.86", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x001462fc, 0x00000000}},   // Big Mutha Truckers 2 (NTSC-U/C)
     {"SLES_529.80", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00146124, 0x00000000}},   // Big Mutha Truckers 2 - Truck Me Harder (PAL)
+    {"SLES_546.32", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x001f60f8, 0x00000000}},   // MTV Pimp My Ride (PAL)
+    {"SLES_546.07", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x001f37d0, 0x00000000}},   // MTV Pimp My Ride (PAL-Australia)
     {"SLUS_201.99", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (NTSC-U/C)
     {"SLES_504.00", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (PAL)
     {"SLES_504.01", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (PAL French)

--- a/ee_core/src/patches.c
+++ b/ee_core/src/patches.c
@@ -129,6 +129,8 @@ static const patchlist_t patch_list[] = {
     {"SLES_532.96", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00144cc4, 0x00000000}},   // Ford Mustang - The Legend Lives (PAL)
     {"SLUS_212.76", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00332814, 0x00000000}},   // Ford vs. Chevy (NTSC-U/C)
     {"SLES_536.98", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00335674, 0x00000000}},   // Ford vs. Chevy  (PAL)
+    {"SLUS_210.86", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x001462fc, 0x00000000}},   // Big Mutha Truckers 2 (NTSC-U/C)
+    {"SLES_529.80", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00146124, 0x00000000}},   // Big Mutha Truckers 2 - Truck Me Harder (PAL)
     {"SLUS_201.99", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (NTSC-U/C)
     {"SLES_504.00", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (PAL)
     {"SLES_504.01", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (PAL French)

--- a/ee_core/src/patches.c
+++ b/ee_core/src/patches.c
@@ -125,6 +125,8 @@ static const patchlist_t patch_list[] = {
     {"SLES_549.71", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x0023d7b8, 0x00000000}},   // Hot Wheels - Beat That! (PAL)
     {"SLUS_213.57", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00386b14, 0x00000000}},   // Hummer Badlands (NTSC-U/C)
     {"SLES_541.58", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00388a84, 0x00000000}},   // Hummer Badlands (PAL)
+    {"SLUS_211.62", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00144bcc, 0x00000000}},   // Ford Mustang - The Legend Lives (NTSC-U/C)
+    {"SLES_532.96", ALL_MODE, {PATCH_EUTECHNYX_WU_TID, 0x00144cc4, 0x00000000}},   // Ford Mustang - The Legend Lives (PAL)
     {"SLUS_201.99", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (NTSC-U/C)
     {"SLES_504.00", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (PAL)
     {"SLES_504.01", ALL_MODE, {PATCH_PRO_SNOWBOARDER, 0x00000000, 0x00000000}},    // Shaun Palmer's Pro Snowboarder (PAL French)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

krat0s:
There are some games using the EutechNyx which behave differently based on the boot state. They use a hardcoded thread id and for this patches were applied. Two common games Hot Wheels and Cartoon Racing Network suffered from same issue but they were missing a patch. Patches have been added even for the other games (some of them untested)
A full list of games using this engine:

Bakusou Convoy Densetsu - Otoko Hanamichi America Roman (Japan)
Big Mutha Truckers (Europe) (En,Fr,De,Es,It)
Big Mutha Truckers (USA)
Big Mutha Truckers 2 (USA)
Big Mutha Truckers 2 - Truck Me Harder (Europe) (En,Fr,De,Es,It)
Bonus Demo 9 (Old) (Europe)
Cartoon Network Racing (Europe)
Cartoon Network Racing (USA)
Fast and the Furious, The (Europe)
Fast and the Furious, The (USA)
Ferrari Challenge - Trofeo Pirelli (Europe) (En,Fr,De,Es,It)
Ferrari Challenge - Trofeo Pirelli (USA)
Ford Mustang - The Legend Lives (Europe) (En,Fr,De,Es)
Ford Mustang - The Legend Lives (USA)
Ford vs. Chevy (Europe, Australia) (En,Fr,De,Es,It)
Ford vs. Chevy (USA)
Hot Wheels - Beat That! (Europe) (En,Fr,De,It)
Hot Wheels - Beat That! (USA)
Hummer Badlands (Europe)
Hummer Badlands (USA)
Magazine Ufficiale PlayStation 2 Demo Italia Special Racing (Italy) (En,Fr,De,Es,It)
MTV Pimp My Ride (Europe) (Fr,De,Es,It)
MTV Pimp My Ride (Europe, Australia)
MTV Pimp My Ride (USA) (v1.00)
MTV Pimp My Ride (USA) (v2.00)
Namco Transmission v2 (USA)
Namco Transmission Vol. 2 (USA)
Official PlayStation 2 Magazine Demo 59 (Europe, Australia) (En,Fr,De,Es,It)
Official PlayStation 2 Magazine Demo 60 (Germany) (En,De)
Official PlayStation 2 Magazine Demo 60 (UK) (En,Fr,De,Es,It)
Official PlayStation 2 Magazine Demo 74 (Germany)
Official PlayStation 2 Magazine Demo 82 (Germany) (En,Fr,De,Es,It)
SRS - Street Racing Syndicate (Europe) (En,Fr,De,Es,It)
SRS - Street Racing Syndicate (USA) (v1.03)
SRS - Street Racing Syndicate (USA) (v2.00)

List of games using the engine but not using a fixed thread id so no need for a patch:
Bakusou Convoy Densetsu - Otoko Hanamichi America Roman (Japan)
Big Mutha Truckers (Europe) (En,Fr,De,Es,It)
Big Mutha Truckers (USA)
All demos and multicompilations (like Namco Transmission) which have the other games we use patches for have no patch applied for obvious reasons. They may or may not work.