### PR TITLE
Remove LTO flags because it creates artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,8 +204,8 @@ EE_OBJS := $(EE_OBJS:%=$(EE_OBJS_DIR)%)
 EE_DEPS = $($(filter %.o,$(EE_OBJS)):%.o=%.d)
 
 # To help linking getting rid off unused functions and data
-EE_CFLAGS += -fdata-sections -ffunction-sections -flto
-EE_LDFLAGS += -fdata-sections -ffunction-sections -flto -Wl,--gc-sections
+EE_CFLAGS += -fdata-sections -ffunction-sections
+EE_LDFLAGS += -fdata-sections -ffunction-sections -Wl,--gc-sections
 
 .SILENT:
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [X] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
The error we are suffering here: https://github.com/ps2homebrew/Open-PS2-Loader/issues/1135 is due of LTO flags.
I have been checking, and the issue actually is in the OPL source code because removing `-flto` just for the OPL files and keeping the flag in the linker makes the theme to work back.
Most probably the issue is on some optimizations done by the compiler on the "plasma" functions, could be great to find out why this is happening.

<img width="1162" alt="Screenshot 2023-12-18 at 08 33 40" src="https://github.com/ps2homebrew/Open-PS2-Loader/assets/10010409/5cff75ac-b5e9-4b02-bcb2-874ccdced7b5">

Close https://github.com/ps2homebrew/Open-PS2-Loader/issues/1135

Cheers.