### PR TITLE
Revert "kr_ps2: remove UDNL"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ IOP_OBJS =	iomanx.o filexio.o ps2fs.o usbd.o bdmevent.o \
 		iremsndpatch.o apemodpatch.o f2techioppatch.o cleareffects.o resetspu.o \
 		libsd.o audsrv.o
 
-EECORE_OBJS = ee_core.o ioprp.o util.o imgdrv.o eesync.o \
+EECORE_OBJS = ee_core.o ioprp.o util.o \
+		udnl.o imgdrv.o eesync.o \
 		bdm_cdvdman.o IOPRP_img.o smb_cdvdman.o \
 		hdd_cdvdman.o hdd_hdpro_cdvdman.o cdvdfsv.o \
 		ingame_smstcpip.o smap_ingame.o smbman.o smbinit.o
@@ -132,6 +133,9 @@ endif
 ifeq ($(DTL_T10000),1)
   EE_CFLAGS += -D_DTL_T10000
   EECORE_EXTRA_FLAGS += DTL_T10000=1
+  UDNL_OUT = $(PS2SDK)/iop/irx/udnl-t300.irx
+else
+  UDNL_OUT = $(PS2SDK)/iop/irx/udnl.irx
 endif
 
 ifeq ($(IGS),1)
@@ -360,6 +364,9 @@ ee_core/ee_core.elf: ee_core
 
 $(EE_ASM_DIR)ee_core.c: ee_core/ee_core.elf | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ eecore_elf
+
+$(EE_ASM_DIR)udnl.c: $(UDNL_OUT) | $(EE_ASM_DIR)
+	$(BIN2C) $(UDNL_OUT) $@ udnl_irx
 
 modules/iopcore/imgdrv/imgdrv.irx: modules/iopcore/imgdrv
 	$(MAKE) -C $<

--- a/ee_core/include/modmgr.h
+++ b/ee_core/include/modmgr.h
@@ -86,7 +86,7 @@ typedef struct
 
 int LoadFileInit();
 void LoadFileExit();
-int LoadModule(const char *path, int arg_len, const char *args, int mode);
+int LoadModule(const char *path, int arg_len, const char *args);
 int LoadMemModule(int mode, void *modptr, unsigned int modsize, int arg_len, const char *args);
 int GetOPLModInfo(int id, void **pointer, unsigned int *size);
 int LoadOPLModule(int id, int mode, int arg_len, const char *args);

--- a/ee_core/include/modules.h
+++ b/ee_core/include/modules.h
@@ -1,6 +1,7 @@
 enum OPL_MODULE_ID {
     // Basic modules
-    OPL_MODULE_ID_IOPRP = 1,
+    OPL_MODULE_ID_UDNL = 1,
+    OPL_MODULE_ID_IOPRP,
     OPL_MODULE_ID_IMGDRV,
     OPL_MODULE_ID_RESETSPU,
 

--- a/ee_core/src/igs_api.c
+++ b/ee_core/src/igs_api.c
@@ -779,8 +779,8 @@ int InGameScreenshot(void)
 
     // Load modules.
     LoadFileInit();
-    LoadModule("rom0:SIO2MAN", 0, NULL, 0);
-    LoadModule("rom0:MCMAN", 0, NULL, 0);
+    LoadModule("rom0:SIO2MAN", 0, NULL);
+    LoadModule("rom0:MCMAN", 0, NULL);
 
     // Save IGS Bitmap File first, since it's the bigger file)
     intffmd = GET_SMODE2_INTFFMD(smode2);

--- a/ee_core/src/iopmgr.c
+++ b/ee_core/src/iopmgr.c
@@ -34,11 +34,11 @@ static void ResetIopSpecial(const char *args, unsigned int arglen)
         command[arglen] = '\0'; /* In a normal IOP reset process, the IOP reset command line will be NULL-terminated properly somewhere.
                         Since we're now taking things into our own hands, NULL terminate it here.
                         Some games like SOCOM3 will use a command line that isn't NULL terminated, resulting in things like "cdrom0:\RUN\IRX\DNAS300.IMGG;1" */
-        _strcpy(&command[arglen + 1], "img0:");
-        CommandLen = arglen + 6;
+        _strcpy(&command[arglen + 1], "host0:");
+        CommandLen = arglen + 7;
     } else {
-        _strcpy(command, "img0:");
-        CommandLen = 5;
+        _strcpy(command, "host0:");
+        CommandLen = 6;
     }
 
     GetOPLModInfo(OPL_MODULE_ID_IOPRP, &IOPRP_img, &size_IOPRP_img);

--- a/ee_core/src/iopmgr.c
+++ b/ee_core/src/iopmgr.c
@@ -34,11 +34,11 @@ static void ResetIopSpecial(const char *args, unsigned int arglen)
         command[arglen] = '\0'; /* In a normal IOP reset process, the IOP reset command line will be NULL-terminated properly somewhere.
                         Since we're now taking things into our own hands, NULL terminate it here.
                         Some games like SOCOM3 will use a command line that isn't NULL terminated, resulting in things like "cdrom0:\RUN\IRX\DNAS300.IMGG;1" */
-        _strcpy(&command[arglen + 1], "host0:");
-        CommandLen = arglen + 7;
+        _strcpy(&command[arglen + 1], "img0:");
+        CommandLen = arglen + 6;
     } else {
-        _strcpy(command, "host0:");
-        CommandLen = 6;
+        _strcpy(command, "img0:");
+        CommandLen = 5;
     }
 
     GetOPLModInfo(OPL_MODULE_ID_IOPRP, &IOPRP_img, &size_IOPRP_img);
@@ -63,15 +63,20 @@ static void ResetIopSpecial(const char *args, unsigned int arglen)
     *(void **)(UNCACHED_SEG(&((unsigned char *)imgdrv_irx)[imgdrv_offset_ioprpimg])) = pIOP_buffer;
     *(u32 *)(UNCACHED_SEG(&((unsigned char *)imgdrv_irx)[imgdrv_offset_ioprpsiz])) = size_IOPRP_img;
 
-    LoadModule("rom0:SYSCLIB", 0, NULL, 0);
     LoadMemModule(0, imgdrv_irx, size_imgdrv_irx, 0, NULL);
-    LoadModule("rom0:UDNL", CommandLen, command, 1);
+
+    DIntr();
+    ee_kmode_enter();
+    Old_SifSetReg(SIF_REG_SMFLAG, SIF_STAT_BOOTEND);
+    ee_kmode_exit();
+    EIntr();
+
+    LoadOPLModule(OPL_MODULE_ID_UDNL, SIF_RPC_M_NOWAIT, CommandLen, command);
 
     DIntr();
     ee_kmode_enter();
     Old_SifSetReg(SIF_REG_SMFLAG, SIF_STAT_SIFINIT);
     Old_SifSetReg(SIF_REG_SMFLAG, SIF_STAT_CMDINIT);
-    Old_SifSetReg(SIF_REG_SMFLAG, SIF_STAT_BOOTEND);
     Old_SifSetReg(SIF_SYSREG_RPCINIT, 0);
     Old_SifSetReg(SIF_SYSREG_SUBADDR, (int)NULL);
     ee_kmode_exit();

--- a/ee_core/src/modmgr.c
+++ b/ee_core/src/modmgr.c
@@ -50,7 +50,7 @@ void LoadFileExit()
 /*----------------------------------------------------------------------------------------*/
 /* Load an irx module from path with waiting.                                             */
 /*----------------------------------------------------------------------------------------*/
-int LoadModule(const char *path, int arg_len, const char *args, int mode)
+int LoadModule(const char *path, int arg_len, const char *args)
 {
     struct _lf_module_load_arg arg;
 
@@ -68,7 +68,7 @@ int LoadModule(const char *path, int arg_len, const char *args, int mode)
     } else
         arg.p.arg_len = 0;
 
-    if (SifCallRpc(&_lf_cd, LF_F_MOD_LOAD, mode, &arg, sizeof(arg), &arg, 8, NULL, NULL) < 0)
+    if (SifCallRpc(&_lf_cd, LF_F_MOD_LOAD, 0x0, &arg, sizeof(arg), &arg, 8, NULL, NULL) < 0)
         return -SCE_ECALLMISS;
 
     return arg.p.result;

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -82,16 +82,16 @@ static void t_loadElf(void)
         GS_BGCOLOUR = 0xFF8000; // Blue sky
 
     // Load basic modules
-    LoadModule("rom0:SIO2MAN", 0, NULL, 0);
-    LoadModule("rom0:MCMAN", 0, NULL, 0);
+    LoadModule("rom0:SIO2MAN", 0, NULL);
+    LoadModule("rom0:MCMAN", 0, NULL);
 
     if (config->ExitPath[1] == 'a') { // ie mass:
-        ret = LoadModule("mc0:SYS-CONF/USBD.IRX", 0, NULL, 0);
+        ret = LoadModule("mc0:SYS-CONF/USBD.IRX", 0, NULL);
         if (ret >= 0)
-            LoadModule("mc0:SYS-CONF/USBHDFSD.IRX", 0, NULL, 0);
+            LoadModule("mc0:SYS-CONF/USBHDFSD.IRX", 0, NULL);
         else {
-            LoadModule("mc1:SYS-CONF/USBD.IRX", 0, NULL, 0);
-            LoadModule("mc1:SYS-CONF/USBHDFSD.IRX", 0, NULL, 0);
+            LoadModule("mc1:SYS-CONF/USBD.IRX", 0, NULL);
+            LoadModule("mc1:SYS-CONF/USBHDFSD.IRX", 0, NULL);
         }
         delay(5); // Wait for device to be detected.
     }

--- a/include/extern_irx.h
+++ b/include/extern_irx.h
@@ -126,6 +126,8 @@ IMPORT_BIN2C(udptty_irx);
 
 IMPORT_BIN2C(udptty_ingame_irx);
 
+IMPORT_BIN2C(udnl_irx);
+
 IMPORT_BIN2C(usbd_irx);
 
 IMPORT_BIN2C(usbmass_bd_irx);

--- a/modules/iopcore/imgdrv/imgdrv.c
+++ b/modules/iopcore/imgdrv/imgdrv.c
@@ -8,6 +8,7 @@ IRX_ID(MODNAME, 1, 1);
 
 unsigned int ioprpimg = 0xDEC1DEC1;
 int ioprpsiz = 0xDEC2DEC2;
+const char name[] = "host";
 
 int dummy_fs()
 {
@@ -27,6 +28,12 @@ int read_fs(iop_file_t *fd, void *buffer, int size)
 {
     memcpy(buffer, (void *)ioprpimg, size);
     return size;
+}
+
+int close_fs()
+{
+    DelDrv(name);
+    return 0;
 }
 
 typedef struct _iop_device_tm
@@ -54,24 +61,25 @@ iop_device_ops_t my_device_ops =
     {
         dummy_fs, // init
         dummy_fs, // deinit
-        NULL,     // dummy_fs,//format
-        dummy_fs, // open_fs,//open
-        dummy_fs, // close_fs,//close
+        NULL,     // dummy_fs,// format
+        dummy_fs, // open_fs,// open
+        close_fs, // close
         read_fs,  // read
-        NULL,     // dummy_fs,//write
+        NULL,     // dummy_fs,// write
         lseek_fs, // lseek
-                  /*dummy_fs,//ioctl
-    dummy_fs,//remove
-    dummy_fs,//mkdir
-    dummy_fs,//rmdir
-    dummy_fs,//dopen
-    dummy_fs,//dclose
-    dummy_fs,//dread
-    dummy_fs,//getstat
-    dummy_fs,//chstat*/
+                  /*
+        dummy_fs, // ioctl
+        dummy_fs, // remove
+        dummy_fs, // mkdir
+        dummy_fs, // rmdir
+        dummy_fs, // dopen
+        dummy_fs, // dclose
+        dummy_fs, // dread
+        dummy_fs, // getstat
+        dummy_fs, // chstat
+                   */
 };
 
-const char name[] = "img";
 iop_device_t my_device = {
     name,
     IOP_DT_FS,
@@ -81,7 +89,7 @@ iop_device_t my_device = {
 
 int _start(int argc, char **argv)
 {
-    // DelDrv("img");
+    DelDrv(name);
     AddDrv((iop_device_t *)&my_device);
 
     return MODULE_RESIDENT_END;

--- a/modules/iopcore/imgdrv/imgdrv.c
+++ b/modules/iopcore/imgdrv/imgdrv.c
@@ -71,7 +71,7 @@ iop_device_ops_t my_device_ops =
     dummy_fs,//chstat*/
 };
 
-const char name[] = "host";
+const char name[] = "img";
 iop_device_t my_device = {
     name,
     IOP_DT_FS,
@@ -81,7 +81,7 @@ iop_device_t my_device = {
 
 int _start(int argc, char **argv)
 {
-    DelDrv("host");
+    // DelDrv("img");
     AddDrv((iop_device_t *)&my_device);
 
     return MODULE_RESIDENT_END;

--- a/modules/iopcore/imgdrv/imports.lst
+++ b/modules/iopcore/imgdrv/imports.lst
@@ -1,6 +1,6 @@
 ioman_IMPORTS_start
 I_AddDrv
-/*I_DelDrv*/
+I_DelDrv
 ioman_IMPORTS_end
 
 sysclib_IMPORTS_start

--- a/modules/iopcore/imgdrv/imports.lst
+++ b/modules/iopcore/imgdrv/imports.lst
@@ -1,6 +1,6 @@
 ioman_IMPORTS_start
 I_AddDrv
-I_DelDrv
+/*I_DelDrv*/
 ioman_IMPORTS_end
 
 sysclib_IMPORTS_start

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -861,7 +861,7 @@ struct UIItem diaAbout[] = {
     {UI_BREAK},
 
     {UI_SPACER},
-    {UI_LABEL, 0, 1, 1, -1, 0, 15, {.label = {"Maximus32 - misfire - Polo35 - reprep - SP193 - volca", -1}}},
+    {UI_LABEL, 0, 1, 1, -1, 0, 15, {.label = {"kr_ps2 - Maximus32 - misfire - Polo35 - reprep - SP193 - volca", -1}}},
     {UI_BREAK},
 
     {UI_SPACER},


### PR DESCRIPTION
Reverts ps2homebrew/Open-PS2-Loader#1198

Seems, that rom0:UDNL has issues with USB devices in some games.
Still keep changes, necessary for support UDNL on DTL-T10000.

Fixes #1286 , #1293