### PR TITLE
Fix GSM H-position unaligment

### DIFF
--- a/src/gsm.c
+++ b/src/gsm.c
@@ -144,8 +144,8 @@ void PrepareGSM(char *cmdline)
             predef_vmode[gGSMVMode].display,
             predef_vmode[gGSMVMode].syncv,
             ((predef_vmode[gGSMVMode].ffmd) << 1) | (predef_vmode[gGSMVMode].interlace),
-            gGSMXOffset,
-            gGSMYOffset,
+            (u32)gGSMXOffset,
+            (u32)gGSMYOffset,
             k576p_fix,
             kGsDxDyOffsetSupported,
             FIELD_fix);

--- a/src/gsm.c
+++ b/src/gsm.c
@@ -138,7 +138,7 @@ void PrepareGSM(char *cmdline)
 
     FIELD_fix = gGSMFIELDFix != 0 ? 1 : 0;
 
-    sprintf(cmdline, "%hhu %hhu %hhu %llu %llu %hu %d %d %d %d %d", predef_vmode[gGSMVMode].interlace,
+    sprintf(cmdline, "%hhu %hhu %hhu %llu %llu %hu %u %u %d %d %d", predef_vmode[gGSMVMode].interlace,
             predef_vmode[gGSMVMode].mode,
             predef_vmode[gGSMVMode].ffmd,
             predef_vmode[gGSMVMode].display,


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Partially revert 112a0d21e193353cc98d53d3842ea6860d826e13 . @uyjulian it seems that signed int should be transferred as unsigned and then gsm api will make conversion back on its side :)

fixes #750