### PR TITLE
USB/SMB: Support for longer file names to accept redump names

### DIFF
--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -2,7 +2,7 @@
 #define __SUPPORT_BASE_H
 
 #define UL_GAME_NAME_MAX       32
-#define ISO_GAME_NAME_MAX      64
+#define ISO_GAME_NAME_MAX      160
 #define ISO_GAME_EXTENSION_MAX 4
 #define GAME_STARTUP_MAX       12
 

--- a/modules/iopcore/common/cdvd_config.h
+++ b/modules/iopcore/common/cdvd_config.h
@@ -44,7 +44,7 @@ struct cdvdman_settings_hdd
 struct cdvdman_settings_smb
 {
     struct cdvdman_settings_common common;
-    char filename[88];
+    char filename[160];
     union
     {
         struct


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

The purpose is to accept the masterpiece `Suki na Mono wa Suki dakara Shou ga Nai!! First Limit & Target Nights: Sukishou! Episode #01+#02 (Disc 2) (Target Nights: Sukishou! Episode #02)` (or any other redump-named file) without having to rename it:
![ss0](https://github.com/ps2homebrew/Open-PS2-Loader/assets/2995486/af7c13eb-4283-40da-8711-61182c7bf530)
![ss1](https://github.com/ps2homebrew/Open-PS2-Loader/assets/2995486/cd0a4d5f-b94f-4a24-9ab6-e539f64524d0)
![ss2](https://github.com/ps2homebrew/Open-PS2-Loader/assets/2995486/b3698015-c496-47d3-8fce-56f8045ed933)

Fixes #282