### PR TITLE
krat0s: sceCdGetToc EE fix

### DIFF
--- a/modules/iopcore/cdvdfsv/ncmd.c
+++ b/modules/iopcore/cdvdfsv/ncmd.c
@@ -393,7 +393,14 @@ static void *cbrpc_cdvdNcmds(int fno, void *buf, int size)
             cdvd_readee(buf);
             break;
         case CD_NCMD_GETTOC:
-            *(int *)buf = sceCdGetToc((u8 *)(*(u32 *)buf));
+            u32 eeaddr = *(u32 *)buf;
+            DPRINTF("cbrpc_cdvdNcmds GetToc eeaddr=%08x\n", (int)eeaddr);
+            char toc[2064];
+            memset(toc, 0, 2064);
+            int result = sceCdGetToc(toc);
+            *(int *)buf = result;
+            if (result)
+                sysmemSendEE(toc, (void *)eeaddr, 2064);
             break;
         case CD_NCMD_SEEK:
             *(int *)buf = sceCdSeek(*(u32 *)buf);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Proper implementation of EE version of sceCdGetToc (such games as NHL 2001, NBA 2001, NFS Underground 1 and 2, Primal Image Vol. 1, Tokimemo 3)
Fixes multiple issues cause by incomplete sceCdGetToc implementation in 33d8143e801e3912703e364a96860e2139d8500f

fixes #772
