### PR TITLE
document debug colors and add debug colors for IRX errors

### DIFF
--- a/ee_core/debug_colors_doc.sh
+++ b/ee_core/debug_colors_doc.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# automated listing of debug colors. with small description and location in source code
+echo "# EECORE Color automated documentation"
+echo "## Static Debug Colors:"
+echo "source file | line | Color (BGR) | Category | Description"
+echo ":---------- | :--- | :---------: | :------: | :--------- "
+grep -Eon "DBGCOL\(.*\);" src/* | sed -E 's/(.*):([0-9]*):DBGCOL\((.*), (.*), "(.*)"\).*/\1 | \2 | \3 | \4 | \5/g' | sed -E "s/0x([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})/\!\[0x\1\2\3\](https:\/\/img.shields.io\/badge\/\1\2\3-\3\2\1\?style=for-the-badge)/g"
+
+echo "## Blinking Debug Colors:"
+#DBGCOL_BLNK(blinkCount, colour, forever, type, description)
+echo "source file | line | Blinks | Color (BGR) | Blinks forever? | Category | Description"
+echo ":---------- | :--- | :----- | :---------: | :-------------: | :------: | :--------- "
+grep -Eon "DBGCOL_BLNK\(.*\);" src/* | sed -E 's/(.*):([0-9]*):DBGCOL_BLNK\((.*), (.*), (.*), (.*), "(.*)"\).*/\1 | \2 | \3 | \4 | **\5** | \6 | \7/g' | sed -E "s/0x([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})/\!\[0x\1\2\3\](https:\/\/img.shields.io\/badge\/\1\2\3-\3\2\1\?style=for-the-badge)/g"
+

--- a/ee_core/include/ee_core.h
+++ b/ee_core/include/ee_core.h
@@ -20,6 +20,8 @@
 #include <sbv_patches.h>
 #include <smem.h>
 #include <smod.h>
+#include <stdbool.h>
+
 
 #ifdef __EESIO_DEBUG
 #define DPRINTF(args...) _print(args);
@@ -73,5 +75,9 @@ enum GAME_MODE {
 
 extern int EnableDebug;
 #define GS_BGCOLOUR *((volatile unsigned long int *)0x120000E0)
+#define DBGCOL(color, type, description) GS_BGCOLOUR = color // this wrapper macro only serves the purpose of allowing us to grep from outside for documentation
+#define BGCOLND(color) GS_BGCOLOUR = color // same as DBGCOL() but this one is not passed to debug color documentation. used for blinking or setting screen to black wich usually means nothing
+#define DBGCOL_BLNK(blinkCount, colour, forever, type, description) BlinkColour(blinkCount, colour, forever) //same as DBGCOL() but this one includes screen blinking effect
+
 
 #endif

--- a/ee_core/include/ee_core.h
+++ b/ee_core/include/ee_core.h
@@ -74,9 +74,10 @@ enum GAME_MODE {
 };
 
 extern int EnableDebug;
-#define GS_BGCOLOUR *((volatile unsigned long int *)0x120000E0)
-#define DBGCOL(color, type, description) GS_BGCOLOUR = color // this wrapper macro only serves the purpose of allowing us to grep from outside for documentation
-#define BGCOLND(color) GS_BGCOLOUR = color // same as DBGCOL() but this one is not passed to debug color documentation. used for blinking or setting screen to black wich usually means nothing
+extern void BlinkColour(u8 x, u32 colour, u8 forever);
+#define GS_BGCOLOUR                                                 *((volatile unsigned long int *)0x120000E0)
+#define DBGCOL(color, type, description)                            GS_BGCOLOUR = color                      // this wrapper macro only serves the purpose of allowing us to grep from outside for documentation
+#define BGCOLND(color)                                              GS_BGCOLOUR = color                      // same as DBGCOL() but this one is not passed to debug color documentation. used for blinking or setting screen to black wich usually means nothing
 #define DBGCOL_BLNK(blinkCount, colour, forever, type, description) BlinkColour(blinkCount, colour, forever) //same as DBGCOL() but this one includes screen blinking effect
 
 

--- a/ee_core/src/igs_api.c
+++ b/ee_core/src/igs_api.c
@@ -43,12 +43,13 @@ static void BlinkColour(u8 x, u32 colour, u8 forever)
     u8 i;
     do {
         delay(2);
-        GS_BGCOLOUR = 0x000000; // Black
+        BGCOLND(0x000000); // Black
+        //foo
         for (i = 1; i <= x; i++) {
             delay(1);
-            GS_BGCOLOUR = colour; // Chosen colour
+            BGCOLND(colour); // Chosen colour
             delay(1);
-            GS_BGCOLOUR = 0x000000; // Black
+            BGCOLND(0x000000); // Black
         }
     } while (forever);
 }
@@ -73,11 +74,11 @@ static u32 FindEmptyArea(u32 start, u32 end, u32 emptysize)
     if (counter == emptysize) {
         result = (u32)addr - emptysize;
         result = (((result) >> 4) << 4); // It must be 16-bytes aligned
-        BlinkColour(2, 0x00FF00, 0);     // FOUND => Double Green :-)
+        DBGCOL_BLNK(2, 0x00FF00, false, IGS, "FindEmptyArea(): Found");     // FOUND => Double Green :-)
     } else {
         // result = 0x00100000;                                // 1st. possible workaround: Use the ingame area (Typically starts on "0x00100000"). It must be 16-bytes aligned
         result = ((0x01F32568 - emptysize - 16) >> 4) << 4; // 2nd. possible workaround: Himem area ("0x01F32568" taken from  PS2LINK hi-mem).   It must be 16-bytes aligned
-        BlinkColour(2, 0x0066FF, 0);                        // Double Orange :-(
+        DBGCOL_BLNK(2, 0x0066FF, false, IGS, "FindEmptyArea(): Not found");                        // Double Orange :-(
     }
 
     return result;
@@ -176,7 +177,7 @@ static u8 PixelSize(u8 spsm)
     else if ((spsm == GS_PSM_CT16) || (spsm == GS_PSM_CT16S))
         result = 2;
     else
-        BlinkColour(1, 0x0000FF, 1); // Red
+        DBGCOL_BLNK(1, 0x0000FF, true, IGS, "PixelSize(): Unknown?"); // Red
     return result;
 }
 
@@ -184,7 +185,7 @@ static void Screenshot(u16 sbp, u8 sbw, u8 spsm, u16 width, u16 height, u32 dime
 {
 
     delay(1);
-    GS_BGCOLOUR = 0xCCFFFF; // Light Yellow
+    DBGCOL(0xCCFFFF, IGS, "Screenshot() begins");
 
     static u128 EnableGIFPATH3;
 
@@ -206,10 +207,10 @@ static void Screenshot(u16 sbp, u8 sbw, u8 spsm, u16 width, u16 height, u32 dime
     u8 i;
 
     if ((sbw < 1) || (sbw > 32))
-        BlinkColour(2, 0x0000FF, 1); // Red
+        DBGCOL_BLNK(2, 0x0000FF, true, IGS, "Screenshot(): sbw out of range [1-32]"); // Red
 
     if ((height < 64) || (height > 1080))
-        BlinkColour(3, 0x0000FF, 1); // Red
+        DBGCOL_BLNK(3, 0x0000FF, true, IGS, "Screenshot(): height out of range [64-1080]"); // Red
 
     // Number of qwords (each qword = 2^4 bytes = 16 bytes = 128 bits)
     qwords = image_size >> 4;
@@ -316,7 +317,7 @@ static void Screenshot(u16 sbp, u8 sbw, u8 spsm, u16 width, u16 height, u32 dime
             ;
 
         delay(1);
-        GS_BGCOLOUR = (0x00FFFF - (255 * i / slices) * 0x000101); // Yellow Fade Out Effect
+        BGCOLND((0x00FFFF - (255 * i / slices) * 0x000101)); // Yellow Fade Out Effect
 
     } while (i < slices);
 
@@ -353,7 +354,7 @@ static void ConvertColors32(u32 *buffer, u32 dimensions)
         buffer[i] = ((x32 >> 16) & 0xFF) | ((x32 << 16) & 0xFF0000) | (x32 & 0xFF00FF00);
 
         FastDelay(1);
-        GS_BGCOLOUR = (0x0000FF - (255 * (i + 1) / dimensions) * 0x000001); // Red Fade Out Effect
+        BGCOLND((0x0000FF - (255 * (i + 1) / dimensions) * 0x000001)); // Red Fade Out Effect
     }
 }
 
@@ -369,7 +370,7 @@ static void ConvertColors24(u8 *buffer, u32 image_size)
         buffer[i + 2] = (u8)((x32 >> 16) & 0xFF);
 
         FastDelay(1);
-        GS_BGCOLOUR = (0x00FF00 - (255 * (i + 1) / image_size) * 0x000100); // Green Fade Out Effect
+        BGCOLND((0x00FF00 - (255 * (i + 1) / image_size) * 0x000100)); // Green Fade Out Effect
     }
 }
 
@@ -383,7 +384,7 @@ static void ConvertColors16(u16 *buffer, u32 dimensions)
         buffer[i] = (x16 & 0x8000) | ((x16 << 10) & 0x7C00) | (x16 & 0x3E0) | ((x16 >> 10) & 0x1F);
 
         FastDelay(1);
-        GS_BGCOLOUR = (0xFF0000 - (255 * (i + 1) / dimensions) * 0x010000); // Blue Fade Out Effect
+        BGCOLND((0xFF0000 - (255 * (i + 1) / dimensions) * 0x010000)); // Blue Fade Out Effect
     }
 }
 
@@ -392,7 +393,7 @@ static void SaveTextFile(u32 buffer, u16 width, u16 height, u8 pixel_size, u32 i
     USE_LOCAL_EECORE_CONFIG;
 
     delay(1);
-    GS_BGCOLOUR = 0x0099FF; // Orange
+    DBGCOL(0x0099FF, IGS, "SaveTextFile() begins");
 
     //  0000000001111111111222222222
     //  1234567890123456789012345678
@@ -425,7 +426,7 @@ static void SaveTextFile(u32 buffer, u16 width, u16 height, u8 pixel_size, u32 i
     // Create file
     file_handle = fioOpen(PathFilenameExtension, O_CREAT | O_WRONLY);
     if (file_handle < 0)
-        BlinkColour(4, 0x0000FF, 1); // Red
+        DBGCOL_BLNK(4, 0x0000FF, true, IGS, "SaveTextFile(): FILEIO Open Error"); // Red
 
     _strcpy(text, "PS2 IGS (InGame Screenshot)\n---------------------------\n");
     _strcat(text, "\n\nGame ID=");
@@ -569,7 +570,7 @@ static void SaveTextFile(u32 buffer, u16 width, u16 height, u8 pixel_size, u32 i
     fioClose(file_handle);
 
     delay(1);
-    GS_BGCOLOUR = 0x000000; // Black
+    BGCOLND(0x000000); // Black
 }
 
 static u8 SaveBitmapFile(u16 width, u16 height, u8 pixel_size, void *buffer, u8 intffmd)
@@ -577,7 +578,7 @@ static u8 SaveBitmapFile(u16 width, u16 height, u8 pixel_size, void *buffer, u8 
     USE_LOCAL_EECORE_CONFIG;
 
     delay(1);
-    GS_BGCOLOUR = 0x990066; // Purple Violet
+    BGCOLND(0x990066); // Purple Violet
 
     //  00000000011111111112222222222
     //  12345678901234567890123456789
@@ -612,7 +613,7 @@ static u8 SaveBitmapFile(u16 width, u16 height, u8 pixel_size, void *buffer, u8 
     // Sequential numbering feature
     while (1) {
         if (Number == 255)               // 255 screenshots per-game should be enough? lol
-            BlinkColour(6, 0x0000FF, 1); // Red
+            DBGCOL_BLNK(6, 0x0000FF, true, IGS, "SaveBitmapFile(): Number == 255"); // Red
         Number++;
         _strcpy(PathFilenameExtension, "mc1:/");
         _strcat(PathFilenameExtension, config->GameID);
@@ -632,13 +633,13 @@ static u8 SaveBitmapFile(u16 width, u16 height, u8 pixel_size, void *buffer, u8 
     // Create file
     file_handle = fioOpen(PathFilenameExtension, O_CREAT | O_WRONLY);
     if (file_handle < 0)
-        BlinkColour(4, 0x0000FF, 1); // Red
+        DBGCOL_BLNK(4, 0x0000FF, true, IGS, "SaveBitmapFile(): FILEIO error"); // Red
 
     // Write Bitmap Header
     //(first, write the BMP Header ID ouside of struct, due to alignment issues...)
     ret = fioWrite(file_handle, id, 2);
     if (ret != 2)
-        BlinkColour(5, 0x0000FF, 1); // Red
+        DBGCOL_BLNK(5, 0x0000FF, true, IGS, "SaveBitmapFile(): FILEIO write err"); // Red
     //(...then, write the remaining info!)
     bh = (void *)((u8 *)buffer + image_size);
     bh->filesize = (u32)file_size;
@@ -660,7 +661,7 @@ static u8 SaveBitmapFile(u16 width, u16 height, u8 pixel_size, void *buffer, u8 
 
     ret = fioWrite(file_handle, bh, 52);
     if (ret != 52)
-        BlinkColour(5, 0x0000FF, 1); // Red
+        DBGCOL_BLNK(5, 0x0000FF, true, IGS, "SaveBitmapFile(): FILEIO write error"); // Red
 
     // Write image in reverse order (since BMP is written Left to Right, Bottom to Top)
     if (intffmd == 3) // Interlace Mode, FRAME Mode (Read every line)
@@ -673,20 +674,20 @@ static u8 SaveBitmapFile(u16 width, u16 height, u8 pixel_size, void *buffer, u8 
 
         ret = fioWrite(file_handle, addr, lenght);
         if (ret != lenght)
-            BlinkColour(5, 0x0000FF, 1); // Red
+            DBGCOL_BLNK(5, 0x0000FF, true, IGS, "SaveBitmapFile(): FILEIO write error"); // Red
         if (intffmd == 3) {              // Interlace Mode, FRAME Mode (Read every line)
             ret = fioWrite(file_handle, addr, lenght);
             if (ret != lenght)
-                BlinkColour(5, 0x0000FF, 1); // Red
+                DBGCOL_BLNK(5, 0x0000FF, true, IGS, "SaveBitmapFile(): FILEIO write error"); // Red
         }
-        GS_BGCOLOUR = (0xFFFFFF - (255 * i / height) * 0x010101); // Gray Fade Out Effect
+        BGCOLND((0xFFFFFF - (255 * i / height) * 0x010101)); // Gray Fade Out Effect
     }
 
     // Close file
     fioClose(file_handle);
 
     delay(1);
-    GS_BGCOLOUR = 0x000000; // Black
+    BGCOLND(0x000000); // Black
 
     // Return the Sequential Number to the related Text File
     return Number;
@@ -775,7 +776,7 @@ int InGameScreenshot(void)
     EI();
 
     delay(1);
-    GS_BGCOLOUR = 0x660033; // Midnight Blue
+    BGCOLND(0x660033); // Midnight Blue
 
     // Load modules.
     LoadFileInit();
@@ -799,7 +800,7 @@ int InGameScreenshot(void)
     FlushCache(0);
     FlushCache(2);
 
-    BlinkColour(1, 0xFF0000, 0); // Double Blue :-)
+    DBGCOL_BLNK(1, 0xFF0000, false, IGS, "InGameScreenshot() end"); // Double Blue :-)
 
     return 0;
 }

--- a/ee_core/src/igs_api.c
+++ b/ee_core/src/igs_api.c
@@ -38,22 +38,6 @@ static void FastDelay(int count)
     }
 }
 
-static void BlinkColour(u8 x, u32 colour, u8 forever)
-{
-    u8 i;
-    do {
-        delay(2);
-        BGCOLND(0x000000); // Black
-        //foo
-        for (i = 1; i <= x; i++) {
-            delay(1);
-            BGCOLND(colour); // Chosen colour
-            delay(1);
-            BGCOLND(0x000000); // Black
-        }
-    } while (forever);
-}
-
 static u32 FindEmptyArea(u32 start, u32 end, u32 emptysize)
 {
     u128 *addr = (u128 *)start;
@@ -73,12 +57,12 @@ static u32 FindEmptyArea(u32 start, u32 end, u32 emptysize)
 
     if (counter == emptysize) {
         result = (u32)addr - emptysize;
-        result = (((result) >> 4) << 4); // It must be 16-bytes aligned
-        DBGCOL_BLNK(2, 0x00FF00, false, IGS, "FindEmptyArea(): Found");     // FOUND => Double Green :-)
+        result = (((result) >> 4) << 4);                                // It must be 16-bytes aligned
+        DBGCOL_BLNK(2, 0x00FF00, false, IGS, "FindEmptyArea(): Found"); // FOUND => Double Green :-)
     } else {
         // result = 0x00100000;                                // 1st. possible workaround: Use the ingame area (Typically starts on "0x00100000"). It must be 16-bytes aligned
-        result = ((0x01F32568 - emptysize - 16) >> 4) << 4; // 2nd. possible workaround: Himem area ("0x01F32568" taken from  PS2LINK hi-mem).   It must be 16-bytes aligned
-        DBGCOL_BLNK(2, 0x0066FF, false, IGS, "FindEmptyArea(): Not found");                        // Double Orange :-(
+        result = ((0x01F32568 - emptysize - 16) >> 4) << 4;                 // 2nd. possible workaround: Himem area ("0x01F32568" taken from  PS2LINK hi-mem).   It must be 16-bytes aligned
+        DBGCOL_BLNK(2, 0x0066FF, false, IGS, "FindEmptyArea(): Not found"); // Double Orange :-(
     }
 
     return result;
@@ -612,7 +596,7 @@ static u8 SaveBitmapFile(u16 width, u16 height, u8 pixel_size, void *buffer, u8 
 
     // Sequential numbering feature
     while (1) {
-        if (Number == 255)               // 255 screenshots per-game should be enough? lol
+        if (Number == 255)                                                          // 255 screenshots per-game should be enough? lol
             DBGCOL_BLNK(6, 0x0000FF, true, IGS, "SaveBitmapFile(): Number == 255"); // Red
         Number++;
         _strcpy(PathFilenameExtension, "mc1:/");
@@ -675,7 +659,7 @@ static u8 SaveBitmapFile(u16 width, u16 height, u8 pixel_size, void *buffer, u8 
         ret = fioWrite(file_handle, addr, lenght);
         if (ret != lenght)
             DBGCOL_BLNK(5, 0x0000FF, true, IGS, "SaveBitmapFile(): FILEIO write error"); // Red
-        if (intffmd == 3) {              // Interlace Mode, FRAME Mode (Read every line)
+        if (intffmd == 3) {                                                              // Interlace Mode, FRAME Mode (Read every line)
             ret = fioWrite(file_handle, addr, lenght);
             if (ret != lenght)
                 DBGCOL_BLNK(5, 0x0000FF, true, IGS, "SaveBitmapFile(): FILEIO write error"); // Red

--- a/ee_core/src/iopmgr.c
+++ b/ee_core/src/iopmgr.c
@@ -149,7 +149,7 @@ int New_Reset_Iop(const char *arg, int arglen)
     USE_LOCAL_EECORE_CONFIG;
     DPRINTF("New_Reset_Iop start!\n");
     if (EnableDebug)
-        GS_BGCOLOUR = 0xFF00FF; // Purple
+        DBGCOL(0xFF00FF, IOPMGR, "New_Reset_Iop()");
 
     SifInitRpc(0);
 
@@ -170,12 +170,12 @@ int New_Reset_Iop(const char *arg, int arglen)
 
     ResetIopSpecial(NULL, 0);
     if (EnableDebug)
-        GS_BGCOLOUR = 0x00A5FF; // Orange
+        DBGCOL(0x00A5FF, IOPMGR, "ResetIopSpecial (without args) finished!");
 
     if (arglen > 0) {
         ResetIopSpecial(&arg[10], arglen - 10);
         if (EnableDebug)
-            GS_BGCOLOUR = 0x00FFFF; // Yellow
+            DBGCOL(0x00FFFF, IOPMGR, "ResetIopSpecial (with args) finished!");
     }
 
     if (iop_reboot_count >= 2) {
@@ -206,7 +206,7 @@ int New_Reset_Iop(const char *arg, int arglen)
         set_reg_hook = 4;
 
     if (EnableDebug)
-        GS_BGCOLOUR = 0x000000; // Black
+        BGCOLND(0x000000);
 
     return 1;
 }

--- a/ee_core/src/main.c
+++ b/ee_core/src/main.c
@@ -113,7 +113,7 @@ static int eecoreInit(int argc, char **argv)
     Install_Kernel_Hooks();
 
     if (config->EnableDebug)
-        GS_BGCOLOUR = 0xff0000; // Blue
+        DBGCOL(0xFF0000, MAIN, "Reached end of eecoreinit()");
 
     SifExitRpc();
 

--- a/ee_core/src/modmgr.c
+++ b/ee_core/src/modmgr.c
@@ -149,7 +149,7 @@ int GetOPLModInfo(int id, void **pointer, unsigned int *size)
 
 int LoadOPLModule(int id, int mode, int arg_len, const char *args)
 {
-    int result, x = 50;
+    int result;
     void *pointer;
     unsigned int size;
 
@@ -158,20 +158,24 @@ int LoadOPLModule(int id, int mode, int arg_len, const char *args)
             result = LoadMemModule(mode, pointer, size, arg_len, args);
             if (result < 1) { // El_isra: only check for MODLOAD errors for simplicity
                 if (EnableDebug) {
-                    GS_BGCOLOUR = 0xdcff00; // Yellow. MODLOAD cannot load IRX
-                    while(--x)
+                    DBGCOL(0x00FFDC, MODMGR, "IRX loading error (from MODLOAD)");
+                    delay(3);
+                }
+                if (result == -400) {
+                    DBGCOL_BLNK(1, 0x0000FF, true, MODMGR, "MODLOAD: out of IOP Memory"); // yellow blinking
+                    while (1)
                         ;
                 }
             }
         } else {
             if (EnableDebug) {
-                GS_BGCOLOUR = 0xdcff00; // Teal // Module size is not right
-                while(--x)
-                    ;
+                DBGCOL(0xDCFF00, MODMGR, "IRX size is 0 or less");
+                delay(3);
             }
         }
     }
-    GS_BGCOLOUR = 0x000000; // reset color
+
+    BGCOLND(0x000000);
     return result;
 }
 

--- a/ee_core/src/modmgr.c
+++ b/ee_core/src/modmgr.c
@@ -149,15 +149,29 @@ int GetOPLModInfo(int id, void **pointer, unsigned int *size)
 
 int LoadOPLModule(int id, int mode, int arg_len, const char *args)
 {
-    int result;
+    int result, x = 50;
     void *pointer;
     unsigned int size;
 
     if ((result = GetOPLModInfo(id, &pointer, &size)) == 0) {
-        if (size > 0)
+        if (size > 0) {
             result = LoadMemModule(mode, pointer, size, arg_len, args);
+            if (result < 1) { // El_isra: only check for MODLOAD errors for simplicity
+                if (EnableDebug) {
+                    GS_BGCOLOUR = 0xdcff00; // Yellow. MODLOAD cannot load IRX
+                    while(--x)
+                        ;
+                }
+            }
+        } else {
+            if (EnableDebug) {
+                GS_BGCOLOUR = 0xdcff00; // Teal // Module size is not right
+                while(--x)
+                    ;
+            }
+        }
     }
-
+    GS_BGCOLOUR = 0x000000; // reset color
     return result;
 }
 

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -67,19 +67,19 @@ static void t_loadElf(void)
     t_ExecData elf;
 
     if (EnableDebug)
-        GS_BGCOLOUR = 0x80FF00; // Blue Green
+        DBGCOL(0x80FF00, LOADELF, "t_loadElf() begins");
 
     // Init RPC & CMD
     SifInitRpc(0);
 
     if (EnableDebug)
-        GS_BGCOLOUR = 0x000080; // Dark Red
+        DBGCOL(0x000080, LOADELF, "Patch prefix check");
 
     // Apply Sbv patches
     sbv_patch_disable_prefix_check();
 
     if (EnableDebug)
-        GS_BGCOLOUR = 0xFF8000; // Blue sky
+        DBGCOL(0xFF8000, LOADELF, "loading SIO2 modules and USBD if found");
 
     // Load basic modules
     LoadModule("rom0:SIO2MAN", 0, NULL);
@@ -118,14 +118,14 @@ static void t_loadElf(void)
         FlushCache(2);
 
         if (EnableDebug)
-            GS_BGCOLOUR = 0x0080FF; // Orange
+            DBGCOL(0x0080FF, LOADELF, "ExecPS2() begins");
 
         // Execute BOOT.ELF
         ExecPS2((void *)elf.epc, (void *)elf.gp, 1, argv);
     }
 
     if (EnableDebug) {
-        GS_BGCOLOUR = 0x0000FF; // Red
+        DBGCOL(0x0000FF, LOADELF, "LoadElf() error");
         delay(5);
     }
 
@@ -146,7 +146,7 @@ static void IGR_Thread(void *arg)
     DPRINTF("IGR thread woken up!\n");
 
     if (EnableDebug)
-        GS_BGCOLOUR = 0xFFFFFF; // White
+        DBGCOL(0xFFFFFF, IGR, "Thread WakeUp");
 
     // Re-Init RPC & CMD
     SifInitRpc(0);
@@ -159,12 +159,12 @@ static void IGR_Thread(void *arg)
     ) {
 
         if (EnableDebug)
-            GS_BGCOLOUR = 0xFF8000; // Blue sky
+                DBGCOL(0xFF8000, IGR, "oplIGRShutdown()");
 
         oplIGRShutdown(0);
 
         if (EnableDebug)
-            GS_BGCOLOUR = 0x0000FF; // Red
+                DBGCOL(0x0000FF, IGR, "Reset IOP");
 
         // Reset IO Processor
         while (!Reset_Iop("", 0)) {
@@ -197,27 +197,27 @@ static void IGR_Thread(void *arg)
 
         if (config->EnableGSMOp) {
             if (EnableDebug)
-                GS_BGCOLOUR = 0x00FF00; // Green
+                DBGCOL(0x00FF00, IGR, "Stopping GSM");
             DPRINTF("Stopping GSM...\n");
             DisableGSM();
         }
 
         if (config->gCheatList) {
             if (EnableDebug)
-                GS_BGCOLOUR = 0xFF0000; // Blue
+                DBGCOL(0xFF0000, IGR, "Stopping CheatEngine");
             DPRINTF("Stopping PS2RD Cheat Engine...\n");
             DisableCheats();
         }
 
         if (EnableDebug)
-            GS_BGCOLOUR = 0x00FFFF; // Yellow
+            DBGCOL(0x00FFFF, IGR, "Waiting for IOP Reboot");
 
         while (!SifIopSync()) {
             ;
         }
 
         if (EnableDebug)
-            GS_BGCOLOUR = 0xFF80FF; // Pink
+            DBGCOL(0xFF80FF, IGR, "Initializing RPC and services");
 
         // Init RPC & CMD
         SifInitRpc(0);
@@ -226,7 +226,7 @@ static void IGR_Thread(void *arg)
         sbv_patch_enable_lmb();
 
         if (EnableDebug)
-            GS_BGCOLOUR = 0x800000; // Dark Blue
+            DBGCOL(0x800000, IGR, "Execute RESETSPU.IRX");
 
         // Reset SPU - do it after the IOP reboot, so nothing will compete with the EE for it.
         LoadOPLModule(OPL_MODULE_ID_RESETSPU, 0, 0, NULL);
@@ -237,7 +237,7 @@ static void IGR_Thread(void *arg)
 #endif
 
         if (EnableDebug)
-            GS_BGCOLOUR = 0x008000; // Dark Green
+            DBGCOL(0x008000, IGR, "Exiting services");
 
         // Exit services
         SifExitIopHeap();
@@ -247,7 +247,7 @@ static void IGR_Thread(void *arg)
         IGR_Exit(0);
     } else {
         if (EnableDebug)
-            GS_BGCOLOUR = 0x0000FF; // Red
+            DBGCOL(0x0000FF, IGR, "oplIGRShutdown(1)");
 
         // If combo is R3 + L3, Poweroff PS2
         oplIGRShutdown(1);
@@ -534,7 +534,7 @@ int Install_PadOpen_Hook(u32 mem_start, u32 mem_end, int mode)
         while (ptr) {
             // Purple while PadOpen pattern search
             if (EnableDebug)
-                GS_BGCOLOUR = 0x800080; // Purple
+                DBGCOL(0x800080, PADHOOK, "Searching PadOpen() pattern");
 
             mem_size = mem_end - (u32)ptr;
 
@@ -546,7 +546,7 @@ int Install_PadOpen_Hook(u32 mem_start, u32 mem_end, int mode)
 
                 // Green while PadOpen patches
                 if (EnableDebug)
-                    GS_BGCOLOUR = 0x008000; // Dark green
+                    DBGCOL(0x008000, PADHOOK, "Patching PadOpen()");
 
                 // Save original PadOpen function
                 if (padopen_patterns[i].type == IGR_LIBPAD)
@@ -661,7 +661,7 @@ int Install_PadOpen_Hook(u32 mem_start, u32 mem_end, int mode)
 
     // Done
     if (EnableDebug)
-        GS_BGCOLOUR = 0x000000; // Black
+        BGCOLND(0x000000); // Black
 
     return patched;
 }

--- a/ee_core/src/padhook.c
+++ b/ee_core/src/padhook.c
@@ -159,12 +159,12 @@ static void IGR_Thread(void *arg)
     ) {
 
         if (EnableDebug)
-                DBGCOL(0xFF8000, IGR, "oplIGRShutdown()");
+            DBGCOL(0xFF8000, IGR, "oplIGRShutdown()");
 
         oplIGRShutdown(0);
 
         if (EnableDebug)
-                DBGCOL(0x0000FF, IGR, "Reset IOP");
+            DBGCOL(0x0000FF, IGR, "Reset IOP");
 
         // Reset IO Processor
         while (!Reset_Iop("", 0)) {

--- a/ee_core/src/syshook.c
+++ b/ee_core/src/syshook.c
@@ -87,7 +87,7 @@ void sysLoadElf(char *filename, int argc, char **argv)
     DPRINTF("t_loadElf: elf path = '%s'\n", filename);
 
     if (EnableDebug)
-        GS_BGCOLOUR = 0x00ff00; // Green
+        DBGCOL(0x00FF00, SYSHOOK, "WipeUserMemory()");
 
     DPRINTF("t_loadElf: cleaning user memory...");
 
@@ -128,7 +128,7 @@ void sysLoadElf(char *filename, int argc, char **argv)
     DPRINTF(" failed\n");
 
     // Error
-    GS_BGCOLOUR = 0xffffff; // White    - shouldn't happen.
+    DBGCOL(0xFFFFFF, LOADELF, "sysLoadElf() error. hitting function end");
     SleepThread();
 }
 

--- a/ee_core/src/util.c
+++ b/ee_core/src/util.c
@@ -392,3 +392,22 @@ void delay(int count)
             asm("nop\nnop\nnop\nnop");
     }
 }
+
+/*----------------------------------------------------------------------------------------*/
+/* for debug colors                                                                           */
+/*----------------------------------------------------------------------------------------*/
+void BlinkColour(u8 x, u32 colour, u8 forever)
+{
+    u8 i;
+    do {
+        delay(2);
+        BGCOLND(0x000000); // Black
+        //foo
+        for (i = 1; i <= x; i++) {
+            delay(1);
+            BGCOLND(colour); // Chosen colour
+            delay(1);
+            BGCOLND(0x000000); // Black
+        }
+    } while (forever);
+}


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

- When an IRX size is not larger than 0, screen will be set to light blue.
- When an IRX loading returns an error from MODLOAD, the screen will be set to yellow
   - Also, if the error from MODLOAD is (`KE_NO_MEMORY`) the screen will indefinitely blink in the same yellow color
