### PR TITLE
Fix argument support

### DIFF
--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -378,9 +378,9 @@ static void appLaunchItem(item_list_t *itemList, int id, config_set_t *configSet
 
     fd = open(filename, O_RDONLY);
     if (fd >= 0) {
-        int mode, argc = 1;
+        int mode, argc = 0;
         char partition[128];
-        char *argv[2];
+        char *argv[1];
         close(fd);
 
         strcpy(partition, "");
@@ -393,11 +393,9 @@ static void appLaunchItem(item_list_t *itemList, int id, config_set_t *configSet
         if (mode == HDD_MODE)
             snprintf(partition, sizeof(partition), "%s:", gOPLPart);
 
-        argv[0] = (char *)filename;
-
         if (configGetStr(configSet, CONFIG_ITEM_ALTSTARTUP, &argv1) != 0) {
-            argv[1] = (char *)argv1;
-            argc = 2;
+            argv[0] = (char *)argv1;
+            argc = 1;
         }
 
         deinit(UNMOUNT_EXCEPTION, mode); // CAREFUL: deinit will call appCleanUp, so configApps/cur will be freed


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
This update brings Open PS2 Loader (OPL) in line with PS2SDK standards. OPL now utilizes standard PS2SDK libraries, which eliminates the need to manually copy the filename into the first argument during file operations. The SDK automatically sets up the path, reducing code complexity. Additionally, this change removes the duplication of the filepath in both `argv[0]` and `argv[1]`