### PR TITLE
krat0s: CDVDMAN: out of bounds implemented

### DIFF
--- a/modules/iopcore/cdvdfsv/cdvdfsv-internal.h
+++ b/modules/iopcore/cdvdfsv/cdvdfsv-internal.h
@@ -22,6 +22,14 @@
 
 #include "smsutils.h"
 
+#ifdef __IOPCORE_DEBUG
+#define DPRINTF(args...)  printf(args)
+#define iDPRINTF(args...) Kprintf(args)
+#else
+#define DPRINTF(args...)
+#define iDPRINTF(args...)
+#endif
+
 extern void cdvdfsv_register_scmd_rpc(SifRpcDataQueue_t *rpc_DQ);
 extern void cdvdfsv_register_ncmd_rpc(SifRpcDataQueue_t *rpc_DQ);
 extern void cdvdfsv_register_searchfile_rpc(SifRpcDataQueue_t *rpc_DQ);

--- a/modules/iopcore/cdvdfsv/imports.lst
+++ b/modules/iopcore/cdvdfsv/imports.lst
@@ -4,6 +4,7 @@ I_sceCdStandby
 I_sceCdRead
 I_sceCdSeek
 I_sceCdGetError
+I_sceCdGetToc
 I_sceCdSearchFile
 I_sceCdSync
 I_sceCdGetDiskType

--- a/modules/iopcore/cdvdfsv/ncmd.c
+++ b/modules/iopcore/cdvdfsv/ncmd.c
@@ -172,7 +172,7 @@ static inline void cdvd_readee(void *buf)
             }
 
             if (flag_64b == 0) { // not 64 bytes aligned buf
-                //The data of the last sector of the chunk will be used to correct buffer alignment.
+                // The data of the last sector of the chunk will be used to correct buffer alignment.
                 if (sectors_to_read < CDVDMAN_FS_SECTORS - 1)
                     nsectors = sectors_to_read;
                 else
@@ -222,7 +222,7 @@ static inline void cdvd_readee(void *buf)
 
         } while ((flag_64b) || (sectors_to_read));
 
-        //At the very last pass, copy readee.b2len bytes from the last sector, to complete the alignment correction.
+        // At the very last pass, copy readee.b2len bytes from the last sector, to complete the alignment correction.
         memcpy((void *)readee.buf2, (void *)(fsvRbuf + size_64b - readee.b2len), readee.b2len);
     }
 
@@ -357,7 +357,7 @@ static inline void cdvd_readchain(void *buf)
             }
         }
 
-        //The pointer to the read position variable within EE RAM is stored at ((RpcCdvdchain_t *)buf)[65].sectors.
+        // The pointer to the read position variable within EE RAM is stored at ((RpcCdvdchain_t *)buf)[65].sectors.
         sysmemSendEE(&readpos, (void *)((RpcCdvdchain_t *)buf)[65].sectors, sizeof(readpos));
     }
 }
@@ -393,6 +393,7 @@ static void *cbrpc_cdvdNcmds(int fno, void *buf, int size)
             cdvd_readee(buf);
             break;
         case CD_NCMD_GETTOC:
+            DPRINTF("cbrpc_cdvdNcmds CD_NCMD_GETTOC NOT IMPLEMENTED buf=%x\n", (int)buf);
             *(int *)buf = 1;
             break;
         case CD_NCMD_SEEK:
@@ -426,6 +427,7 @@ static void *cbrpc_cdvdNcmds(int fno, void *buf, int size)
             rpcNCmd_cdgetdisktype(buf);
             break;
         default:
+            DPRINTF("cbrpc_cdvdNcmds unknown rpc fno=%x buf=%x size=%x\n", fno, (int)buf, size);
             *(int *)buf = 0;
             break;
     }

--- a/modules/iopcore/cdvdfsv/ncmd.c
+++ b/modules/iopcore/cdvdfsv/ncmd.c
@@ -393,8 +393,7 @@ static void *cbrpc_cdvdNcmds(int fno, void *buf, int size)
             cdvd_readee(buf);
             break;
         case CD_NCMD_GETTOC:
-            DPRINTF("cbrpc_cdvdNcmds CD_NCMD_GETTOC NOT IMPLEMENTED buf=%x\n", (int)buf);
-            *(int *)buf = 1;
+            *(int *)buf = sceCdGetToc((u8 *)(*(u32 *)buf));
             break;
         case CD_NCMD_SEEK:
             *(int *)buf = sceCdSeek(*(u32 *)buf);

--- a/modules/iopcore/cdvdfsv/scmd.c
+++ b/modules/iopcore/cdvdfsv/scmd.c
@@ -172,6 +172,7 @@ static void *cbrpc_cdvdScmds(int fno, void *buf, int size)
             rpcSCmd_cdreaddvddualinfo(buf);
             break;
         default:
+            DPRINTF("cbrpc_cdvdScmds unknown rpc fno=%x buf=%x size=%x\n", fno, (int)buf, size);
             *(int *)buf = 0;
             break;
     }

--- a/modules/iopcore/cdvdman/internal.h
+++ b/modules/iopcore/cdvdman/internal.h
@@ -125,5 +125,6 @@ extern cdvdman_status_t cdvdman_stat;
 
 extern unsigned char sync_flag;
 extern unsigned char cdvdman_cdinited;
+extern u32 mediaLsnCount;
 
 #endif

--- a/modules/iopcore/cdvdman/internal.h
+++ b/modules/iopcore/cdvdman/internal.h
@@ -52,6 +52,8 @@
 #error Unknown driver type. Please check the Makefile.
 #endif
 
+#define btoi(b) ((b) / 16 * 10 + (b) % 16) /* BCD to u_char */
+#define itob(i) ((i) / 10 * 16 + (i) % 10) /* u_char to BCD */
 struct SteamingData
 {
     unsigned short int StBufmax;

--- a/modules/iopcore/cdvdman/ioops.c
+++ b/modules/iopcore/cdvdman/ioops.c
@@ -510,6 +510,7 @@ static int cdrom_devctl(iop_file_t *f, const char *name, int cmd, void *args, u3
             result = sceCdGetToc(buf);
             if (result != 1)
                 result = -EIO;
+            sceCdSync(0);
             break;
         case CDIOC_GETINTREVENTFLG:
             *(int *)buf = cdvdman_stat.intr_ef;

--- a/modules/iopcore/cdvdman/ncmd.c
+++ b/modules/iopcore/cdvdman/ncmd.c
@@ -48,12 +48,14 @@ int sceCdReadCdda(u32 lsn, u32 sectors, void *buf, sceCdRMode *mode)
 //-------------------------------------------------------------------------
 int sceCdGetToc(u8 *toc)
 {
+    DPRINTF("sceCdGetToc toc=%08x  NOT IMPLEMENTED \n", (int)toc);
+
     if (sync_flag)
         return 0;
 
     cdvdman_stat.err = SCECdErREAD;
 
-    return 0; //Not supported
+    return 0; // Not supported
 }
 
 //-------------------------------------------------------------------------

--- a/modules/iopcore/cdvdman/ncmd.c
+++ b/modules/iopcore/cdvdman/ncmd.c
@@ -70,6 +70,14 @@ int sceCdSeek(u32 lsn)
 
     cdvdman_stat.status = SCECdStatPause;
 
+    // Set the invalid parament error in case of trying to seek more than max lsn.
+    if (mediaLsnCount) {
+        if (lsn >= mediaLsnCount) {
+            DPRINTF("cdvdman_searchfile_init mediaLsnCount=%d\n", mediaLsnCount);
+            cdvdman_stat.err = SCECdErIPI;
+        }
+    }
+
     cdvdman_cb_event(SCECdFuncSeek);
 
     return 1;

--- a/modules/iopcore/cdvdman/ncmd.c
+++ b/modules/iopcore/cdvdman/ncmd.c
@@ -46,16 +46,140 @@ int sceCdReadCdda(u32 lsn, u32 sectors, void *buf, sceCdRMode *mode)
 }
 
 //-------------------------------------------------------------------------
+void lba_to_msf(s32 lba, u8 *m, u8 *s, u8 *f)
+{
+    lba += 150;
+    *m = lba / (60 * 75);
+    *s = (lba / 75) % 60;
+    *f = lba % 75;
+}
+
+int cdvdman_fill_toc(u8 *tocBuff)
+{
+
+    u8 discType = cdvdman_stat.disc_type_reg & 0xFF;
+
+    DPRINTF("cdvdman_fill_toc tocBuff=%08x discType=%02X\n", (int)tocBuff, discType);
+
+    if (tocBuff == NULL) {
+        return 0;
+    }
+
+    switch (discType) {
+        case 0x12: // SCECdPS2CD
+        case 0x13: // SCECdPS2CDDA
+            u8 min;
+            u8 sec;
+            u8 frm;
+            tocBuff[0] = 0x41;
+            tocBuff[1] = 0x00;
+
+            memset(tocBuff, 0, 1024);
+
+            // Number of FirstTrack,
+            // Always 1 until PS2CCDA support get's added.
+            tocBuff[2] = 0xA0;
+            tocBuff[7] = itob(1);
+
+            // Number of LastTrack
+            // Always 1 until PS2CCDA support get's added.
+            tocBuff[12] = 0xA1;
+            tocBuff[17] = itob(1);
+
+            // DiskLength
+            lba_to_msf(mediaLsnCount, &min, &sec, &frm);
+            tocBuff[22] = 0xA2;
+            tocBuff[27] = itob(min);
+            tocBuff[28] = itob(sec);
+            tocBuff[29] = itob(frm);
+
+            // Later when PS2CCDA is added the tracks need to get filled in toc too.
+            break;
+
+        case 0x14: // SCECdPS2DVD
+        case 0xFE: // SCECdDVDV
+            // Toc for single layer DVD.
+            memset(tocBuff, 0, 2048);
+
+            // Write only what we need, memset has cleared the above buffers.
+            //  Single Layer - Values are fixed.
+            tocBuff[0] = 0x04;
+            tocBuff[1] = 0x02;
+            tocBuff[2] = 0xF2;
+            tocBuff[4] = 0x86;
+            tocBuff[5] = 0x72;
+
+            // These values are fixed on all discs, except position 14 which is the OTP/PTP flags which are 0 in single layer.
+
+            tocBuff[12] = 0x01;
+            tocBuff[13] = 0x02;
+            tocBuff[14] = 0x01;
+            tocBuff[17] = 0x03;
+
+            u32 maxlsn = mediaLsnCount + (0x30000 - 1);
+            tocBuff[20] = (maxlsn >> 24) & 0xFF;
+            tocBuff[21] = (maxlsn >> 16) & 0xff;
+            tocBuff[22] = (maxlsn >> 8) & 0xff;
+            tocBuff[23] = (maxlsn >> 0) & 0xff;
+            break;
+
+        default:
+            // Check if we are DVD9 game and fill toc for it.
+
+            if (!(cdvdman_settings.common.flags & IOPCORE_COMPAT_EMU_DVDDL)) {
+                memset(tocBuff, 0, 2048);
+
+                // Dual sided - Values are fixed.
+                tocBuff[0] = 0x24;
+                tocBuff[1] = 0x02;
+                tocBuff[2] = 0xF2;
+                tocBuff[4] = 0x41;
+                tocBuff[5] = 0x95;
+
+                // These values are fixed on all discs, except position 14 which is the OTP/PTP flags.
+                tocBuff[12] = 0x01;
+                tocBuff[13] = 0x02;
+                tocBuff[14] = 0x21; // PTP
+                tocBuff[15] = 0x10;
+
+                // Values are fixed.
+                tocBuff[17] = 0x03;
+
+                u32 l1s = mediaLsnCount + 0x30000 - 1;
+                tocBuff[20] = (l1s >> 24);
+                tocBuff[21] = (l1s >> 16) & 0xff;
+                tocBuff[22] = (l1s >> 8) & 0xff;
+                tocBuff[23] = (l1s >> 0) & 0xff;
+
+                return 1;
+            }
+
+            // Not known type.
+            DPRINTF("cdvdman_fill_toc unimplemented for  discType=%02X\n", discType);
+            return 0;
+    }
+
+    return 1;
+}
+
+
 int sceCdGetToc(u8 *toc)
 {
-    DPRINTF("sceCdGetToc toc=%08x  NOT IMPLEMENTED \n", (int)toc);
+    DPRINTF("sceCdGetToc toc=%08x\n", (int)toc);
 
     if (sync_flag)
         return 0;
 
-    cdvdman_stat.err = SCECdErREAD;
+    cdvdman_stat.err = SCECdErNO;
+    int result = cdvdman_fill_toc(toc);
 
-    return 0; // Not supported
+    if (!result) {
+        cdvdman_stat.err = SCECdErREAD;
+    }
+
+    cdvdman_cb_event(SCECdFuncGetToc);
+
+    return result;
 }
 
 //-------------------------------------------------------------------------

--- a/modules/iopcore/cdvdman/scmd.c
+++ b/modules/iopcore/cdvdman/scmd.c
@@ -40,11 +40,13 @@ int sceCdGetError(void)
 //-------------------------------------------------------------------------
 int sceCdTrayReq(int mode, u32 *traycnt)
 {
-    DPRINTF("sceCdTrayReq(%d, 0x%lX)\n", mode, *traycnt);
+    DPRINTF("sceCdTrayReq(%d, 0x08%X)\n", mode, traycnt);
 
     if (mode == SCECdTrayCheck) {
         if (traycnt)
             *traycnt = cdvdman_media_changed;
+
+        DPRINTF("sceCdTrayReq TrayCheck result=%d\n", cdvdman_media_changed);
 
         cdvdman_media_changed = 0;
 
@@ -78,7 +80,7 @@ int sceCdTrayReq(int mode, u32 *traycnt)
 //-------------------------------------------------------------------------
 int sceCdApplySCmd(u8 cmd, const void *in, u16 in_size, void *out)
 {
-    DPRINTF("sceCdApplySCmd\n");
+    DPRINTF("sceCdApplySCmd cmd=%02x\n", cmd & 0xFF);
 
     return cdvdman_sendSCmd(cmd & 0xff, in, in_size, out, 16);
 }
@@ -127,7 +129,7 @@ int cdvdman_readID(int mode, u8 *buf)
     if (mode == 0) { // GUID
         u32 *GUID0 = (u32 *)&buf[0];
         u32 *GUID1 = (u32 *)&buf[4];
-        *GUID0 = lbuf[0] | 0x08004600; //Replace the MODEL ID segment with the SCE OUI, to get the console's IEEE1394 EUI-64.
+        *GUID0 = lbuf[0] | 0x08004600; // Replace the MODEL ID segment with the SCE OUI, to get the console's IEEE1394 EUI-64.
         *GUID1 = *(u32 *)&lbuf[4];
     } else { // ModelID
         u32 *ModelID = (u32 *)&buf[0];
@@ -153,7 +155,7 @@ int sceCdReadModelID(unsigned long int *ModelID)
 int sceCdReadDvdDualInfo(int *on_dual, u32 *layer1_start)
 {
     if (cdvdman_settings.common.flags & IOPCORE_COMPAT_EMU_DVDDL) {
-        //Make layer 1 point to layer 0.
+        // Make layer 1 point to layer 0.
         *layer1_start = 0;
         *on_dual = 1;
     } else {

--- a/modules/iopcore/cdvdman/searchfile.c
+++ b/modules/iopcore/cdvdman/searchfile.c
@@ -10,6 +10,9 @@ static void cdvdman_trimspaces(char *str);
 static struct dirTocEntry *cdvdman_locatefile(char *name, u32 tocLBA, int tocLength, int layer);
 static int cdvdman_findfile(sceCdlFILE *pcd_file, const char *name, int layer);
 
+// The max lsn/sectors available based on value retrieved from iso. Used for out of bounds checking. Only check if value non zero.
+u32 mediaLsnCount;
+
 typedef struct
 {
     u32 rootDirtocLBA;
@@ -234,17 +237,30 @@ void cdvdman_searchfile_init(void)
     layer_info[0].rootDirtocLBA = tocEntryPointer->fileLBA;
     layer_info[0].rootDirtocLength = tocEntryPointer->fileSize;
 
+    // PVD Volume Space Size field
+    mediaLsnCount = *(u32 *)&cdvdman_buf[0x50];
+    DPRINTF("cdvdman_searchfile_init mediaLsnCount=%d\n", mediaLsnCount);
+
     // DVD DL support
     if (!(cdvdman_settings.common.flags & IOPCORE_COMPAT_EMU_DVDDL)) {
         int on_dual;
         u32 layer1_start;
         sceCdReadDvdDualInfo(&on_dual, &layer1_start);
         if (on_dual) {
+            u32 lsn0 = mediaLsnCount;
+            // So that CdRead below can read more than first layer.
+            mediaLsnCount = 0;
             sceCdRead(layer1_start + 16, 1, cdvdman_buf, NULL);
             sceCdSync(0);
             tocEntryPointer = (struct dirTocEntry *)&cdvdman_buf[0x9c];
             layer_info[1].rootDirtocLBA = layer1_start + tocEntryPointer->fileLBA;
-            layer_info[1].rootDirtocLength = tocEntryPointer->length;
+            layer_info[1].rootDirtocLength = tocEntryPointer->fileSize;
+
+            u32 lsn1 = *(u32 *)&cdvdman_buf[0x50];
+            DPRINTF("cdvdman_searchfile_init DVD9 L0 mediaLsnCount=%d \n", lsn0);
+            DPRINTF("cdvdman_searchfile_init DVD9 L1 mediaLsnCount=%d \n", lsn1);
+            mediaLsnCount = lsn0 + lsn1 - 16;
+            DPRINTF("cdvdman_searchfile_init DVD9 mediaLsnCount=%d\n", mediaLsnCount);
         }
     }
 }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
krat0s

Another issue causing random results has been fixed. There are several games that try to read past the disc and on real ps2 this properly fails because it is impossible to read more. In OPL things were different. It would actually try to read and it would give whatever was after the iso. This means that the experience will totally depend on what was on the sectors right after the end of iso. Sometimes they would empty or next file or even data of deleted files. Even simple operations like moving iso order on usb or compressing to zso and moving it back to iso would change the game experience. The only lucky case was when the iso was right at the the end sectors of the usb for usb which was an extreme rare case. Fixes Hot Wheels, Ratchet and other games. Worth testing with others.
Also implemented missing sceGetToc which should help some games go further. Worth trying on any games you have which freeze at same same place.