### PR TITLE
Using `exit` instead of `Exit`

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -379,7 +379,7 @@ void sysExecExit(void)
 {
     // Deinitialize without shutting down active devices.
     deinit(NO_EXCEPTION, IO_MODE_SELECTED_ALL);
-    Exit(0);
+    exit(0);
 }
 
 // Module bits


### PR DESCRIPTION
## Description
When existing OPL we were using `Exit` instead of `exit`, which is the standard call. Using `Exit` implies we are not going through the whole `deinit` process.

More info here:
https://github.com/ps2dev/ps2sdk/blob/master/ee/startup/src/crt0.c#L138-L143

## Pull Request checklist

Note: these are not necessarily requirements

- [X] I reformatted the code with clang-format
- [X] I checked to make sure my submission worked
- [X] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

Cheers