### PR TITLE
Remove references from dirent->d_stat

### DIFF
--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -289,6 +289,7 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
     char fullpath[256], startup[GAME_STARTUP_MAX];
     struct dirent *dirent;
     DIR *dir;
+    struct stat statbuf;
 
     cache.games = NULL;
     cache.count = 0;
@@ -301,6 +302,8 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
 
                 if (NameLen > ISO_GAME_NAME_MAX)
                     continue; // Skip files that cannot be supported properly.
+
+                snprintf(fullpath, sizeof(fullpath), "%s/%s", path, dirent->d_name);
 
                 if (format == GAME_FORMAT_OLD_ISO) {
                     struct game_list_t *next = (struct game_list_t *)malloc(sizeof(struct game_list_t));
@@ -324,8 +327,6 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
                     }
                 } else {
                     if (queryISOGameListCache(&cache, &cachedGInfo, dirent->d_name) != 0) {
-                        snprintf(fullpath, sizeof(fullpath), "%s/%s", path, dirent->d_name);
-
                         if ((MountFD = fileXioMount("iso:", fullpath, FIO_MT_RDONLY)) >= 0) {
                             if (GetStartupExecName("iso:/SYSTEM.CNF;1", startup, GAME_STARTUP_MAX - 1) == 0) {
                                 struct game_list_t *next = (struct game_list_t *)malloc(sizeof(struct game_list_t));
@@ -378,7 +379,12 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
                 game->parts = 1;
                 game->media = type;
                 game->format = format;
-                game->sizeMB = dirent->d_stat.st_size >> 20;
+
+                if (stat(fullpath, &statbuf) == 0) {
+                    game->sizeMB = statbuf.st_size >> 20;
+                } else {
+                    game->sizeMB = 0;
+                }
 
                 count++;
             }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [X] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Please check that OPL keeps working as expected especially with file I/O operations.

I have just checked that OPL at least was booting.

<img width="1162" alt="Screenshot 2023-11-30 at 00 33 20" src="https://github.com/ps2homebrew/Open-PS2-Loader/assets/10010409/c4200274-fc62-4b30-bb8a-9a888e258bf4">


Cheers
