### PR TITLE
Fixing issues with cdvdman, custom sector sizes

### DIFF
--- a/modules/iopcore/cdvdfsv/ncmd.c
+++ b/modules/iopcore/cdvdfsv/ncmd.c
@@ -397,7 +397,7 @@ static void *cbrpc_cdvdNcmds(int fno, void *buf, int size)
             DPRINTF("cbrpc_cdvdNcmds GetToc eeaddr=%08x\n", (int)eeaddr);
             char toc[2064];
             memset(toc, 0, 2064);
-            int result = sceCdGetToc(toc);
+            int result = sceCdGetToc((u8 *)toc);
             *(int *)buf = result;
             if (result)
                 sysmemSendEE(toc, (void *)eeaddr, 2064);

--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -36,7 +36,7 @@ static void cdvdman_signal_read_end(void);
 static void cdvdman_signal_read_end_intr(void);
 static void cdvdman_startThreads(void);
 static void cdvdman_create_semaphores(void);
-static int cdvdman_read(u32 lsn, u32 sectors, void *buf);
+static int cdvdman_read(u32 lsn, u32 sectors, u16 sector_size, void *buf);
 
 // Sector cache to improve IO
 static u8 MAX_SECTOR_CACHE = 0;
@@ -351,13 +351,18 @@ static int cdvdman_read_sectors(u32 lsn, unsigned int sectors, void *buf)
     return (cdvdman_stat.err == SCECdErNO ? 0 : 1);
 }
 
-static int cdvdman_read(u32 lsn, u32 sectors, void *buf)
+static int cdvdman_read(u32 lsn, u32 sectors, u16 sector_size, void *buf)
 {
     cdvdman_stat.status = SCECdStatRead;
 
+    // OPL only has 2048 bytes no matter what. For other sizes we have to copy to the offset and prepoluate the sector header data (the extra bytes.)
+    u32 offset = 0;
+
+    if (sector_size == 2340)
+        offset = 12; // head - sub - data(2048) -- edc-ecc
+
     buf = (void *)PHYSADDR(buf);
-#ifdef HDD_DRIVER // As of now, only the ATA interface requires this. We do this here to share cdvdman_buf.
-    if ((u32)(buf)&3) {
+    if (((u32)(buf)&3) || (sector_size != 2048)) {
         // For transfers to unaligned buffers, a double-copy is required to avoid stalling the device's DMA channel.
         WaitSema(cdvdman_searchfilesema);
 
@@ -369,24 +374,48 @@ static int cdvdman_read(u32 lsn, u32 sectors, void *buf)
             if (nsectors > CDVDMAN_BUF_SECTORS)
                 nsectors = CDVDMAN_BUF_SECTORS;
 
+            // For other sizes we can only read one sector at a time.
+            // There are only very few games (CDDA games, EA Tiburon) that will be affected
+            if (sector_size != 2048)
+                nsectors = 1;
+
             cdvdman_read_sectors(rpos, nsectors, cdvdman_buf);
 
             rpos += nsectors;
             sectors -= nsectors;
-            nbytes = nsectors * 2048;
+            nbytes = nsectors * sector_size;
 
-            memcpy(buf, cdvdman_buf, nbytes);
+
+            // Copy the data for buffer.
+            // For any sector other than 2048 one sector at a time is copied.
+            memcpy((void *)((u32)buf + offset), cdvdman_buf, nbytes);
+
+            // For these custom sizes we need to manually fix the header.
+            // For 2340 we have 12bytes. 4 are position.
+            if (sector_size == 2340) {
+                u8 *header = (u8 *)buf;
+                // position.
+                sceCdlLOCCD p;
+                sceCdIntToPos(rpos - 1, &p); // to get current pos.
+                header[0] = p.minute;
+                header[1] = p.second;
+                header[2] = p.sector;
+                header[3] = 0; // p.track for cdda only non-zero
+
+                // Subheader and copy of subheader.
+                header[4] = header[8] = 0;
+                header[5] = header[9] = 0;
+                header[6] = header[10] = 0x8;
+                header[7] = header[11] = 0;
+            }
 
             buf = (void *)((u8 *)buf + nbytes);
         }
 
         SignalSema(cdvdman_searchfilesema);
     } else {
-#endif
         cdvdman_read_sectors(lsn, sectors, buf);
-#ifdef HDD_DRIVER
     }
-#endif
 
     ReadPos = 0; /* Reset the buffer offset indicator. */
 
@@ -419,7 +448,7 @@ static int cdvdman_common_lock(int IntrContext)
     return 1;
 }
 
-int cdvdman_AsyncRead(u32 lsn, u32 sectors, void *buf)
+int cdvdman_AsyncRead(u32 lsn, u32 sectors, u16 sector_size, void *buf)
 {
     int IsIntrContext, OldState;
 
@@ -435,6 +464,7 @@ int cdvdman_AsyncRead(u32 lsn, u32 sectors, void *buf)
 
     cdvdman_stat.cdread_lba = lsn;
     cdvdman_stat.cdread_sectors = sectors;
+    cdvdman_stat.sector_size = sector_size;
     cdvdman_stat.cdread_buf = buf;
 
     CpuResumeIntr(OldState);
@@ -447,7 +477,7 @@ int cdvdman_AsyncRead(u32 lsn, u32 sectors, void *buf)
     return 1;
 }
 
-int cdvdman_SyncRead(u32 lsn, u32 sectors, void *buf)
+int cdvdman_SyncRead(u32 lsn, u32 sectors, u16 sector_size, void *buf)
 {
     int IsIntrContext, OldState;
 
@@ -463,7 +493,7 @@ int cdvdman_SyncRead(u32 lsn, u32 sectors, void *buf)
 
     CpuResumeIntr(OldState);
 
-    cdvdman_read(lsn, sectors, buf);
+    cdvdman_read(lsn, sectors, sector_size, buf);
 
     cdvdman_cb_event(SCECdFuncRead);
     sync_flag = 0;
@@ -702,7 +732,7 @@ static void cdvdman_cdread_Thread(void *args)
     while (1) {
         WaitSema(cdrom_rthread_sema);
 
-        cdvdman_read(cdvdman_stat.cdread_lba, cdvdman_stat.cdread_sectors, cdvdman_stat.cdread_buf);
+        cdvdman_read(cdvdman_stat.cdread_lba, cdvdman_stat.cdread_sectors, cdvdman_stat.sector_size, cdvdman_stat.cdread_buf);
 
         /* This streaming callback is not compatible with the original SONY stream channel 0 (IOP) callback's design.
        The original is run from the interrupt handler, but we want it to run

--- a/modules/iopcore/cdvdman/cdvdman.c
+++ b/modules/iopcore/cdvdman/cdvdman.c
@@ -486,12 +486,14 @@ u32 sceCdPosToInt(sceCdlLOCCD *p)
 {
     register u32 result;
 
-    result = ((u32)p->minute >> 16) * 10 + ((u32)p->minute & 0xF);
+    result = ((u32)p->minute >> 4) * 10 + ((u32)p->minute & 0xF);
     result *= 60;
-    result += ((u32)p->second >> 16) * 10 + ((u32)p->second & 0xF);
+    result += ((u32)p->second >> 4) * 10 + ((u32)p->second & 0xF);
     result *= 75;
-    result += ((u32)p->sector >> 16) * 10 + ((u32)p->sector & 0xF);
+    result += ((u32)p->sector >> 4) * 10 + ((u32)p->sector & 0xF);
     result -= 150;
+
+    DPRINTF("%s({0x%X, 0x%X, 0x%X, 0x%X}) = %d\n", __FUNCTION__, p->minute, p->second, p->sector, p->track, result);
 
     return result;
 }

--- a/modules/iopcore/cdvdman/internal.h
+++ b/modules/iopcore/cdvdman/internal.h
@@ -77,6 +77,7 @@ typedef struct
     int disc_type_reg;
     u32 cdread_lba;
     u32 cdread_sectors;
+    u16 sector_size;
     void *cdread_buf;
 } cdvdman_status_t;
 
@@ -99,8 +100,8 @@ typedef void (*StmCallback_t)(void);
 
 // Internal (common) function prototypes
 extern void SetStm0Callback(StmCallback_t callback);
-extern int cdvdman_AsyncRead(u32 lsn, u32 sectors, void *buf);
-extern int cdvdman_SyncRead(u32 lsn, u32 sectors, void *buf);
+extern int cdvdman_AsyncRead(u32 lsn, u32 sectors, u16 sector_size, void *buf);
+extern int cdvdman_SyncRead(u32 lsn, u32 sectors, u16 sector_size, void *buf);
 extern int cdvdman_sendSCmd(u8 cmd, const void *in, u16 in_size, void *out, u16 out_size);
 extern void cdvdman_cb_event(int reason);
 

--- a/modules/iopcore/cdvdman/ioops.c
+++ b/modules/iopcore/cdvdman/ioops.c
@@ -121,12 +121,11 @@ static int cdvdman_open(iop_file_t *f, const char *filename, int mode)
     sceCdlFILE cdfile;
 
     WaitSema(cdrom_io_sema);
+    WaitEventFlag(cdvdman_stat.intr_ef, 1, WEF_AND, NULL);
 
     cdvdman_init();
 
     if (f->unit < 2) {
-        sceCdDiskReady(0);
-
         fh = cdvdman_getfilefreeslot();
         if (fh) {
             r = sceCdLayerSearchFile(&cdfile, filename, f->unit);
@@ -230,6 +229,8 @@ static int cdrom_open(iop_file_t *f, const char *filename, int mode)
     int result;
     char path_buffer[128]; // Original buffer size in the SCE CDVDMAN module.
 
+    WaitEventFlag(cdvdman_stat.intr_ef, 1, WEF_AND, NULL);
+
     DPRINTF("cdrom_open %s mode=%d layer %d\n", filename, mode, f->unit);
 
     strncpy(path_buffer, filename, sizeof(path_buffer));
@@ -247,6 +248,7 @@ static int cdrom_close(iop_file_t *f)
     FHANDLE *fh = (FHANDLE *)f->privdata;
 
     WaitSema(cdrom_io_sema);
+    WaitEventFlag(cdvdman_stat.intr_ef, 1, WEF_AND, NULL);
 
     DPRINTF("cdrom_close\n");
 
@@ -266,13 +268,12 @@ static int cdrom_read(iop_file_t *f, void *buf, int size)
     int rpos;
 
     WaitSema(cdrom_io_sema);
+    WaitEventFlag(cdvdman_stat.intr_ef, 1, WEF_AND, NULL);
 
     DPRINTF("cdrom_read size=%db (%ds) file_position=%d\n", size, size / 2048, fh->position);
 
     if ((fh->position + size) > fh->filesize)
         size = fh->filesize - fh->position;
-
-    sceCdDiskReady(0);
 
     rpos = 0;
     if (size > 0) {
@@ -334,6 +335,7 @@ static int cdrom_lseek(iop_file_t *f, int offset, int where)
     FHANDLE *fh = (FHANDLE *)f->privdata;
 
     WaitSema(cdrom_io_sema);
+    WaitEventFlag(cdvdman_stat.intr_ef, 1, WEF_AND, NULL);
 
     DPRINTF("cdrom_lseek offset=%d where=%d\n", offset, where);
 
@@ -366,11 +368,11 @@ static int cdrom_getstat(iop_file_t *f, const char *filename, iox_stat_t *stat)
     char path_buffer[128]; // Original buffer size in the SCE CDVDMAN module.
 
     DPRINTF("cdrom_getstat %s layer %d\n", filename, f->unit);
+    WaitEventFlag(cdvdman_stat.intr_ef, 1, WEF_AND, NULL);
 
     strncpy(path_buffer, filename, sizeof(path_buffer));
     cdrom_purifyPath(path_buffer); // Unlike the SCE original, purify the path right away.
 
-    sceCdDiskReady(0);
     return sceCdLayerSearchFile((sceCdlFILE *)&stat->attr, path_buffer, f->unit) - 1;
 }
 
@@ -391,12 +393,12 @@ static int cdrom_dread(iop_file_t *f, iox_dirent_t *dirent)
     struct dirTocEntry *tocEntryPointer;
 
     WaitSema(cdrom_io_sema);
+    WaitEventFlag(cdvdman_stat.intr_ef, 1, WEF_AND, NULL);
 
     DPRINTF("cdrom_dread fh->lsn=%lu\n", fh->lsn);
 
-    sceCdDiskReady(0);
     if ((r = sceCdRead(fh->lsn, 1, cdvdman_fs_buf, NULL)) == 1) {
-        sceCdSync(0);
+        // sceCdSync(0); // TODO: need to verify
 
         do {
             r = 0;

--- a/modules/iopcore/cdvdman/ncmd.c
+++ b/modules/iopcore/cdvdman/ncmd.c
@@ -28,12 +28,24 @@ int sceCdRead(u32 lsn, u32 sectors, void *buf, sceCdRMode *mode)
 {
     int result;
 
-    DPRINTF("sceCdRead lsn=%d sectors=%d buf=%08x\n", (int)lsn, (int)sectors, (int)buf);
+    u16 sector_size = 2048;
+
+    // Is is NULL in our emulated cdvdman routines so check if valid.
+    if (mode) {
+        // 0 is 2048
+        if (mode->datapattern == SCECdSecS2328)
+            sector_size = 2328;
+
+        if (mode->datapattern == SCECdSecS2340)
+            sector_size = 2340;
+    }
+
+    DPRINTF("sceCdRead lsn=%d sectors=%d sector_size=%d buf=%08x\n", (int)lsn, (int)sectors, (int)sector_size, (int)buf);
 
     if ((!(cdvdman_settings.common.flags & IOPCORE_COMPAT_ALT_READ)) || QueryIntrContext()) {
-        result = cdvdman_AsyncRead(lsn, sectors, buf);
+        result = cdvdman_AsyncRead(lsn, sectors, sector_size, buf);
     } else {
-        result = cdvdman_SyncRead(lsn, sectors, buf);
+        result = cdvdman_SyncRead(lsn, sectors, sector_size, buf);
     }
 
     return result;

--- a/modules/iopcore/cdvdman/streaming.c
+++ b/modules/iopcore/cdvdman/streaming.c
@@ -20,7 +20,7 @@ static void StmCallback(void)
 {
     int OldState;
 
-    //Only update parameters if the streaming system was reading. Otherwise, this callback might have been triggered by the game reading data (BUG!)
+    // Only update parameters if the streaming system was reading. Otherwise, this callback might have been triggered by the game reading data (BUG!)
     if (cdvdman_stat.StreamingData.StIsReading) {
         CpuSuspendIntr(&OldState);
         cdvdman_stat.StreamingData.Stlsn += cdvdman_stat.StreamingData.StBanksize;
@@ -51,8 +51,8 @@ static int StFillStreamBuffer(void)
     int result, OldState;
     void *ptr;
 
-    /*	SCEI used a similar design, but their implementation uses a bitmap to mark the filled/empty banks instead
-	(which is probably immune to race conditions, but we are interested in saving memory).	*/
+    /* SCEI used a similar design, but their implementation uses a bitmap to mark the filled/empty banks instead
+    (which is probably immune to race conditions, but we are interested in saving memory).	*/
     CpuSuspendIntr(&OldState);
 
     if (cdvdman_stat.StreamingData.StIsReading) {
@@ -63,15 +63,15 @@ static int StFillStreamBuffer(void)
     CancelAlarm(&StmScheduleCb, &cdvdman_stat.StreamingData);
     cdvdman_stat.StreamingData.StIsReading = 1;
 
-    //Determine how much more to read.
+    // Determine how much more to read.
     result = AllocBank(&ptr);
 
     CpuResumeIntr(OldState);
 
     if (result == 0) {
-        //iDPRINTF("Stream fill buffer: Stream lsn 0x%08x - %u sectors:%p\n", cdvdman_stat.StreamingData.Stlsn, cdvdman_stat.StreamingData.StBanksize, ptr);
-        if (cdvdman_AsyncRead(cdvdman_stat.StreamingData.Stlsn, cdvdman_stat.StreamingData.StBanksize, ptr) == 0) {
-            //Failed to start reading.
+        // iDPRINTF("Stream fill buffer: Stream lsn 0x%08x - %u sectors:%p\n", cdvdman_stat.StreamingData.Stlsn, cdvdman_stat.StreamingData.StBanksize, ptr);
+        if (cdvdman_AsyncRead(cdvdman_stat.StreamingData.Stlsn, cdvdman_stat.StreamingData.StBanksize, 2048, ptr) == 0) {
+            // Failed to start reading.
             cdvdman_stat.StreamingData.StIsReading = 0;
             result = -1;
         } else {
@@ -79,7 +79,7 @@ static int StFillStreamBuffer(void)
         }
     } else {
         iDPRINTF("Stream fill buffer: Stream full.\n");
-        //Nothing else to read.
+        // Nothing else to read.
         cdvdman_stat.StreamingData.StIsReading = 0;
         result = 1;
     }
@@ -121,7 +121,7 @@ int sceCdStInit(u32 bufmax, u32 bankmax, void *iop_bufaddr)
     return 1;
 }
 
-//Must be called from an interrupt-disabled state.
+// Must be called from an interrupt-disabled state.
 static int AllocBank(void **pointer)
 {
     int result;
@@ -156,7 +156,7 @@ static int ReadSectorsEE(int maxcount, void *buffer)
     CpuSuspendIntr(&OldState);
     rdptr = cdvdman_stat.StreamingData.StReadPtr;
 
-    //When Wr <= Rd, the buffer is either full or empty. Check StStreamed.
+    // When Wr <= Rd, the buffer is either full or empty. Check StStreamed.
     if (cdvdman_stat.StreamingData.StWritePtr <= rdptr && cdvdman_stat.StreamingData.StStreamed > 0) {
         SectorsToCopy = cdvdman_stat.StreamingData.StBufmax - rdptr;
         if (SectorsToCopy > maxcount)
@@ -174,7 +174,7 @@ static int ReadSectorsEE(int maxcount, void *buffer)
             result += SectorsToCopy;
         }
     }
-    //When Rd < Wr, there are sectors in the buffer.
+    // When Rd < Wr, there are sectors in the buffer.
     if (result < maxcount && rdptr < cdvdman_stat.StreamingData.StWritePtr) {
         SectorsToCopy = cdvdman_stat.StreamingData.StWritePtr - rdptr;
         if (SectorsToCopy > maxcount - result)
@@ -198,12 +198,12 @@ static int ReadSectorsEE(int maxcount, void *buffer)
 
     CpuResumeIntr(OldState);
 
-    if (dmat_count > 0) //Only if there is data to copy
+    if (dmat_count > 0) // Only if there is data to copy
     {
         while (sceSifDmaStat(dmat_id) >= 0) {
         };
 
-        //Finally, update variables.
+        // Finally, update variables.
         CpuSuspendIntr(&OldState);
         cdvdman_stat.StreamingData.StReadPtr = rdptr;
         cdvdman_stat.StreamingData.StStreamed -= result;
@@ -225,7 +225,7 @@ static int ReadSectors(int maxcount, void *buffer)
     ptr = buffer;
     CpuSuspendIntr(&OldState);
 
-    //When Wr <= Rd, the buffer is either full or empty. Check StStreamed.
+    // When Wr <= Rd, the buffer is either full or empty. Check StStreamed.
     if (cdvdman_stat.StreamingData.StWritePtr <= cdvdman_stat.StreamingData.StReadPtr && cdvdman_stat.StreamingData.StStreamed > 0) {
         SectorsToCopy = cdvdman_stat.StreamingData.StBufmax - cdvdman_stat.StreamingData.StReadPtr;
         if (SectorsToCopy > maxcount)
@@ -240,7 +240,7 @@ static int ReadSectors(int maxcount, void *buffer)
             result += SectorsToCopy;
         }
     }
-    //When Rd < Wr, there are sectors in the buffer.
+    // When Rd < Wr, there are sectors in the buffer.
     if (result < maxcount && cdvdman_stat.StreamingData.StReadPtr < cdvdman_stat.StreamingData.StWritePtr) {
         SectorsToCopy = cdvdman_stat.StreamingData.StWritePtr - cdvdman_stat.StreamingData.StReadPtr;
         if (SectorsToCopy > maxcount - result)
@@ -303,7 +303,7 @@ int sceCdStStop(void)
 
         CpuSuspendIntr(&OldState);
 
-        //Stop.
+        // Stop.
         SetStm0Callback(NULL);
         cdvdman_stat.StreamingData.StStreamed = 0;
         cdvdman_stat.StreamingData.StStat = 0;
@@ -329,7 +329,7 @@ int sceCdStPause(void)
         CancelAlarm(&StmScheduleCb, &cdvdman_stat.StreamingData);
 
         CpuSuspendIntr(&OldState);
-        //Pause.
+        // Pause.
         SetStm0Callback(NULL);
         cdvdman_stat.StreamingData.StIsReading = 0;
         CpuResumeIntr(OldState);
@@ -352,7 +352,7 @@ int sceCdStResume(void)
     cdvdman_stat.status = SCECdStatPause;
     if (cdvdman_stat.StreamingData.StStat) {
         CpuSuspendIntr(&OldState);
-        //Resume
+        // Resume
         SetStm0Callback(&StmCallback);
         CpuResumeIntr(OldState);
 
@@ -402,7 +402,7 @@ int sceCdStRead(u32 sectors, u32 *buffer, u32 mode, u32 *error)
                 DPRINTF("StRead: buffer underrun. %u/%lu read.\n", result, sectors);
 
             result += SectorsRead;
-            //if(mode == STMNBLK) break;
+            // if(mode == STMNBLK) break;
             if (mode == 0)
                 break;
         }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [x] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
by **krat0s**:
This pull request addresses several issues encountered in Tiburon games and introduces new features for better functionality. The following changes have been made:

- previously added missing GetToc command (in different PR)
- Corrected semaphore-related problems
- Implemented support for custom size sectors.
To achieve these changes, the approach taken was to track the desired sector and manually copy the raw 2048 data to the requested buffer for custom size sectors. Additionally, the header bytes were filled manually, leveraging simple calculations. This method requires reading only one sector at a time for these games, but it has proven to work effectively.

It's worth noting that this approach was chosen to avoid the need for a complete rewrite of the codebase to support various sector sizes on filesystem level. This pull request also includes fixes for issues in [Cy Girls](https://github.com/ps2homebrew/Open-PS2-Loader/issues/834) and potentially addresses crashes in [Test Drive 2002](https://github.com/ps2homebrew/Open-PS2-Loader/issues/314) and [Gun](https://github.com/ps2homebrew/Open-PS2-Loader/issues/969). However, there might be impacts on other aspects of the code.

Importantly, this PR does not address the [Splinter Cell family's problems](https://github.com/ps2homebrew/Open-PS2-Loader/issues/860), as those stem from a distinct custom IOP reset issue that necessitates a different solution.

fixes https://github.com/ps2homebrew/Open-PS2-Loader/issues/963