### PR TITLE
Use iop_fd when `fileXioIoctl` and `fileXioIoctl2`

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -14,6 +14,7 @@
 
 #include <usbhdfsd-common.h>
 
+#include <ps2sdkapi.h>
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioIoctl, fileXioDevctl
 
@@ -168,7 +169,8 @@ static int bdmNeedsUpdate(void)
     DIR *dir = opendir("mass0:/");
     if (dir != NULL) {
         int *pBDMDriver = (int *)bdmDriver;
-        *pBDMDriver = fileXioIoctl(dir->dd_fd, USBMASS_IOCTL_GET_DRIVERNAME, "");
+        int iop_fd = ps2sdk_get_iop_fd(dir->dd_fd);
+        *pBDMDriver = fileXioIoctl(iop_fd, USBMASS_IOCTL_GET_DRIVERNAME, "");
         closedir(dir);
     }
 
@@ -255,7 +257,7 @@ static void bdmRenameGame(int id, char *newName)
 
 void bdmLaunchGame(int id, config_set_t *configSet)
 {
-    int i, fd, index, compatmask = 0;
+    int i, fd, iop_fd, index, compatmask = 0;
     int EnablePS2Logo = 0;
     int result;
     u64 startingLBA;
@@ -293,7 +295,8 @@ void bdmLaunchGame(int id, config_set_t *configSet)
 
                 fd = open(vmc_path, O_RDONLY);
                 if (fd >= 0) {
-                    if (fileXioIoctl2(fd, USBMASS_IOCTL_GET_LBA, NULL, 0, &startingLBA, sizeof(startingLBA)) == 0 && (startCluster = (unsigned int)fileXioIoctl(fd, USBMASS_IOCTL_GET_CLUSTER, vmc_path)) != 0) {
+                    iop_fd = ps2sdk_get_iop_fd(fd);
+                    if (fileXioIoctl2(iop_fd, USBMASS_IOCTL_GET_LBA, NULL, 0, &startingLBA, sizeof(startingLBA)) == 0 && (startCluster = (unsigned int)fileXioIoctl(iop_fd, USBMASS_IOCTL_GET_CLUSTER, vmc_path)) != 0) {
 
                         // VMC only supports 32bit LBAs at the moment, so if the starting LBA + size of the VMC crosses the 32bit boundary
                         // just report the VMC as being fragmented to prevent file system corruption.
@@ -303,7 +306,7 @@ void bdmLaunchGame(int id, config_set_t *configSet)
                             have_error = 2;
                         }
                         // Check VMC cluster chain for fragmentation (write operation can cause damage to the filesystem).
-                        else if (fileXioIoctl(fd, USBMASS_IOCTL_CHECK_CHAIN, "") == 1) {
+                        else if (fileXioIoctl(iop_fd, USBMASS_IOCTL_CHECK_CHAIN, "") == 1) {
                             LOG("BDMSUPPORT Cluster Chain OK\n");
                             have_error = 0;
                             bdm_vmc_infos.active = 1;
@@ -366,6 +369,7 @@ void bdmLaunchGame(int id, config_set_t *configSet)
         // Open file
         sbCreatePath(game, partname, bdmPrefix, "/", i);
         fd = open(partname, O_RDONLY);
+        iop_fd = ps2sdk_get_iop_fd(fd);
         if (fd < 0) {
             sbUnprepare(&settings->common);
             guiMsgBox(_l(_STR_ERR_FILE_INVALID), 0, NULL);
@@ -374,10 +378,10 @@ void bdmLaunchGame(int id, config_set_t *configSet)
 
         // Get driver - we should only need to do this once
         int *pBDMDriver = (int *)bdmDriver;
-        *pBDMDriver = fileXioIoctl(fd, USBMASS_IOCTL_GET_DRIVERNAME, "");
+        *pBDMDriver = fileXioIoctl(iop_fd, USBMASS_IOCTL_GET_DRIVERNAME, "");
 
         // Get fragment list
-        int iFragCount = fileXioIoctl2(fd, USBMASS_IOCTL_GET_FRAGLIST, NULL, 0, (void *)&settings->frags[iTotalFragCount], sizeof(bd_fragment_t) * (BDM_MAX_FRAGS - iTotalFragCount));
+        int iFragCount = fileXioIoctl2(iop_fd, USBMASS_IOCTL_GET_FRAGLIST, NULL, 0, (void *)&settings->frags[iTotalFragCount], sizeof(bd_fragment_t) * (BDM_MAX_FRAGS - iTotalFragCount));
         if (iFragCount > BDM_MAX_FRAGS) {
             // Too many fragments
             close(fd);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [X] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
This PR solves the latest issues in OPL created after the upgrade of the `newlib` improvements.

Solves #1124