### PR TITLE
[OSD history] try writing to `mc1:` first, like OSDSYS

### DIFF
--- a/src/OSDHistory.c
+++ b/src/OSDHistory.c
@@ -133,7 +133,7 @@ int AddHistoryRecord(const char *name)
     char path[32];
     DEBUG_PRINTF("OSDHistory@%s: starts\n", __func__);
 
-    for (i = 0; i < 2; i++) { // increase number of slots for mt (not sure how multi tap works haven’t looked at docs ie mc0 - mc4 ?)
+    for (i = 1; i >= 0; i--) { // increase number of slots for mt (not sure how multi tap works haven’t looked at docs ie mc0 - mc4 ?)
         mcGetInfo(i, 0, &mcType, NULL, &format);
         mcSync(0, NULL, &result);
         DEBUG_PRINTF("\tslot=%d, mctype=%d, format=%d\n", i, mcType, format);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Since OSD history is having more importance due to mcpro2 and sd2psx this change allows more consistency between OSDSYS and OPL.