### PR TITLE
Hold a button on start to force opl's interface force to 480p (Auto)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,5 +299,9 @@ Since 05/07/2021 every OPL build dispatched to the release section of this repos
 
 > Main game executable could not be found. Either game is fragmented or image is corrupted
 
+### OPL does not display anything on boot
+
+> You may have selected a Video Mode which your TV does not support. Hold Triangle and Cross while OPL initializes to reset your video mode to "Auto".
+
 </p>
 </details>

--- a/src/opl.c
+++ b/src/opl.c
@@ -890,7 +890,15 @@ static void _loadConfig()
             configGetInt(configOPL, CONFIG_OPL_ENABLE_NOTIFICATIONS, &gEnableNotifications);
             configGetInt(configOPL, CONFIG_OPL_ENABLE_COVERART, &gEnableArt);
             configGetInt(configOPL, CONFIG_OPL_WIDESCREEN, &gWideScreen);
-            configGetInt(configOPL, CONFIG_OPL_VMODE, &gVMode);
+
+            if (!(getKeyPressed(KEY_TRIANGLE) && getKeyPressed(KEY_CROSS))) {
+                configGetInt(configOPL, CONFIG_OPL_VMODE, &gVMode);
+            } else {
+                LOG("--- Select held at boot - setting Video Mode to Auto ---\n");
+                gVMode = 0;
+                configSetInt(configOPL, CONFIG_OPL_VMODE, gVMode);
+            }
+
             configGetInt(configOPL, CONFIG_OPL_XOFF, &gXOff);
             configGetInt(configOPL, CONFIG_OPL_YOFF, &gYOff);
             configGetInt(configOPL, CONFIG_OPL_OVERSCAN, &gOverscan);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- I ran `make format` and this passed with no issues - not sure if this is the requirement for this task. I also tried running `make format-check` which gave me some errors unrelated to my changes, so I'm not 100% sure of the pass criteria here. Happy to make any required changes, just let me know.
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Hold Select on boot to force OPL to reset video mode to "auto" as per FR #1318. This is useful if you end up in the situation of your video mode being incompatible with your TV, but you don't want to reset all your settings as you would by holding start. I'm not 100% sure this is a required addition, but I figured it was still an open issue and it was a good trivial first submission to get familiar with the codebase if nothing else.