### PR TITLE
bdmsupport: fix deinit

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -489,6 +489,11 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     if (configGetStrCopy(configSet, CONFIG_ITEM_ALTSTARTUP, filename, sizeof(filename)) == 0)
         strcpy(filename, game->startup);
 
+    // deinit will free per device data.. copy driver name before free to compare for launch
+    char bdmCurrentDriver[32];
+    snprintf(bdmCurrentDriver, sizeof(bdmCurrentDriver), pDeviceData->bdmDriver);
+    settings->bdDeviceId = pDeviceData->massDeviceIndex;
+
     if (gAutoLaunchBDMGame == NULL)
         deinit(NO_EXCEPTION, itemList->mode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
     else {
@@ -499,14 +504,13 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     }
 
     LOG("bdm pre sysLaunchLoaderElf\n");
-    settings->bdDeviceId = pDeviceData->massDeviceIndex;
-    if (!strcmp(pDeviceData->bdmDriver, "usb")) {
+    if (!strcmp(bdmCurrentDriver, "usb")) {
         settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_USBD;
         sysLaunchLoaderElf(filename, "BDM_USB_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
-    } else if (!strcmp(pDeviceData->bdmDriver, "sd") && strlen(pDeviceData->bdmDriver) == 2) {
+    } else if (!strcmp(bdmCurrentDriver, "sd") && strlen(bdmCurrentDriver) == 2) {
         settings->common.fakemodule_flags |= 0 /* TODO! fake ilinkman ? */;
         sysLaunchLoaderElf(filename, "BDM_ILK_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
-    } else if (!strcmp(pDeviceData->bdmDriver, "sdc") && strlen(pDeviceData->bdmDriver) == 3) {
+    } else if (!strcmp(bdmCurrentDriver, "sdc") && strlen(bdmCurrentDriver) == 3) {
         settings->common.fakemodule_flags |= 0;
         sysLaunchLoaderElf(filename, "BDM_M4S_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
     }

--- a/src/opl.c
+++ b/src/opl.c
@@ -335,10 +335,15 @@ static void itemExecTriangle(struct menu_item *curMenu)
 
 static void initMenuForListSupport(opl_io_module_t *mod)
 {
+    item_list_t *list = mod->support;
+
     mod->menuItem.icon_id = mod->support->itemIconId(mod->support);
     mod->menuItem.text = NULL;
     mod->menuItem.text_id = mod->support->itemTextId(mod->support);
-    mod->menuItem.visible = 1;
+    if (list->mode >= BDM_MODE1 && list->mode <= BDM_MODE4)
+        mod->menuItem.visible = 0;
+    else
+        mod->menuItem.visible = 1;
 
     mod->menuItem.userdata = mod->support;
 
@@ -427,13 +432,8 @@ static void initAllSupport(int force_reinit)
 static void deinitAllSupport(int exception, int modeSelected)
 {
     for (int i = 0; i < MODE_COUNT; i++) {
-        if (list_support[i].support != NULL) {
-            // If the selected mode is one of the mass devices then skip deinit for all mass device objects.
-            if (modeSelected >= BDM_MODE && modeSelected <= BDM_MODE4 && i <= BDM_MODE4)
-                continue;
-
+        if (list_support[i].support != NULL)
             moduleCleanup(&list_support[i], exception, modeSelected);
-        }
     }
 }
 
@@ -1640,10 +1640,8 @@ void setDefaultColors(void)
 
 static void setDefaults(void)
 {
-    clearIOModuleT(&list_support[BDM_MODE]);
-    clearIOModuleT(&list_support[ETH_MODE]);
-    clearIOModuleT(&list_support[HDD_MODE]);
-    clearIOModuleT(&list_support[APP_MODE]);
+    for (int i = 0; i < MODE_COUNT; i++)
+        clearIOModuleT(&list_support[i]);
 
     gAutoLaunchGame = NULL;
     gAutoLaunchBDMGame = NULL;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
"May" fix bug2 in #1316 

Clean initialisation of opl_io_module_t was not being performed for additional bdm modes, this may have no affect but best to do it anyway.

De-initialisation of all bdm modes was being skipped.. only reason I can see for that is we're trying to use per device data after the fact, so I've fixed that.. and we don't need additional bdm modes to init as visible.

Only tested on pcsx2 which showed no difference but before this it was all working fine for me on pcsx2 anyway so idk it "might" fix some problems and appears to be a more correct approach avoiding potential memory leaks. If someone with real hardware is available to test that would be appreciated.
