### PR TITLE
[ee_core]: use EE_SIO syscall from libkernel

### DIFF
--- a/ee_core/include/ee_core.h
+++ b/ee_core/include/ee_core.h
@@ -22,8 +22,8 @@
 #include <smod.h>
 
 #ifdef __EESIO_DEBUG
-#define DPRINTF(args...) ;
-#define DINIT()          ;
+#define DPRINTF(args...) _print(args);
+#define DINIT()          InitDebug();
 #else
 #define DPRINTF(args...) \
     do {                 \


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Enables EE SIO debug on the EE Core by using the kernel syscall for EE SIO

## Known side effects:
- duplicated printf on PCSX2 because they seem to also use this syscall
