### PR TITLE
Improve `readdir` speed

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -9,7 +9,7 @@ void checkMCFolder(void);
 int openFile(char *path, int mode);
 void *readFile(char *path, int align, int *size);
 int listDir(char *path, const char *separator, int maxElem,
-            int (*readEntry)(int index, const char *path, const char *separator, const char *name, unsigned int mode));
+            int (*readEntry)(int index, const char *path, const char *separator, const char *name, unsigned char d_type));
 
 typedef struct
 {

--- a/pc/iso2opl/src/iso2opl.c
+++ b/pc/iso2opl/src/iso2opl.c
@@ -462,7 +462,6 @@ void scan_dir(int isBigEndian)
     char *name;
     char fullname[512];
     char newname[512];
-    struct stat buf;
 
     DIR *rep = opendir(".");
     if (rep != NULL) {
@@ -470,7 +469,7 @@ void scan_dir(int isBigEndian)
             name = ent->d_name;
             size = strlen(name);
             sprintf(fullname, "./%s", name);
-            if (!stat(fullname, &buf) && !S_ISDIR(buf.st_mode)) {
+            if (ent->d_type != DT_DIR) {
                 if (strstr(name, ".iso")) {
                     if ((size >= 17) && (name[4] == '_') && (name[8] == '.') && (name[11] == '.')) {
                         printf("%s seems to be correctly named\n", fullname);

--- a/src/lang.c
+++ b/src/lang.c
@@ -99,9 +99,9 @@ char *lngGetValue(void)
     return guiLangNames[guiLangID];
 }
 
-static int lngReadEntry(int index, const char *path, const char *separator, const char *name, unsigned int mode)
+static int lngReadEntry(int index, const char *path, const char *separator, const char *name, unsigned char d_type)
 {
-    if (!S_ISDIR(mode)) {
+    if (d_type != DT_DIR) {
         if (strstr(name, ".lng") || strstr(name, ".LNG")) {
 
             language_t *currLang = &languages[nLanguages + index];

--- a/src/opl.c
+++ b/src/opl.c
@@ -478,7 +478,6 @@ int oplScanApps(int (*callback)(const char *path, config_set_t *appConfig, void 
 {
     struct dirent *pdirent;
     DIR *pdir;
-    struct stat st;
     int i, count, ret;
     item_list_t *listSupport;
     config_set_t *appConfig;
@@ -499,9 +498,7 @@ int oplScanApps(int (*callback)(const char *path, config_set_t *appConfig, void 
                         continue;
 
                     snprintf(dir, sizeof(dir), "%s/%s", appsPath, pdirent->d_name);
-                    if (stat(dir, &st) < 0)
-                        continue;
-                    if (!S_ISDIR(st.st_mode))
+                    if (pdirent->d_type != DT_DIR)
                         continue;
 
                     snprintf(path, sizeof(path), "%s/%s", dir, APP_TITLE_CONFIG_FILE);

--- a/src/themes.c
+++ b/src/themes.c
@@ -1055,9 +1055,9 @@ static void thmFree(theme_t *theme)
     }
 }
 
-static int thmReadEntry(int index, const char *path, const char *separator, const char *name, unsigned int mode)
+static int thmReadEntry(int index, const char *path, const char *separator, const char *name, unsigned char d_type)
 {
-    if (S_ISDIR(mode) && strstr(name, "thm_")) {
+    if (d_type == DT_DIR && strstr(name, "thm_")) {
         theme_file_t *currTheme = &themes[nThemes + index];
 
         int length = strlen(name) - 4 + 1;

--- a/src/util.c
+++ b/src/util.c
@@ -209,10 +209,9 @@ void *readFile(char *path, int align, int *size)
 }
 
 int listDir(char *path, const char *separator, int maxElem,
-            int (*readEntry)(int index, const char *path, const char *separator, const char *name, unsigned int mode))
+            int (*readEntry)(int index, const char *path, const char *separator, const char *name, unsigned char d_type))
 {
     int index = 0;
-    struct stat st;
     char filename[128];
 
     if (checkFile(path, O_RDONLY)) {
@@ -221,8 +220,7 @@ int listDir(char *path, const char *separator, int maxElem,
         if (dir != NULL) {
             while (index < maxElem && (dirent = readdir(dir)) != NULL) {
                 snprintf(filename, 128, "%s/%s", path, dirent->d_name);
-                stat(filename, &st);
-                index = readEntry(index, path, separator, dirent->d_name, st.st_mode);
+                index = readEntry(index, path, separator, dirent->d_name, dirent->d_type);
             }
 
             closedir(dir);
@@ -589,7 +587,6 @@ int sysDeleteFolder(const char *folder)
     char *path;
     struct dirent *dirent;
     DIR *dir;
-    struct stat st;
     struct DirentToDelete *head, *start;
 
     result = 0;
@@ -602,9 +599,8 @@ int sysDeleteFolder(const char *folder)
 
             path = malloc(strlen(folder) + strlen(dirent->d_name) + 2);
             sprintf(path, "%s/%s", folder, dirent->d_name);
-            stat(path, &st);
 
-            if (S_ISDIR(st.st_mode)) {
+            if (dirent->d_type == DT_DIR) {
                 /* Recursive, delete all subfolders */
                 result = sysDeleteFolder(path);
                 free(path);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [X] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
This PR basically makes the `readdir` function to work faster, as it doesn't require anymore to run `stat` function to identify if it is or not a folder/file.
stat function is an expensive call, skipping it we are going to have a much faster game/app listing.

Cheers.