### PR TITLE
debug colors for errors related to IRX execution

### DIFF
--- a/ee_core/src/modmgr.c
+++ b/ee_core/src/modmgr.c
@@ -149,15 +149,29 @@ int GetOPLModInfo(int id, void **pointer, unsigned int *size)
 
 int LoadOPLModule(int id, int mode, int arg_len, const char *args)
 {
-    int result;
+    int result, x = 50;
     void *pointer;
     unsigned int size;
 
     if ((result = GetOPLModInfo(id, &pointer, &size)) == 0) {
-        if (size > 0)
+        if (size > 0) {
             result = LoadMemModule(mode, pointer, size, arg_len, args);
+            if (result < 1) { // El_isra: only check for MODLOAD errors for simplicity
+                if (EnableDebug) {
+                    GS_BGCOLOUR = 0xdcff00; // Yellow. MODLOAD cannot load IRX
+                    while(--x)
+                        ;
+                }
+            }
+        } else {
+            if (EnableDebug) {
+                GS_BGCOLOUR = 0xdcff00; // Teal // Module size is not right
+                while(--x)
+                    ;
+            }
+        }
     }
-
+    GS_BGCOLOUR = 0x000000; // reset color
     return result;
 }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description


When error is returned (MODLOAD error) screen is set to yellow 
![image](https://github.com/user-attachments/assets/80587418-3b9b-4d91-ba9b-48016dd32b5d)

When IRX size is 0 or negative. screen sets light blue 
![image](https://github.com/user-attachments/assets/d50e52ee-a097-4a7f-911a-8017a631aedf)
