### PR TITLE
krat0s: fix toc search bug

### DIFF
--- a/modules/iopcore/cdvdman/searchfile.c
+++ b/modules/iopcore/cdvdman/searchfile.c
@@ -40,11 +40,11 @@ static void cdvdman_trimspaces(char *str)
 static struct dirTocEntry *cdvdman_locatefile(char *name, u32 tocLBA, int tocLength, int layer)
 {
     char cdvdman_dirname[32]; /* Like below, but follow the original SCE limitation of 32-characters.
-						Some games specify filenames like "\\FILEFILE.EXT;1", which result in a length longer than just 14.
-						SCE does not perform bounds-checking on this buffer.	*/
+                        Some games specify filenames like "\\FILEFILE.EXT;1", which result in a length longer than just 14.
+                        SCE does not perform bounds-checking on this buffer.	*/
     char cdvdman_curdir[15];  /* Maximum 14 characters: the filename (8) + '.' + extension (3) + ';' + '1'.
-						Unlike the SCE original which used a 32-character buffer,
-						we'll assume that ISO9660 disc images are all _strictly_ compliant with ISO9660 level 1.	*/
+                        Unlike the SCE original which used a 32-character buffer,
+                        we'll assume that ISO9660 disc images are all _strictly_ compliant with ISO9660 level 1.	*/
     char *p = (char *)name;
     char *slash;
     int r, len, filename_len;
@@ -161,7 +161,7 @@ static int cdvdman_findfile(sceCdlFILE *pcdfile, const char *name, int layer)
 
     if (cdvdman_settings.common.flags & IOPCORE_COMPAT_EMU_DVDDL)
         layer = 0;
-    pLayerInfo = (layer != 0) ? &layer_info[1] : &layer_info[0]; //SCE CDVDMAN simply treats a non-zero value as a signal for the 2nd layer.
+    pLayerInfo = (layer != 0) ? &layer_info[1] : &layer_info[0]; // SCE CDVDMAN simply treats a non-zero value as a signal for the 2nd layer.
 
     WaitSema(cdvdman_searchfilesema);
 
@@ -232,7 +232,7 @@ void cdvdman_searchfile_init(void)
 
     struct dirTocEntry *tocEntryPointer = (struct dirTocEntry *)&cdvdman_buf[0x9c];
     layer_info[0].rootDirtocLBA = tocEntryPointer->fileLBA;
-    layer_info[0].rootDirtocLength = tocEntryPointer->length;
+    layer_info[0].rootDirtocLength = tocEntryPointer->fileSize;
 
     // DVD DL support
     if (!(cdvdman_settings.common.flags & IOPCORE_COMPAT_EMU_DVDDL)) {

--- a/modules/isofs/isofs.c
+++ b/modules/isofs/isofs.c
@@ -540,7 +540,7 @@ int ProbeISO9660(int fd, unsigned int sector, layer_info_t *layer_info)
 
             layer_info->maxLBA = *(u32 *)&cdvdman_buf[0x50];
             layer_info->rootDirtocLBA = tocEntryPointer->fileLBA;
-            layer_info->rootDirtocLength = tocEntryPointer->length;
+            layer_info->rootDirtocLength = tocEntryPointer->fileSize;
 
             result = 0;
         } else {


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

krat0s:
This bug was hard to spot. I had to find out what Naruto game was failing to find files in TOC although there were there. I wrote several code for parsing the root directory till it's completely and each worked but there were hacks rather than bugs. Turns out there was eternal unknown bug in OPL since eternity. 
The root directory was only ever checked on the first sector and if it happened that the file was in next sectors it was failing. This can make any game fail any possible time depending on what it is reading.
Worth testing on any game on any possible stage but it's finally fixed after all this years. Enjoy.

Affected game list:
ATV Offroad - All Terrain Vehicle (Europe) (En,Fr,De,Es,It)
ATV Offroad Fury (USA) (Demo)
ATV Offroad Fury (USA) (v1.00)
ATV Offroad Fury (USA) (v3.01)
ATV Offroad Fury 2 (USA) (Demo)
Godai - Elemental Force (Europe)
GoDai - Elemental Force (Europe) (Es,It)
GoDai - Elemental Force (Europe) (Fr,De)
Godai - Elemental Force (USA)
Impossible Mission (Europe) (En,Fr,De,Es,It)
Ka (Japan) (Tentou Taikenban)
Naruto - Uzumaki Chronicles 2 (Europe) (En,Ja,Fr,De,Es,It)
NBA Live 06 (USA)
NBA Live 06 (USA) (Beta)
NBA Live 2003 (USA)
NCAA March Madness 06 (USA)
NCAA March Madness 07 (USA)
PopStar Guitar (USA) (En,Fr,De,Es,It)

Related
https://www.reddit.com/r/ps2/comments/hz3yy5/issues_with_certain_games_in_opl_via_usb/

