### PR TITLE
ci: update actions to v4

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,7 +13,7 @@ jobs:
     container: ghcr.io/ps2homebrew/ps2homebrew:main
     steps:
     - name: git checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -27,7 +27,7 @@ jobs:
 
     - name: Upload release artifact ELF
       if: ${{ success() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: OPNPS2LD
         path: |
@@ -35,7 +35,7 @@ jobs:
 
     - name: Upload release artifact info
       if: ${{ success() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: INFO
         path: |
@@ -56,7 +56,7 @@ jobs:
     container: ghcr.io/ps2homebrew/ps2homebrew:main
     steps:
     - name: git checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -75,17 +75,28 @@ jobs:
       run: sh ./make_changelog.sh
 
     - name: Upload variants artifact ELF
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: OPNPS2LD-VARIANTS
+        name: OPNPS2LD-VARIANTS ${{ matrix.t10k }} ${{ matrix.igs }} ${{ matrix.pademu }} ${{ matrix.rtl }}
         path: OPNPS2LD*.ELF
+
+  merge-variants:
+    runs-on: ubuntu-latest
+    needs: build-variants
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: OPNPS2LD-VARIANTS
+          pattern: OPNPS2LD-VARIANTS*
+          delete-merged: true
 
   build-lang:
     runs-on: ubuntu-latest
     container: ghcr.io/ps2homebrew/ps2homebrew:main
     steps:
     - name: git checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -99,7 +110,7 @@ jobs:
 
     - name: Upload release artifact
       if: ${{ success() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: OPNPS2LD-LANGS
         path: |
@@ -114,7 +125,7 @@ jobs:
     container: ghcr.io/ps2homebrew/ps2homebrew:main
     steps:
     - name: git checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -130,10 +141,21 @@ jobs:
         mv opl.elf opl-${{ matrix.debug }}.elf
 
     - name: Upload variants artifact ELF
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: opl-debug-${{ env.OPL_VERSION }}-${{ matrix.docker }}
+        name: opl-${{ matrix.debug }}-${{ env.OPL_VERSION }}
         path: opl-*.elf
+
+  merge-debug:
+    runs-on: ubuntu-latest
+    needs: build-debug
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: OPNPS2LD-DEBUG
+          pattern: opl-*
+          delete-merged: true
 
   release:
     needs: [build, build-variants, build-lang]
@@ -144,7 +166,7 @@ jobs:
       PASSWORD: ${{ secrets.PASSWORD }}
     steps:
     - name: git checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - run: git fetch --prune --unshallow
 
@@ -153,7 +175,7 @@ jobs:
         echo "OPL_VERSION=$(make oplversion)" >> $GITHUB_ENV
 
     - name: Download all artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
 
     - name: Prepare artifacts for release
       run: |
@@ -169,7 +191,7 @@ jobs:
 
     - name: Create prerelease
       if: github.ref == 'refs/heads/master'
-      uses: marvinpinto/action-automatic-releases@latest
+      uses: mathieucarbou/marvinpinto-action-automatic-releases@latest
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         prerelease: true
@@ -185,7 +207,7 @@ jobs:
 
     - name: Create release
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: marvinpinto/action-automatic-releases@latest
+      uses: mathieucarbou/marvinpinto-action-automatic-releases@latest
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         prerelease: "${{ contains(github.ref, '-rc') }}"


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Updated CI due to depreciation see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Version 4 does not allow uploading Artifacts with the same name so I had to 'build-upload-merge-delete merged' for variants and debug builds. The warnings regarding 'release' builds should be gone also see https://github.com/marvinpinto/actions/issues/695#issuecomment-1817664939 as to why I changed the repo .. only thing I'm not sure about is whether or not we need to merge Artifacts within release builds also.. I can't test this on a fork so tagging @AKuHAK 