### PR TITLE
kr_ps2: fix Kidou Senshi Gundam Ichinen Sensou

### DIFF
--- a/ee_core/src/patches.c
+++ b/ee_core/src/patches.c
@@ -149,6 +149,7 @@ static const patchlist_t patch_list[] = {
     {"SLPS_732.22", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000000, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-J) (PlayStation 2 The Best)
     {"SLUS_211.71", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000001, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-U/C)
     {"SLES_534.80", ALL_MODE, {PATCH_HARVEST_MOON_AWL, 0x00000002, 0x00000000}},   // Harvest Moon: A Wonderful Life (NTSC-PAL)
+    {"SLPS_254.78", ALL_MODE, {0x00365BC0, 0x1040FFFD, 0x1440FFFD}},               // Kidou Senshi Gundam Ichinen Sensou sceSifSyncIop() != 0 to == 0 return check fix.
     {NULL, 0, {0x00000000, 0x00000000, 0x00000000}}                                // terminator
 };
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
by kr_ps2:
This game has an IOP reset bug (yes, a game bug for once and not an OPL IOP bug).

Here's how a normal IOP reset in proper sync should be:

```c
while (sceSifRebootIop("cdrom0:\\IOPRP300.IMG") == 0) {};
while (sceSifSyncIop() == 0) {};
```
Here's what this game does:


```c
while (sceSifRebootIop("cdrom0:\\IOPRP300.IMG") == 0) {};
while (sceSifSyncIop() != 0) {};
```
`sceSifSyncIop()` returns 1 once the full process of IOP reboot has finished. This game is accidentally checking for 0 instead, so it gets stuck for eternity.

This is because OPL always waits on its own for `sceSifSyncIop()`, and once it has returned, the `sceSifSyncIop()` of the game will pass on the first run.

The game works on real hardware because, despite not being in sync with IOP reset finishing (`sceSifRebootIop` only initiates a DMA transfer and directly returns, so `sceSifSyncIop()` is run almost directly and by then it will fail, which for this game means it passes), it does other EE things while the IOP has finished. After some `SifInitRpc`, it calls `sceSifInitIopHeap`, which waits forever for the bind to finish, and by that time, the IOP reset has already finished, or it causes no issues.

The solution is to patch the game bug because not only OPL but any other media might be impacted by this. Other than this, the game works perfectly fine.

If it worked in some obscure version, it's because their method did not call `sceSifSyncIop()` on their own but let the game do it, a thing we can't do without changing a lot of OPL core design.

In the future, it might be an idea for OPL to hook into the `SifRegs` and clear the finish status for the first read of it, yet this would make other future games with this problem hard to spot.

fixes #1155