### PR TITLE
Avoid divide by zero when calculating FPS

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1383,6 +1383,9 @@ static void guiDrawOverlays()
 
     if (prevtime != 0) {
         clock_t diff = curtime - prevtime;
+        if (diff == 0)
+            diff = 1;
+
         // Raw FPS value with 2 decimal places
         float rawfps = ((100 * CLOCKS_PER_SEC) / diff) / 100.0f;
 


### PR DESCRIPTION
Adapted from Grimdoomer's fork

## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
