### PR TITLE
make PFS.IRX use same params than wLaunchELF

### DIFF
--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -183,6 +183,14 @@ void hddLoadModules(void)
                            "\0"
                            "20";
 
+	static char pfsarg[] = "\0"
+                           "-o" // max open
+                           "\0"
+                           "10" // Default value: 2
+                           "\0"
+                           "-n" // Number of buffers
+                           "\0"
+                           "40"; // Default value: 8 | Max value: 127
     LOG("HDDSUPPORT LoadModules\n");
 
     if (!hddModulesLoaded) {
@@ -227,7 +235,7 @@ void hddLoadModules(void)
         }
 
         LOG("[PS2FS]:\n");
-        ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, 0, NULL);
+        ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, sizeof(pfsarg), pfsarg);
         if (ret < 0) {
             LOG("HDD: HardDisk Drive not formatted (PFS).\n");
             setErrorMessageWithCode(_STR_HDD_NOT_FORMATTED_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -183,7 +183,7 @@ void hddLoadModules(void)
                            "\0"
                            "20";
 
-	static char pfsarg[] = "\0"
+    static char pfsarg[] = "\0"
                            "-o" // max open
                            "\0"
                            "10" // Default value: 2

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -183,6 +183,14 @@ void hddLoadModules(void)
                            "\0"
                            "20";
 
+	static char pfsarg[] = "\0"
+	                       "-o" // max open
+	                       "\0"
+	                       "10" // Default value: 2
+	                       "\0"
+	                       "-n" // Number of buffers
+	                       "\0"
+	                       "40"; // Default value: 8 | Max value: 127
     LOG("HDDSUPPORT LoadModules\n");
 
     if (!hddModulesLoaded) {
@@ -227,7 +235,7 @@ void hddLoadModules(void)
         }
 
         LOG("[PS2FS]:\n");
-        ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, 0, NULL);
+        ret = sysLoadModuleBuffer(&ps2fs_irx, size_ps2fs_irx, sizeof(pfsarg), pfsarg);
         if (ret < 0) {
             LOG("HDD: HardDisk Drive not formatted (PFS).\n");
             setErrorMessageWithCode(_STR_HDD_NOT_FORMATTED_ERROR, ERROR_HDD_MODULE_PFS_FAILURE);


### PR DESCRIPTION
This is a blind attempt to make OPL stop corrupting > 3gb +OPL Partitions while saving config.

For obvious reasons, the `-m 4` parameter used by wLaunchELF has been ignored

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
