### PR TITLE
Use POSIX functions to get romname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ PNG_ASSETS_DIR = gfx/
 MAPFILE = opl.map
 EE_LDFLAGS += -Wl,-Map,$(MAPFILE)
 
-EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lgskit_toolkit -lpoweroff -lfileXio -lpatches -ljpeg_ps2_addons -ljpeg -lpng -lz -ldebug -lm -lmc -lfreetype -lvux -lcdvd -lnetman -lps2ips -laudsrv -lvorbisfile -lvorbis -logg -lpadx -lelf-loader-nocolour
+EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lgskit_toolkit -lpoweroff -lfileXio -lpatches -ljpeg_ps2_addons -ljpeg -lpng -lz -lmc -lfreetype -lvux -lcdvd -lnetman -lps2ips -laudsrv -lvorbisfile -lvorbis -logg -lpadx -lelf-loader-nocolour
 EE_INCS += -I$(PS2SDK)/ports/include -I$(PS2SDK)/ports/include/freetype2 -I$(GSKIT)/include -I$(GSKIT)/ee/dma/include -I$(GSKIT)/ee/gs/include -I$(GSKIT)/ee/toolkit/include -Imodules/iopcore/common -Imodules/network/common -Imodules/hdd/common -Iinclude
 
 BIN2C = $(PS2SDK)/bin/bin2c

--- a/src/util.c
+++ b/src/util.c
@@ -9,6 +9,8 @@
 #include "include/ioman.h"
 #include "include/system.h"
 #include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
 #include <malloc.h>
 #include <rom0_info.h>
 
@@ -456,7 +458,8 @@ int InitConsoleRegionData(void)
     char romver[16];
 
     if ((result = ConsoleRegion) < 0) {
-        GetRomName(romver);
+        _io_driver driver = {open, close, (int (*)(int, void *, int))read, O_RDONLY};
+        GetRomNameWithIODriver(romver, &driver);
 
         switch (romver[4]) {
             case 'C':


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [X] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
This PR uses POSIX (fileXio functions) to get the `GetRomName`, additionally some other linked library are removed are they aren't needed anymore.

Cheers