### PR TITLE
Use bin2c instead of bin2s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ DETAILED_CHANGELOG
 #
 pc/iso2usbld/bin/iso2usbld
 IOPRP_img.c
+asm/*.c
 
 #
 # 3rd party

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,6 @@ EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lgskit_
 EE_INCS += -I$(PS2SDK)/ports/include -I$(PS2SDK)/ports/include/freetype2 -I$(GSKIT)/include -I$(GSKIT)/ee/dma/include -I$(GSKIT)/ee/gs/include -I$(GSKIT)/ee/toolkit/include -Imodules/iopcore/common -Imodules/network/common -Imodules/hdd/common -Iinclude
 
 BIN2C = $(PS2SDK)/bin/bin2c
-BIN2S = $(PS2SDK)/bin/bin2s
-BIN2O = $(PS2SDK)/bin/bin2o
 
 # WARNING: Only extra spaces are allowed and ignored at the beginning of the conditional directives (ifeq, ifneq, ifdef, ifndef, else and endif)
 # but a tab is not allowed; if the line begins with a tab, it will be considered part of a recipe for a rule!
@@ -362,113 +360,113 @@ ee_core/ee_core.elf: ee_core
 	echo "-EE core"
 	$(MAKE) $(IGS_FLAGS) $(PADEMU_FLAGS) $(EECORE_EXTRA_FLAGS) -C $<
 
-$(EE_ASM_DIR)ee_core.s: ee_core/ee_core.elf | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ eecore_elf
+$(EE_ASM_DIR)ee_core.c: ee_core/ee_core.elf | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ eecore_elf
 
-$(EE_ASM_DIR)udnl.s: $(UDNL_OUT) | $(EE_ASM_DIR)
-	$(BIN2S) $(UDNL_OUT) $@ udnl_irx
+$(EE_ASM_DIR)udnl.c: $(UDNL_OUT) | $(EE_ASM_DIR)
+	$(BIN2C) $(UDNL_OUT) $@ udnl_irx
 
 modules/iopcore/imgdrv/imgdrv.irx: modules/iopcore/imgdrv
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)imgdrv.s: modules/iopcore/imgdrv/imgdrv.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ imgdrv_irx
+$(EE_ASM_DIR)imgdrv.c: modules/iopcore/imgdrv/imgdrv.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)eesync.s: $(PS2SDK)/iop/irx/eesync-nano.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ eesync_irx
+$(EE_ASM_DIR)eesync.c: $(PS2SDK)/iop/irx/eesync-nano.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/iopcore/cdvdman/bdm_cdvdman.irx: modules/iopcore/cdvdman
 	$(MAKE) $(CDVDMAN_PS2LOGO_FLAGS) $(CDVDMAN_DEBUG_FLAGS) USE_BDM=1 -C $< all
 
-$(EE_ASM_DIR)bdm_cdvdman.s: modules/iopcore/cdvdman/bdm_cdvdman.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ bdm_cdvdman_irx
+$(EE_ASM_DIR)bdm_cdvdman.c: modules/iopcore/cdvdman/bdm_cdvdman.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/iopcore/cdvdman/smb_cdvdman.irx: modules/iopcore/cdvdman
 	$(MAKE) $(CDVDMAN_PS2LOGO_FLAGS) $(CDVDMAN_DEBUG_FLAGS) USE_SMB=1 -C $< all
 
-$(EE_ASM_DIR)smb_cdvdman.s: modules/iopcore/cdvdman/smb_cdvdman.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ smb_cdvdman_irx
+$(EE_ASM_DIR)smb_cdvdman.c: modules/iopcore/cdvdman/smb_cdvdman.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/iopcore/cdvdman/hdd_cdvdman.irx: modules/iopcore/cdvdman
 	$(MAKE) $(CDVDMAN_PS2LOGO_FLAGS) $(CDVDMAN_DEBUG_FLAGS) USE_HDD=1 -C $< all
 
-$(EE_ASM_DIR)hdd_cdvdman.s: modules/iopcore/cdvdman/hdd_cdvdman.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ hdd_cdvdman_irx
+$(EE_ASM_DIR)hdd_cdvdman.c: modules/iopcore/cdvdman/hdd_cdvdman.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/iopcore/cdvdman/hdd_hdpro_cdvdman.irx: modules/iopcore/cdvdman
 	$(MAKE) $(CDVDMAN_PS2LOGO_FLAGS) $(CDVDMAN_DEBUG_FLAGS) USE_HDPRO=1 -C $< all
 
-$(EE_ASM_DIR)hdd_hdpro_cdvdman.s: modules/iopcore/cdvdman/hdd_hdpro_cdvdman.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ hdd_hdpro_cdvdman_irx
+$(EE_ASM_DIR)hdd_hdpro_cdvdman.c: modules/iopcore/cdvdman/hdd_hdpro_cdvdman.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/iopcore/cdvdfsv/cdvdfsv.irx: modules/iopcore/cdvdfsv
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)cdvdfsv.s: modules/iopcore/cdvdfsv/cdvdfsv.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ cdvdfsv_irx
+$(EE_ASM_DIR)cdvdfsv.c: modules/iopcore/cdvdfsv/cdvdfsv.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/iopcore/patches/iremsndpatch/iremsndpatch.irx: modules/iopcore/patches/iremsndpatch
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)iremsndpatch.s: modules/iopcore/patches/iremsndpatch/iremsndpatch.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ iremsndpatch_irx
+$(EE_ASM_DIR)iremsndpatch.c: modules/iopcore/patches/iremsndpatch/iremsndpatch.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/iopcore/patches/apemodpatch/apemodpatch.irx: modules/iopcore/patches/apemodpatch
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)apemodpatch.s: modules/iopcore/patches/apemodpatch/apemodpatch.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ apemodpatch_irx
+$(EE_ASM_DIR)apemodpatch.c: modules/iopcore/patches/apemodpatch/apemodpatch.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/iopcore/patches/f2techioppatch/f2techioppatch.irx: modules/iopcore/patches/f2techioppatch
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)f2techioppatch.s: modules/iopcore/patches/f2techioppatch/f2techioppatch.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ f2techioppatch_irx
+$(EE_ASM_DIR)f2techioppatch.c: modules/iopcore/patches/f2techioppatch/f2techioppatch.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/iopcore/patches/cleareffects/cleareffects.irx: modules/iopcore/patches/cleareffects
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)cleareffects.s: modules/iopcore/patches/cleareffects/cleareffects.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ cleareffects_irx
+$(EE_ASM_DIR)cleareffects.c: modules/iopcore/patches/cleareffects/cleareffects.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/iopcore/resetspu/resetspu.irx: modules/iopcore/resetspu
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)resetspu.s: modules/iopcore/resetspu/resetspu.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ resetspu_irx
+$(EE_ASM_DIR)resetspu.c: modules/iopcore/resetspu/resetspu.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/mcemu/bdm_mcemu.irx: modules/mcemu
 	$(MAKE) $(MCEMU_DEBUG_FLAGS) $(PADEMU_FLAGS) USE_BDM=1 -C $< all
 
-$(EE_ASM_DIR)bdm_mcemu.s: modules/mcemu/bdm_mcemu.irx
-	$(BIN2S) $< $@ bdm_mcemu_irx
+$(EE_ASM_DIR)bdm_mcemu.c: modules/mcemu/bdm_mcemu.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/mcemu/hdd_mcemu.irx: modules/mcemu
 	$(MAKE) $(MCEMU_DEBUG_FLAGS) $(PADEMU_FLAGS) USE_HDD=1 -C $< all
 
-$(EE_ASM_DIR)hdd_mcemu.s: modules/mcemu/hdd_mcemu.irx
-	$(BIN2S) $< $@ hdd_mcemu_irx
+$(EE_ASM_DIR)hdd_mcemu.c: modules/mcemu/hdd_mcemu.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/mcemu/smb_mcemu.irx: modules/mcemu
 	$(MAKE) $(MCEMU_DEBUG_FLAGS) $(PADEMU_FLAGS) USE_SMB=1 -C $< all
 
-$(EE_ASM_DIR)smb_mcemu.s: modules/mcemu/smb_mcemu.irx
-	$(BIN2S) $< $@ smb_mcemu_irx
+$(EE_ASM_DIR)smb_mcemu.c: modules/mcemu/smb_mcemu.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/isofs/isofs.irx: modules/isofs
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)isofs.s: modules/isofs/isofs.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ isofs_irx
+$(EE_ASM_DIR)isofs.c: modules/isofs/isofs.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)usbd.s: $(PS2SDK)/iop/irx/usbd_mini.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ usbd_irx
+$(EE_ASM_DIR)usbd.c: $(PS2SDK)/iop/irx/usbd_mini.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)libsd.s: $(PS2SDK)/iop/irx/libsd.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ libsd_irx
+$(EE_ASM_DIR)libsd.c: $(PS2SDK)/iop/irx/libsd.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)audsrv.s: $(PS2SDK)/iop/irx/audsrv.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ audsrv_irx
+$(EE_ASM_DIR)audsrv.c: $(PS2SDK)/iop/irx/audsrv.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 $(EE_OBJS_DIR)libds34bt.a: modules/ds34bt/ee/libds34bt.a
 	cp $< $@
@@ -479,8 +477,8 @@ modules/ds34bt/ee/libds34bt.a: modules/ds34bt/ee
 modules/ds34bt/iop/ds34bt.irx: modules/ds34bt/iop
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)ds34bt.s: modules/ds34bt/iop/ds34bt.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ds34bt_irx
+$(EE_ASM_DIR)ds34bt.c: modules/ds34bt/iop/ds34bt.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 $(EE_OBJS_DIR)libds34usb.a: modules/ds34usb/ee/libds34usb.a
 	cp $< $@
@@ -491,246 +489,246 @@ modules/ds34usb/ee/libds34usb.a: modules/ds34usb/ee
 modules/ds34usb/iop/ds34usb.irx: modules/ds34usb/iop
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)ds34usb.s: modules/ds34usb/iop/ds34usb.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ds34usb_irx
+$(EE_ASM_DIR)ds34usb.c: modules/ds34usb/iop/ds34usb.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/pademu/bt_pademu.irx: modules/pademu
 	$(MAKE) -C $< USE_BT=1
 
-$(EE_ASM_DIR)bt_pademu.s: modules/pademu/bt_pademu.irx
-	$(BIN2S) $< $@ bt_pademu_irx
+$(EE_ASM_DIR)bt_pademu.c: modules/pademu/bt_pademu.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/pademu/usb_pademu.irx: modules/pademu
 	$(MAKE) -C $< USE_USB=1
 
-$(EE_ASM_DIR)usb_pademu.s: modules/pademu/usb_pademu.irx
-	$(BIN2S) $< $@ usb_pademu_irx
+$(EE_ASM_DIR)usb_pademu.c: modules/pademu/usb_pademu.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)bdm.s: $(PS2SDK)/iop/irx/bdm.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ bdm_irx
+$(EE_ASM_DIR)bdm.c: $(PS2SDK)/iop/irx/bdm.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)bdmfs_fatfs.s: $(PS2SDK)/iop/irx/bdmfs_fatfs.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ bdmfs_fatfs_irx
+$(EE_ASM_DIR)bdmfs_fatfs.c: $(PS2SDK)/iop/irx/bdmfs_fatfs.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)iLinkman.s: $(PS2SDK)/iop/irx/iLinkman.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ iLinkman_irx
+$(EE_ASM_DIR)iLinkman.c: $(PS2SDK)/iop/irx/iLinkman.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 ifeq ($(DEBUG),1)
 # block device drivers with printf's
-$(EE_ASM_DIR)usbmass_bd.s: $(PS2SDK)/iop/irx/usbmass_bd.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ usbmass_bd_irx
+$(EE_ASM_DIR)usbmass_bd.c: $(PS2SDK)/iop/irx/usbmass_bd.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)IEEE1394_bd.s: $(PS2SDK)/iop/irx/IEEE1394_bd.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ IEEE1394_bd_irx
+$(EE_ASM_DIR)IEEE1394_bd.c: $(PS2SDK)/iop/irx/IEEE1394_bd.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)mx4sio_bd.s: $(PS2SDK)/iop/irx/mx4sio_bd.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ mx4sio_bd_irx
+$(EE_ASM_DIR)mx4sio_bd.c: $(PS2SDK)/iop/irx/mx4sio_bd.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 else
 # block device drivers without printf's
-$(EE_ASM_DIR)usbmass_bd.s: $(PS2SDK)/iop/irx/usbmass_bd_mini.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ usbmass_bd_irx
+$(EE_ASM_DIR)usbmass_bd.c: $(PS2SDK)/iop/irx/usbmass_bd_mini.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)IEEE1394_bd.s: $(PS2SDK)/iop/irx/IEEE1394_bd_mini.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ IEEE1394_bd_irx
+$(EE_ASM_DIR)IEEE1394_bd.c: $(PS2SDK)/iop/irx/IEEE1394_bd_mini.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)mx4sio_bd.s: $(PS2SDK)/iop/irx/mx4sio_bd_mini.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ mx4sio_bd_irx
+$(EE_ASM_DIR)mx4sio_bd.c: $(PS2SDK)/iop/irx/mx4sio_bd_mini.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 endif
 
 modules/bdmevent/bdmevent.irx: modules/bdmevent
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)bdmevent.s: modules/bdmevent/bdmevent.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ bdmevent_irx
+$(EE_ASM_DIR)bdmevent.c: modules/bdmevent/bdmevent.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)ps2dev9.s: $(PS2SDK)/iop/irx/ps2dev9.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ps2dev9_irx
+$(EE_ASM_DIR)ps2dev9.c: $(PS2SDK)/iop/irx/ps2dev9.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/network/SMSUTILS/SMSUTILS.irx: modules/network/SMSUTILS
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)smsutils.s: modules/network/SMSUTILS/SMSUTILS.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ smsutils_irx
+$(EE_ASM_DIR)smsutils.c: modules/network/SMSUTILS/SMSUTILS.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)ps2ip.s: $(PS2SDK)/iop/irx/ps2ip-nm.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ps2ip_irx
+$(EE_ASM_DIR)ps2ip.c: $(PS2SDK)/iop/irx/ps2ip-nm.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/network/SMSTCPIP/SMSTCPIP.irx: modules/network/SMSTCPIP
 	$(MAKE) $(SMSTCPIP_INGAME_CFLAGS) -C $< rebuild
 
-$(EE_ASM_DIR)ingame_smstcpip.s: modules/network/SMSTCPIP/SMSTCPIP.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ingame_smstcpip_irx
+$(EE_ASM_DIR)ingame_smstcpip.c: modules/network/SMSTCPIP/SMSTCPIP.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/network/smap-ingame/smap.irx: modules/network/smap-ingame
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)smap_ingame.s: modules/network/smap-ingame/smap.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ smap_ingame_irx
+$(EE_ASM_DIR)smap_ingame.c: modules/network/smap-ingame/smap.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)smap.s: $(PS2SDK)/iop/irx/smap.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ smap_irx
+$(EE_ASM_DIR)smap.c: $(PS2SDK)/iop/irx/smap.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)netman.s: $(PS2SDK)/iop/irx/netman.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ netman_irx
+$(EE_ASM_DIR)netman.c: $(PS2SDK)/iop/irx/netman.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)ps2ips.s: $(PS2SDK)/iop/irx/ps2ips.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ps2ips_irx
+$(EE_ASM_DIR)ps2ips.c: $(PS2SDK)/iop/irx/ps2ips.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)smbman.s: $(PS2SDK)/iop/irx/smbman.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ smbman_irx
+$(EE_ASM_DIR)smbman.c: $(PS2SDK)/iop/irx/smbman.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/network/smbinit/smbinit.irx: modules/network/smbinit
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)smbinit.s: modules/network/smbinit/smbinit.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ smbinit_irx
+$(EE_ASM_DIR)smbinit.c: modules/network/smbinit/smbinit.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)ps2atad.s: $(PS2SDK)/iop/irx/ps2atad.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ps2atad_irx
+$(EE_ASM_DIR)ps2atad.c: $(PS2SDK)/iop/irx/ps2atad.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)hdpro_atad.s: $(PS2SDK)/iop/irx/hdproatad.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ hdpro_atad_irx
+$(EE_ASM_DIR)hdpro_atad.c: $(PS2SDK)/iop/irx/hdproatad.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)poweroff.s: $(PS2SDK)/iop/irx/poweroff.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ poweroff_irx
+$(EE_ASM_DIR)poweroff.c: $(PS2SDK)/iop/irx/poweroff.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/hdd/xhdd/xhdd.irx: modules/hdd/xhdd
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)xhdd.s: modules/hdd/xhdd/xhdd.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ xhdd_irx
+$(EE_ASM_DIR)xhdd.c: modules/hdd/xhdd/xhdd.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)ps2hdd.s: $(PS2SDK)/iop/irx/ps2hdd-osd.irx
-	$(BIN2S) $< $@ ps2hdd_irx
+$(EE_ASM_DIR)ps2hdd.c: $(PS2SDK)/iop/irx/ps2hdd-osd.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)ps2fs.s: $(PS2SDK)/iop/irx/ps2fs-osd.irx
-	$(BIN2S) $< $@ ps2fs_irx
+$(EE_ASM_DIR)ps2fs.c: $(PS2SDK)/iop/irx/ps2fs-osd.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/vmc/genvmc/genvmc.irx: modules/vmc/genvmc
 	$(MAKE) $(MOD_DEBUG_FLAGS) -C $<
 
-$(EE_ASM_DIR)genvmc.s: modules/vmc/genvmc/genvmc.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ genvmc_irx
+$(EE_ASM_DIR)genvmc.c: modules/vmc/genvmc/genvmc.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/network/lwNBD/lwnbdsvr.irx: modules/network/lwNBD
 	$(MAKE) TARGET=iop -C $<
 
-$(EE_ASM_DIR)lwnbdsvr.s: modules/network/lwNBD/lwnbdsvr.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ lwnbdsvr_irx
+$(EE_ASM_DIR)lwnbdsvr.c: modules/network/lwNBD/lwnbdsvr.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)udptty.s: $(PS2SDK)/iop/irx/udptty.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ udptty_irx
+$(EE_ASM_DIR)udptty.c: $(PS2SDK)/iop/irx/udptty.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/debug/udptty-ingame/udptty.irx: modules/debug/udptty-ingame
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)udptty-ingame.s: modules/debug/udptty-ingame/udptty.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ udptty_ingame_irx
+$(EE_ASM_DIR)udptty-ingame.c: modules/debug/udptty-ingame/udptty.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ udptty_ingame_irx
 
-$(EE_ASM_DIR)ioptrap.s: $(PS2SDK)/iop/irx/ioptrap.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ioptrap_irx
+$(EE_ASM_DIR)ioptrap.c: $(PS2SDK)/iop/irx/ioptrap.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/debug/ps2link/ps2link.irx: modules/debug/ps2link
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)ps2link.s: modules/debug/ps2link/ps2link.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ps2link_irx
+$(EE_ASM_DIR)ps2link.c: modules/debug/ps2link/ps2link.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
 modules/network/nbns/nbns.irx: modules/network/nbns
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)nbns-iop.s: modules/network/nbns/nbns.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ nbns_irx
+$(EE_ASM_DIR)nbns-iop.c: modules/network/nbns/nbns.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ nbns_irx
 
 modules/network/httpclient/httpclient.irx: modules/network/httpclient
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)httpclient-iop.s: modules/network/httpclient/httpclient.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ httpclient_irx
+$(EE_ASM_DIR)httpclient-iop.c: modules/network/httpclient/httpclient.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ httpclient_irx
 
-$(EE_ASM_DIR)iomanx.s: $(PS2SDK)/iop/irx/iomanX.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ iomanx_irx
+$(EE_ASM_DIR)iomanx.c: $(PS2SDK)/iop/irx/iomanX.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)filexio.s: $(PS2SDK)/iop/irx/fileXio.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ filexio_irx
+$(EE_ASM_DIR)filexio.c: $(PS2SDK)/iop/irx/fileXio.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)sio2man.s: $(PS2SDK)/iop/irx/freesio2.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ sio2man_irx
+$(EE_ASM_DIR)sio2man.c: $(PS2SDK)/iop/irx/freesio2.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)padman.s: $(PS2SDK)/iop/irx/freepad.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ padman_irx
+$(EE_ASM_DIR)padman.c: $(PS2SDK)/iop/irx/freepad.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)mcman.s: $(PS2SDK)/iop/irx/mcman.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ mcman_irx
+$(EE_ASM_DIR)mcman.c: $(PS2SDK)/iop/irx/mcman.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)mcserv.s: $(PS2SDK)/iop/irx/mcserv.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ mcserv_irx
+$(EE_ASM_DIR)mcserv.c: $(PS2SDK)/iop/irx/mcserv.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_irx
 
-$(EE_ASM_DIR)poeveticanew.s: thirdparty/PoeVeticaNew.ttf | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ poeveticanew_raw
+$(EE_ASM_DIR)poeveticanew.c: thirdparty/PoeVeticaNew.ttf | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_raw
 
-$(EE_ASM_DIR)icon_sys.s: gfx/icon.sys | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ icon_sys
+$(EE_ASM_DIR)icon_sys.c: gfx/icon.sys | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
-$(EE_ASM_DIR)icon_icn.s: gfx/opl.icn | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ icon_icn
+$(EE_ASM_DIR)icon_icn.c: gfx/opl.icn | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
-$(EE_ASM_DIR)icon_sys_A.s: misc/icon_A.sys | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ icon_sys_A
+$(EE_ASM_DIR)icon_sys_A.c: misc/icon_A.sys | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
-$(EE_ASM_DIR)icon_sys_J.s: misc/icon_J.sys | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ icon_sys_J
+$(EE_ASM_DIR)icon_sys_J.c: misc/icon_J.sys | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
-$(EE_ASM_DIR)icon_sys_C.s: misc/icon_C.sys | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ icon_sys_C
+$(EE_ASM_DIR)icon_sys_C.c: misc/icon_C.sys | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
-$(EE_ASM_DIR)conf_theme_OPL.s: misc/conf_theme_OPL.cfg | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ conf_theme_OPL_cfg
+$(EE_ASM_DIR)conf_theme_OPL.c: misc/conf_theme_OPL.cfg | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_cfg
 
-$(EE_ASM_DIR)boot.s: audio/boot.adp | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ boot_adp
+$(EE_ASM_DIR)boot.c: audio/boot.adp | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_adp
 
-$(EE_ASM_DIR)cancel.s: audio/cancel.adp | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ cancel_adp
+$(EE_ASM_DIR)cancel.c: audio/cancel.adp | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_adp
 
-$(EE_ASM_DIR)confirm.s: audio/confirm.adp | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ confirm_adp
+$(EE_ASM_DIR)confirm.c: audio/confirm.adp | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_adp
 
-$(EE_ASM_DIR)cursor.s: audio/cursor.adp | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ cursor_adp
+$(EE_ASM_DIR)cursor.c: audio/cursor.adp | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_adp
 
-$(EE_ASM_DIR)message.s: audio/message.adp | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ message_adp
+$(EE_ASM_DIR)message.c: audio/message.adp | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_adp
 
-$(EE_ASM_DIR)transition.s: audio/transition.adp | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ transition_adp
+$(EE_ASM_DIR)transition.c: audio/transition.adp | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)_adp
 
-$(EE_ASM_DIR)IOPRP_img.s: modules/iopcore/IOPRP.img | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ IOPRP_img
+$(EE_ASM_DIR)IOPRP_img.c: modules/iopcore/IOPRP.img | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
-$(EE_ASM_DIR)drvtif_ingame_irx.s: modules/debug/drvtif-ingame.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ drvtif_ingame_irx
+$(EE_ASM_DIR)drvtif_ingame_irx.c: modules/debug/drvtif-ingame.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
-$(EE_ASM_DIR)tifinet_ingame_irx.s: modules/debug/tifinet-ingame.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ tifinet_ingame_irx
+$(EE_ASM_DIR)tifinet_ingame_irx.c: modules/debug/tifinet-ingame.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
-$(EE_ASM_DIR)drvtif_irx.s: modules/debug/drvtif.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ drvtif_irx
+$(EE_ASM_DIR)drvtif_irx.c: modules/debug/drvtif.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
-$(EE_ASM_DIR)tifinet_irx.s: modules/debug/tifinet.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ tifinet_irx
+$(EE_ASM_DIR)tifinet_irx.c: modules/debug/tifinet.irx | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
-$(EE_ASM_DIR)deci2_img.s: modules/debug/deci2.img | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ deci2_img
+$(EE_ASM_DIR)deci2_img.c: modules/debug/deci2.img | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(*F)
 
 $(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.c | $(EE_OBJS_DIR)
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o: $(EE_ASM_DIR)%.s | $(EE_OBJS_DIR)
-	$(EE_AS) $(EE_ASFLAGS) $< -o $@
+$(EE_OBJS_DIR)%.o: $(EE_ASM_DIR)%.c | $(EE_OBJS_DIR)
+	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-$(PNG_ASSETS:%=$(EE_ASM_DIR)%_png.s): $(EE_ASM_DIR)%_png.s: $(PNG_ASSETS_DIR)%.png | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ $(@:$(EE_ASM_DIR)%.s=%)
+$(PNG_ASSETS:%=$(EE_ASM_DIR)%_png.c): $(EE_ASM_DIR)%_png.c: $(PNG_ASSETS_DIR)%.png | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ $(@:$(EE_ASM_DIR)%.c=%)
 
 endif
 

--- a/labs/genvmclab/Makefile
+++ b/labs/genvmclab/Makefile
@@ -6,7 +6,7 @@ EE_LIBS = -lfileXio -lpatches -ldebug -lc -lkernel
 EE_CFLAGS = -g
 EE_LDFLAGS = -s
 
-BIN2S = $(PS2SDK)/bin/bin2s
+BIN2C = $(PS2SDK)/bin/bin2c
 
 all:
 	$(MAKE) $(EE_BIN)
@@ -26,57 +26,57 @@ clean:
 
 rebuild: clean all
 
-poweroff.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/poweroff.irx poweroff.s poweroff_irx
+poweroff.c: $(PS2SDK)/iop/irx/poweroff.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-ps2dev9.s:
+ps2dev9.c: ../../modules/dev9/ps2dev9.irx
 	$(MAKE) -C ../../modules/dev9
-	$(BIN2S) ../../modules/dev9/ps2dev9.irx ps2dev9.s ps2dev9_irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-smsutils.s:
+smsutils.c: ../../modules/network/SMSUTILS/SMSUTILS.irx
 	$(MAKE) -C ../../modules/network/SMSUTILS
-	$(BIN2S) ../../modules/network/SMSUTILS/SMSUTILS.irx smsutils.s smsutils_irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-smstcpip.s:
+smstcpip.c: ../../modules/network/SMSTCPIP/SMSTCPIP.irx
 	$(MAKE) -C ../../modules/network/SMSTCPIP
-	$(BIN2S) ../../modules/network/SMSTCPIP/SMSTCPIP.irx smstcpip.s smstcpip_irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-smsmap.s:
+smsmap.c: ../../modules/network/SMSMAP/SMSMAP.irx
 	$(MAKE) -C ../../modules/network/SMSMAP
-	$(BIN2S) ../../modules/network/SMSMAP/SMSMAP.irx smsmap.s smsmap_irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-iomanx.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/iomanX.irx iomanx.s iomanx_irx
+iomanx.c: $(PS2SDK)/iop/irx/iomanX.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-filexio.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/fileXio.irx filexio.s filexio_irx
+filexio.c: $(PS2SDK)/iop/irx/fileXio.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-usbd.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/usbd.irx usbd.s usbd_irx
+usbd.c: $(PS2SDK)/iop/irx/usbd.irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-usbhdfsd.s:
+usbhdfsd.c: ../../modules/usb/usbhdfsd/usbhdfsd.irx
 	$(MAKE) -C ../../modules/usb/usbhdfsd
-	$(BIN2S) ../../modules/usb/usbhdfsd/usbhdfsd.irx usbhdfsd.s usbhdfsd_irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-udptty.s:
+udptty.c: ../../modules/debug/udptty/udptty.irx
 	$(MAKE) -C ../../modules/debug/udptty
-	$(BIN2S) ../../modules/debug/udptty/udptty.irx udptty.s udptty_irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-ioptrap.s:
+ioptrap.c: ../../modules/debug/ioptrap/ioptrap.irx
 	$(MAKE) -C ../../modules/debug/ioptrap
-	$(BIN2S) ../../modules/debug/ioptrap/ioptrap.irx ioptrap.s ioptrap_irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-ps2link.s:
+ps2link.c: ../../modules/debug/ps2link/ps2link.irx
 	$(MAKE) -C ../../modules/debug/ps2link
-	$(BIN2S) ../../modules/debug/ps2link/ps2link.irx ps2link.s ps2link_irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-mcman.s:
+mcman.c: ../../modules/vmc/mcman/mcman.irx
 	$(MAKE) -C ../../modules/vmc/mcman
-	$(BIN2S) ../../modules/vmc/mcman/mcman.irx mcman.s mcman_irx
+	$(BIN2C) $< $@ $(*F)_irx
 
-genvmc.s:
+genvmc.c: ../../modules/vmc/genvmc/genvmc.irx
 	$(MAKE) -C ../../modules/vmc/genvmc
-	$(BIN2S) ../../modules/vmc/genvmc/genvmc.irx genvmc.s genvmc_irx
+	$(BIN2C) $< $@ $(*F)_irx
 
 include $(PS2SDK)/samples/Makefile.pref
 include $(PS2SDK)/samples/Makefile.eeglobal

--- a/labs/lwnbdsvr/Makefile
+++ b/labs/lwnbdsvr/Makefile
@@ -6,7 +6,7 @@ EE_LIBS = -lfileXio -lpatches -ldebug -lc -lkernel
 EE_CFLAGS = -g
 EE_LDFLAGS = -s
 
-BIN2S = $(PS2SDK)/bin/bin2s
+BIN2C = $(PS2SDK)/bin/bin2c
 
 all:
 	$(MAKE) $(EE_BIN)
@@ -24,46 +24,46 @@ clean:
 
 rebuild: clean all
 
-discid.s:
+discid.c: ../../modules/cdvd/discID/discID.irx
 	$(MAKE) -C ../../modules/cdvd/discID
-	$(BIN2S) ../../modules/cdvd/discID/discID.irx discid.s discid_irx
+	$(BIN2C) $< $@ $(*F)
 
-poweroff.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/poweroff.irx poweroff.s poweroff_irx
+poweroff.c: $(PS2SDK)/iop/irx/poweroff.irx
+	$(BIN2C) $< $@ $(*F)
 
-ps2dev9.s:
+ps2dev9.c: ../../modules/dev9/ps2dev9.irx
 	$(MAKE) -C ../../modules/dev9
-	$(BIN2S) ../../modules/dev9/ps2dev9.irx ps2dev9.s ps2dev9_irx
+	$(BIN2C) $< $@ $(*F)
 
-smsutils.s:
+smsutils.c: ../../modules/network/SMSUTILS/SMSUTILS.irx
 	$(MAKE) -C ../../modules/network/SMSUTILS
-	$(BIN2S) ../../modules/network/SMSUTILS/SMSUTILS.irx smsutils.s smsutils_irx
+	$(BIN2C) $< $@ $(*F)
 
-smstcpip.s:
+smstcpip.c: ../../modules/network/SMSTCPIP/SMSTCPIP.irx
 	$(MAKE) -C ../../modules/network/SMSTCPIP -f Makefile rebuild
-	$(BIN2S) ../../modules/network/SMSTCPIP/SMSTCPIP.irx smstcpip.s smstcpip_irx
+	$(BIN2C) $< $@ $(*F)
 
-smsmap.s:
+smsmap.c: ../../modules/network/SMSMAP/SMSMAP.irx
 	$(MAKE) -C ../../modules/network/SMSMAP
-	$(BIN2S) ../../modules/network/SMSMAP/SMSMAP.irx smsmap.s smsmap_irx
+	$(BIN2C) $< $@ $(*F)
 
-ps2atad.s:
+ps2atad.c: ../../modules/hdd/atad/ps2atad.irx
 	$(MAKE) -C ../../modules/hdd/atad
-	$(BIN2S) ../../modules/hdd/atad/ps2atad.irx ps2atad.s ps2atad_irx
+	$(BIN2C) $< $@ $(*F)
 
-ps2hdd.s:
+ps2hdd.c: ../../modules/hdd/ps2hdd/ps2hdd.irx
 	$(MAKE) -C ../../modules/hdd/ps2hdd
-	$(BIN2S) ../../modules/hdd/ps2hdd/ps2hdd.irx ps2hdd.s ps2hdd_irx
+	$(BIN2C) $< $@ $(*F)
 
-lwnbdsvr.s:
+lwnbdsvr.c: ../../modules/network/lwNBD/lwnbdsvr.irx
 	$(MAKE) -C ../../modules/network/lwNBD
-	$(BIN2S) ../../modules/network/lwNBD/lwnbdsvr.irx lwnbdsvr.s lwnbdsvr_irx
+	$(BIN2C) $< $@ $(*F)
 
-iomanx.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/iomanX.irx iomanx.s iomanx_irx
+iomanx.c: $(PS2SDK)/iop/irx/iomanX.irx
+	$(BIN2C) $< $@ $(*F)
 
-filexio.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/fileXio.irx filexio.s filexio_irx
+filexio.c: $(PS2SDK)/iop/irx/fileXio.irx
+	$(BIN2C) $< $@ $(*F)
 
 include $(PS2SDK)/samples/Makefile.pref
 include $(PS2SDK)/samples/Makefile.eeglobal

--- a/labs/smblab/Makefile
+++ b/labs/smblab/Makefile
@@ -6,7 +6,7 @@ EE_LIBS = -lfileXio -lpatches -ldebug -lc -lkernel
 EE_CFLAGS = -g
 EE_LDFLAGS = -s
 
-BIN2S = $(PS2SDK)/bin/bin2s
+BIN2C = $(PS2SDK)/bin/bin2c
 
 all:
 	$(MAKE) $(EE_BIN)
@@ -23,45 +23,45 @@ clean:
 
 rebuild: clean all
 
-poweroff.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/poweroff.irx poweroff.s poweroff_irx
+poweroff.c: $(PS2SDK)/iop/irx/poweroff.irx
+	$(BIN2C) $< $@ $(*F)
 
-ps2dev9.s:
+ps2dev9.c: ../../modules/dev9/ps2dev9.irx
 	$(MAKE) -C ../../modules/dev9
-	$(BIN2S) ../../modules/dev9/ps2dev9.irx ps2dev9.s ps2dev9_irx
+	$(BIN2C) $< $@ $(*F)
 
-smsutils.s:
+smsutils.c: ../../modules/network/SMSUTILS/SMSUTILS.irx
 	$(MAKE) -C ../../modules/network/SMSUTILS
-	$(BIN2S) ../../modules/network/SMSUTILS/SMSUTILS.irx smsutils.s smsutils_irx
+	$(BIN2C) $< $@ $(*F)
 
-smstcpip.s:
+smstcpip.c: ../../modules/network/SMSTCPIP/SMSTCPIP.irx
 	$(MAKE) -C ../../modules/network/SMSTCPIP
-	$(BIN2S) ../../modules/network/SMSTCPIP/SMSTCPIP.irx smstcpip.s smstcpip_irx
+	$(BIN2C) $< $@ $(*F)
 
-smsmap.s:
+smsmap.c: ../../modules/network/SMSMAP/SMSMAP.irx
 	$(MAKE) -C ../../modules/network/SMSMAP
-	$(BIN2S) ../../modules/network/SMSMAP/SMSMAP.irx smsmap.s smsmap_irx
+	$(BIN2C) $< $@ $(*F)
 
-smbman.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/smbman.irx smbman.s smbman_irx
+smbman.c: $(PS2SDK)/iop/irx/smbman.irx
+	$(BIN2C) $< $@ $(*F)
 
-udptty.s:
+udptty.c: ../../modules/debug/udptty/udptty.irx
 	$(MAKE) -C ../../modules/debug/udptty
-	$(BIN2S) ../../modules/debug/udptty/udptty.irx udptty.s udptty_irx
+	$(BIN2C) $< $@ $(*F)
 
-ioptrap.s:
+ioptrap.c: ../../modules/debug/ioptrap/ioptrap.irx
 	$(MAKE) -C ../../modules/debug/ioptrap
-	$(BIN2S) ../../modules/debug/ioptrap/ioptrap.irx ioptrap.s ioptrap_irx
+	$(BIN2C) $< $@ $(*F)
 
-ps2link.s:
+ps2link.c: ../../modules/debug/ps2link/ps2link.irx
 	$(MAKE) -C ../../modules/debug/ps2link
-	$(BIN2S) ../../modules/debug/ps2link/ps2link.irx ps2link.s ps2link_irx
+	$(BIN2C) $< $@ $(*F)
 
-iomanx.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/iomanX.irx iomanx.s iomanx_irx
+iomanx.c: $(PS2SDK)/iop/irx/iomanX.irx
+	$(BIN2C) $< $@ $(*F)
 
-filexio.s:
-	$(BIN2S) $(PS2SDK)/iop/irx/fileXio.irx filexio.s filexio_irx
+filexio.c: $(PS2SDK)/iop/irx/fileXio.irx
+	$(BIN2C) $< $@ $(*F)
 
 include $(PS2SDK)/samples/Makefile.pref
 include $(PS2SDK)/samples/Makefile.eeglobal

--- a/modules/Rules.bin.make
+++ b/modules/Rules.bin.make
@@ -1,6 +1,4 @@
 BIN2C = $(PS2SDK)/bin/bin2c
-BIN2S = $(PS2SDK)/bin/bin2s
-BIN2O = $(PS2SDK)/bin/bin2o
 IOP_SRC_DIR = ./
 
 all: $(IOP_BIN)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Using bin2c instead of bin2s makes code more easy to maintain with less risk of errors. bin2s has been removed from ps2sdk and  this PR is needed to make OPL compile again.

The PR in ps2sdk combined with this PR should close issue #1142 and perhaps other recent issues too.