### PR TITLE
kr_ps2: remove UDNL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,7 @@ IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o bdmevent.o \
 		iremsndpatch.o apemodpatch.o f2techioppatch.o cleareffects.o resetspu.o \
 		libsd.o audsrv.o
 
-EECORE_OBJS = ee_core.o ioprp.o util.o \
-		udnl.o imgdrv.o eesync.o \
+EECORE_OBJS = ee_core.o ioprp.o util.o imgdrv.o eesync.o \
 		bdm_cdvdman.o IOPRP_img.o smb_cdvdman.o \
 		hdd_cdvdman.o hdd_hdpro_cdvdman.o cdvdfsv.o \
 		ingame_smstcpip.o smap_ingame.o smbman.o smbinit.o
@@ -131,9 +130,6 @@ endif
 ifeq ($(DTL_T10000),1)
   EE_CFLAGS += -D_DTL_T10000
   EECORE_EXTRA_FLAGS += DTL_T10000=1
-  UDNL_OUT = $(PS2SDK)/iop/irx/udnl-t300.irx
-else
-  UDNL_OUT = $(PS2SDK)/iop/irx/udnl.irx
 endif
 
 ifeq ($(IGS),1)
@@ -362,9 +358,6 @@ ee_core/ee_core.elf: ee_core
 
 $(EE_ASM_DIR)ee_core.c: ee_core/ee_core.elf | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ eecore_elf
-
-$(EE_ASM_DIR)udnl.c: $(UDNL_OUT) | $(EE_ASM_DIR)
-	$(BIN2C) $(UDNL_OUT) $@ udnl_irx
 
 modules/iopcore/imgdrv/imgdrv.irx: modules/iopcore/imgdrv
 	$(MAKE) -C $<

--- a/ee_core/include/modmgr.h
+++ b/ee_core/include/modmgr.h
@@ -86,7 +86,7 @@ typedef struct
 
 int LoadFileInit();
 void LoadFileExit();
-int LoadModule(const char *path, int arg_len, const char *args);
+int LoadModule(const char *path, int arg_len, const char *args, int mode);
 int LoadMemModule(int mode, void *modptr, unsigned int modsize, int arg_len, const char *args);
 int GetOPLModInfo(int id, void **pointer, unsigned int *size);
 int LoadOPLModule(int id, int mode, int arg_len, const char *args);

--- a/ee_core/include/modules.h
+++ b/ee_core/include/modules.h
@@ -1,7 +1,6 @@
 enum OPL_MODULE_ID {
     // Basic modules
-    OPL_MODULE_ID_UDNL = 1,
-    OPL_MODULE_ID_IOPRP,
+    OPL_MODULE_ID_IOPRP = 1,
     OPL_MODULE_ID_IMGDRV,
     OPL_MODULE_ID_RESETSPU,
 

--- a/ee_core/src/igs_api.c
+++ b/ee_core/src/igs_api.c
@@ -776,8 +776,8 @@ int InGameScreenshot(void)
 
     // Load modules.
     LoadFileInit();
-    LoadModule("rom0:SIO2MAN", 0, NULL);
-    LoadModule("rom0:MCMAN", 0, NULL);
+    LoadModule("rom0:SIO2MAN", 0, NULL, 0);
+    LoadModule("rom0:MCMAN", 0, NULL, 0);
 
     // Save IGS Bitmap File first, since it's the bigger file)
     intffmd = GET_SMODE2_INTFFMD(smode2);

--- a/ee_core/src/modmgr.c
+++ b/ee_core/src/modmgr.c
@@ -50,7 +50,7 @@ void LoadFileExit()
 /*----------------------------------------------------------------------------------------*/
 /* Load an irx module from path with waiting.                                             */
 /*----------------------------------------------------------------------------------------*/
-int LoadModule(const char *path, int arg_len, const char *args)
+int LoadModule(const char *path, int arg_len, const char *args, int mode)
 {
     struct _lf_module_load_arg arg;
 
@@ -68,7 +68,7 @@ int LoadModule(const char *path, int arg_len, const char *args)
     } else
         arg.p.arg_len = 0;
 
-    if (SifCallRpc(&_lf_cd, LF_F_MOD_LOAD, 0x0, &arg, sizeof(arg), &arg, 8, NULL, NULL) < 0)
+    if (SifCallRpc(&_lf_cd, LF_F_MOD_LOAD, mode, &arg, sizeof(arg), &arg, 8, NULL, NULL) < 0)
         return -SCE_ECALLMISS;
 
     return arg.p.result;

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -80,16 +80,16 @@ static void t_loadElf(void)
         GS_BGCOLOUR = 0xFF8000; // Blue sky
 
     // Load basic modules
-    LoadModule("rom0:SIO2MAN", 0, NULL);
-    LoadModule("rom0:MCMAN", 0, NULL);
+    LoadModule("rom0:SIO2MAN", 0, NULL, 0);
+    LoadModule("rom0:MCMAN", 0, NULL, 0);
 
     if (ExitPath[1] == 'a') { // ie mass:
-        ret = LoadModule("mc0:SYS-CONF/USBD.IRX", 0, NULL);
+        ret = LoadModule("mc0:SYS-CONF/USBD.IRX", 0, NULL, 0);
         if (ret >= 0)
-            LoadModule("mc0:SYS-CONF/USBHDFSD.IRX", 0, NULL);
+            LoadModule("mc0:SYS-CONF/USBHDFSD.IRX", 0, NULL, 0);
         else {
-            LoadModule("mc1:SYS-CONF/USBD.IRX", 0, NULL);
-            LoadModule("mc1:SYS-CONF/USBHDFSD.IRX", 0, NULL);
+            LoadModule("mc1:SYS-CONF/USBD.IRX", 0, NULL, 0);
+            LoadModule("mc1:SYS-CONF/USBHDFSD.IRX", 0, NULL, 0);
         }
         delay(5); // Wait for device to be detected.
     }

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -86,7 +86,7 @@ static void t_loadElf(void)
     LoadModule("rom0:MCMAN", 0, NULL, 0);
 
     if (config->ExitPath[1] == 'a') { // ie mass:
-        ret = LoadModule("mc0:SYS-CONF/USBD.IRX", 0, NULL);
+        ret = LoadModule("mc0:SYS-CONF/USBD.IRX", 0, NULL, 0);
         if (ret >= 0)
             LoadModule("mc0:SYS-CONF/USBHDFSD.IRX", 0, NULL, 0);
         else {

--- a/include/extern_irx.h
+++ b/include/extern_irx.h
@@ -126,8 +126,6 @@ IMPORT_BIN2C(udptty_irx);
 
 IMPORT_BIN2C(udptty_ingame_irx);
 
-IMPORT_BIN2C(udnl_irx);
-
 IMPORT_BIN2C(usbd_irx);
 
 IMPORT_BIN2C(usbmass_bd_irx);

--- a/modules/iopcore/imgdrv/imgdrv.c
+++ b/modules/iopcore/imgdrv/imgdrv.c
@@ -71,7 +71,7 @@ iop_device_ops_t my_device_ops =
     dummy_fs,//chstat*/
 };
 
-const char name[] = "img";
+const char name[] = "host";
 iop_device_t my_device = {
     name,
     IOP_DT_FS,
@@ -81,7 +81,7 @@ iop_device_t my_device = {
 
 int _start(int argc, char **argv)
 {
-    // DelDrv("img");
+    DelDrv("host");
     AddDrv((iop_device_t *)&my_device);
 
     return MODULE_RESIDENT_END;

--- a/modules/iopcore/imgdrv/imports.lst
+++ b/modules/iopcore/imgdrv/imports.lst
@@ -1,6 +1,6 @@
 ioman_IMPORTS_start
 I_AddDrv
-/*I_DelDrv*/
+I_DelDrv
 ioman_IMPORTS_end
 
 sysclib_IMPORTS_start

--- a/src/system.c
+++ b/src/system.c
@@ -473,8 +473,6 @@ static unsigned int sendIrxKernelRAM(const char *startup, const char *mode_str, 
 
     modcount = 0;
     // Basic modules
-    irxptr_tab[modcount].info = size_udnl_irx | SET_OPL_MOD_ID(OPL_MODULE_ID_UDNL);
-    irxptr_tab[modcount++].ptr = (void *)&udnl_irx;
     irxptr_tab[modcount].info = size_ioprp_image | SET_OPL_MOD_ID(OPL_MODULE_ID_IOPRP);
     irxptr_tab[modcount++].ptr = ioprp_image;
     irxptr_tab[modcount].info = size_imgdrv_irx | SET_OPL_MOD_ID(OPL_MODULE_ID_IMGDRV);
@@ -555,20 +553,6 @@ static unsigned int sendIrxKernelRAM(const char *startup, const char *mode_str, 
 
     irxtable->modules = irxptr_tab;
     irxtable->count = modcount;
-
-#ifdef __DECI2_DEBUG
-    // For DECI2 debugging mode, the UDNL module will have to be stored within kernel RAM because there isn't enough space below user RAM.
-    // total_size will hence not include the IOPRP image, but it's okay because the EE core is interested in protecting the module storage within user RAM.
-    irxptr = (void *)0x00033000;
-    LOG("SYSTEM DECI2 UDNL address start: %p end: %p\n", irxptr, (void *)((u8 *)irxptr + GET_OPL_MOD_SIZE(irxptr_tab[0].info)));
-    DI();
-    ee_kmode_enter();
-    memcpy((void *)(0x80000000 | (unsigned int)irxptr), irxptr_tab[0].ptr, GET_OPL_MOD_SIZE(irxptr_tab[0].info));
-    ee_kmode_exit();
-    EI();
-
-    irxptr_tab[0].ptr = irxptr; // UDNL is the first module.
-#endif
 
     total_size = (sizeof(irxtab_t) + sizeof(irxptr_t) * modcount + 0xF) & ~0xF;
     irxptr = (void *)((((unsigned int)irxptr_tab + sizeof(irxptr_t) * modcount) + 0xF) & ~0xF);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
kr_ps2:
The UDNL feature has been removed as it was determined to serve no real purpose. This removal results in several benefits, including saving OPL compile time, reducing the final ELF size, minimizing the EE core size, and overall simplifying the codebase.
The "img" parameter in `imgdrv` has been renamed to `host` to support `udnl-t300`. This change is necessary because the blacklist for `udnl-t300` only supports `rom`, `cdrom`, and `host`. Since the first two options are unavailable, the `host` parameter is the only option to ensure out-of-the box support for DTL-T10000.
Please note that while this change may potentially cause issues if a game attempts to reload from `host`, such scenarios are not expected in retail games.