### PR TITLE
Remove .bmp and .jpg support from OPL.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,8 @@ PNG_ASSETS_DIR = gfx/
 MAPFILE = opl.map
 EE_LDFLAGS += -Wl,-Map,$(MAPFILE)
 
-EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lgskit_toolkit -lpoweroff -lfileXio -lpatches -ljpeg_ps2_addons -ljpeg -lpng -lz -lmc -lfreetype -lvux -lcdvd -lnetman -lps2ips -laudsrv -lvorbisfile -lvorbis -logg -lpadx -lelf-loader-nocolour
-EE_INCS += -I$(PS2SDK)/ports/include -I$(PS2SDK)/ports/include/freetype2 -I$(GSKIT)/include -I$(GSKIT)/ee/dma/include -I$(GSKIT)/ee/gs/include -I$(GSKIT)/ee/toolkit/include -Imodules/iopcore/common -Imodules/network/common -Imodules/hdd/common -Iinclude
-
+EE_LIBS = -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib -L./lib -lgskit -ldmakit -lpoweroff -lfileXio -lpatches -lpng -lz -lmc -lfreetype -lvux -lcdvd -lnetman -lps2ips -laudsrv -lvorbisfile -lvorbis -logg -lpadx -lelf-loader-nocolour
+EE_INCS += -I$(PS2SDK)/ports/include -I$(PS2SDK)/ports/include/freetype2 -I$(GSKIT)/include -I$(GSKIT)/ee/dma/include -I$(GSKIT)/ee/gs/include -Imodules/iopcore/common -Imodules/network/common -Imodules/hdd/common -Iinclude
 BIN2C = $(PS2SDK)/bin/bin2c
 
 # WARNING: Only extra spaces are allowed and ignored at the beginning of the conditional directives (ifeq, ifneq, ifdef, ifndef, else and endif)

--- a/include/atlas.h
+++ b/include/atlas.h
@@ -1,8 +1,6 @@
 #ifndef __ATLAS_H
 #define __ATLAS_H
 
-#include <gsToolkit.h>
-
 struct atlas_allocation_t
 {
     int x, y;

--- a/include/fntsys.h
+++ b/include/fntsys.h
@@ -1,8 +1,6 @@
 #ifndef __FNTSYS_H
 #define __FNTSYS_H
 
-#include <gsToolkit.h>
-
 /// default (built-in) font id
 #define FNT_DEFAULT (0)
 /// Value returned on errors

--- a/include/menusys.h
+++ b/include/menusys.h
@@ -1,7 +1,6 @@
 #ifndef __MENUSYS_H
 #define __MENUSYS_H
 
-#include <gsToolkit.h>
 #include "include/config.h"
 #include "include/dia.h"
 

--- a/include/opl.h
+++ b/include/opl.h
@@ -26,7 +26,6 @@
 #include <debug.h>
 #include <gsKit.h>
 #include <dmaKit.h>
-#include <gsToolkit.h>
 #include <malloc.h>
 #include <math.h>
 #include <osd_config.h>

--- a/include/renderman.h
+++ b/include/renderman.h
@@ -1,8 +1,6 @@
 #ifndef __RENDERMAN_H
 #define __RENDERMAN_H
 
-#include <gsToolkit.h>
-
 /*
  * Rendering using renderman
  *

--- a/include/texcache.h
+++ b/include/texcache.h
@@ -1,7 +1,6 @@
 #ifndef __TEX_CACHE_H
 #define __TEX_CACHE_H
 
-#include <gsToolkit.h>
 #include "include/iosupport.h"
 
 /// A single cache entry...

--- a/include/util.h
+++ b/include/util.h
@@ -1,8 +1,6 @@
 #ifndef __UTIL_H
 #define __UTIL_H
 
-#include <gsToolkit.h>
-
 int getmcID(void);
 int getFileSize(int fd);
 void checkMCFolder(void);

--- a/src/atlas.c
+++ b/src/atlas.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <malloc.h>
+#include "include/opl.h"
 #include "include/atlas.h"
 #include "include/renderman.h"
 

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -7,9 +7,9 @@
 #include <stdio.h>
 #include <kernel.h>
 
+#include "include/opl.h"
 #include "include/renderman.h"
 #include "include/ioman.h"
-#include "include/opl.h"
 
 // Allocateable space in vram, as indicated in GsKit's code
 #define __VRAM_SIZE 4194304

--- a/src/textures.c
+++ b/src/textures.c
@@ -98,9 +98,6 @@ extern void *logo_png;
 extern void *case_png;
 extern void *apps_case_png;
 
-static int texPngLoad(GSTEXTURE *texture, const char *path);
-static int texPngLoadInternal(GSTEXTURE *texture, int texId);
-
 // Not related to screen size, just to limit at some point
 static int maxSize = 720 * 512 * 4;
 
@@ -110,6 +107,24 @@ typedef struct
     char *name;
     void **texture;
 } texture_t;
+
+typedef struct
+{
+    u8 red;
+    u8 green;
+    u8 blue;
+    u8 alpha;
+} png_clut_t;
+
+typedef struct
+{
+    png_colorp palette;
+    int numPalette;
+    int numTrans;
+    png_bytep trans;
+} png_texture_t;
+
+static png_texture_t pngTexture;
 
 static texture_t internalDefault[TEXTURES_COUNT] = {
     {LOAD0_ICON, "load0", &load0_png},
@@ -218,12 +233,12 @@ int texLookupInternalTexId(const char *name)
     return result;
 }
 
-static int texSizeValidate(int width, int height, short psm)
+static int texSizeValidate(int width, int height, u8 psm)
 {
     if (width > 1024 || height > 1024)
         return -1;
 
-    if (gsKit_texture_size(width, height, psm) > maxSize)
+    if (gsKit_texture_size(width, height, (int)psm) > maxSize)
         return -1;
 
     return 0;
@@ -258,55 +273,7 @@ void texFree(GSTEXTURE *texture)
     }
 }
 
-typedef int (*fpTexLoad)(GSTEXTURE *texture, const char *path);
-
-int texDiscoverLoad(GSTEXTURE *texture, const char *path, int texId)
-{
-    char filePath[256];
-
-    LOG("texDiscoverLoad(%s)\n", path);
-
-    if (texId != -1)
-        snprintf(filePath, sizeof(filePath), "%s%s.%s", path, internalDefault[texId].name, "png");
-    else
-        snprintf(filePath, sizeof(filePath), "%s.%s", path, "png");
-
-    int fd = open(filePath, O_RDONLY);
-    if (fd > 0) {
-        // File found, load it
-        close(fd);
-        return (texPngLoad(texture, filePath) >= 0) ? 0 : ERR_BAD_FILE;
-    }
-
-    return ERR_BAD_FILE;
-}
-
-int texLoadInternal(GSTEXTURE *texture, int texId)
-{
-    return texPngLoadInternal(texture, texId);
-}
-
-/// PNG SUPPORT ///////////////////////////////////////////////////////////////////////////////////////
-
-typedef struct
-{
-    u8 red;
-    u8 green;
-    u8 blue;
-    u8 alpha;
-} png_clut_t;
-
-typedef struct
-{
-    png_colorp palette;
-    int numPalette;
-    int numTrans;
-    png_bytep trans;
-} png_texture_t;
-
-static png_texture_t pngTexture;
-
-static int texPngEnd(png_structp pngPtr, png_infop infoPtr, void *pFileBuffer, int status)
+static int texEnd(png_structp pngPtr, png_infop infoPtr, void *pFileBuffer, int status)
 {
     if (pFileBuffer != NULL)
         free(pFileBuffer);
@@ -317,7 +284,7 @@ static int texPngEnd(png_structp pngPtr, png_infop infoPtr, void *pFileBuffer, i
     return status;
 }
 
-static void texPngReadMemFunction(png_structp pngPtr, png_bytep data, png_size_t length)
+static void texReadMemFunction(png_structp pngPtr, png_bytep data, png_size_t length)
 {
     void **PngBufferPtr = png_get_io_ptr(pngPtr);
 
@@ -325,7 +292,7 @@ static void texPngReadMemFunction(png_structp pngPtr, png_bytep data, png_size_t
     *PngBufferPtr = (u8 *)(*PngBufferPtr) + length;
 }
 
-static void texPngReadPixels4(GSTEXTURE *texture, png_bytep *rowPointers, size_t size)
+static void texReadPixels4(GSTEXTURE *texture, png_bytep *rowPointers, size_t size)
 {
     unsigned char *pixel = (unsigned char *)texture->Mem;
     png_clut_t *clut = (png_clut_t *)texture->Clut;
@@ -359,7 +326,7 @@ static void texPngReadPixels4(GSTEXTURE *texture, png_bytep *rowPointers, size_t
         tmpdst[byte] = (tmpsrc[byte] << 4) | (tmpsrc[byte] >> 4);
 }
 
-static void texPngReadPixels8(GSTEXTURE *texture, png_bytep *rowPointers, size_t size)
+static void texReadPixels8(GSTEXTURE *texture, png_bytep *rowPointers, size_t size)
 {
     unsigned char *pixel = (unsigned char *)texture->Mem;
     png_clut_t *clut = (png_clut_t *)texture->Clut;
@@ -396,7 +363,7 @@ static void texPngReadPixels8(GSTEXTURE *texture, png_bytep *rowPointers, size_t
     }
 }
 
-static void texPngReadPixels24(GSTEXTURE *texture, png_bytep *rowPointers, size_t size)
+static void texReadPixels24(GSTEXTURE *texture, png_bytep *rowPointers, size_t size)
 {
     struct pixel3
     {
@@ -412,7 +379,7 @@ static void texPngReadPixels24(GSTEXTURE *texture, png_bytep *rowPointers, size_
     }
 }
 
-static void texPngReadPixels32(GSTEXTURE *texture, png_bytep *rowPointers, size_t size)
+static void texReadPixels32(GSTEXTURE *texture, png_bytep *rowPointers, size_t size)
 {
     struct pixel
     {
@@ -429,8 +396,8 @@ static void texPngReadPixels32(GSTEXTURE *texture, png_bytep *rowPointers, size_
     }
 }
 
-static void texPngReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr,
-                           void (*texPngReadPixels)(GSTEXTURE *texture, png_bytep *rowPointers, size_t size))
+static void texReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop infoPtr,
+                        void (*texPngReadPixels)(GSTEXTURE *texture, png_bytep *rowPointers, size_t size))
 {
     int row, rowBytes = png_get_rowbytes(pngPtr, infoPtr);
     size_t size = gsKit_texture_size_ee(texture->Width, texture->Height, texture->PSM);
@@ -458,7 +425,7 @@ static void texPngReadData(GSTEXTURE *texture, png_structp pngPtr, png_infop inf
     png_read_end(pngPtr, NULL);
 }
 
-static int texPngLoadAll(GSTEXTURE *texture, const char *filePath, int texId)
+static int texLoadAll(GSTEXTURE *texture, const char *filePath, int texId)
 {
     texPrepare(texture);
     png_structp pngPtr = NULL;
@@ -487,14 +454,14 @@ static int texPngLoadAll(GSTEXTURE *texture, const char *filePath, int texId)
         fd = -1;
 
         if (readSize != fileSize) {
-            LOG("texPngLoadAll: failed to read file %s\n", filePath);
+            LOG("texLoadAll: failed to read file %s\n", filePath);
             free(pFileBuffer);
             return ERR_BAD_FILE;
         }
 
         PngFileBufferPtr = pFileBuffer;
         readData = &PngFileBufferPtr;
-        readFunction = &texPngReadMemFunction;
+        readFunction = &texReadMemFunction;
     } else {
         if (texId == -1)
             return ERR_BAD_FILE;
@@ -503,19 +470,19 @@ static int texPngLoadAll(GSTEXTURE *texture, const char *filePath, int texId)
 
         PngFileBufferPtr = internalDefault[texId].texture;
         readData = &PngFileBufferPtr;
-        readFunction = &texPngReadMemFunction;
+        readFunction = &texReadMemFunction;
     }
 
     pngPtr = png_create_read_struct(PNG_LIBPNG_VER_STRING, (png_voidp)NULL, NULL, NULL);
     if (!pngPtr)
-        return texPngEnd(pngPtr, infoPtr, pFileBuffer, ERR_READ_STRUCT);
+        return texEnd(pngPtr, infoPtr, pFileBuffer, ERR_READ_STRUCT);
 
     infoPtr = png_create_info_struct(pngPtr);
     if (!infoPtr)
-        return texPngEnd(pngPtr, infoPtr, pFileBuffer, ERR_INFO_STRUCT);
+        return texEnd(pngPtr, infoPtr, pFileBuffer, ERR_INFO_STRUCT);
 
     if (setjmp(png_jmpbuf(pngPtr)))
-        return texPngEnd(pngPtr, infoPtr, pFileBuffer, ERR_SET_JMP);
+        return texEnd(pngPtr, infoPtr, pFileBuffer, ERR_SET_JMP);
 
     png_set_read_fn(pngPtr, readData, readFunction);
 
@@ -545,11 +512,11 @@ static int texPngLoadAll(GSTEXTURE *texture, const char *filePath, int texId)
     switch (png_get_color_type(pngPtr, infoPtr)) {
         case PNG_COLOR_TYPE_RGB_ALPHA:
             texture->PSM = GS_PSM_CT32;
-            texPngReadPixels = &texPngReadPixels32;
+            texPngReadPixels = &texReadPixels32;
             break;
         case PNG_COLOR_TYPE_RGB:
             texture->PSM = GS_PSM_CT24;
-            texPngReadPixels = &texPngReadPixels24;
+            texPngReadPixels = &texReadPixels24;
             break;
         case PNG_COLOR_TYPE_PALETTE:
             pngTexture.palette = NULL;
@@ -566,37 +533,58 @@ static int texPngLoadAll(GSTEXTURE *texture, const char *filePath, int texId)
                 texture->Clut = memalign(128, gsKit_texture_size_ee(8, 2, GS_PSM_CT32));
                 memset(texture->Clut, 0, gsKit_texture_size_ee(8, 2, GS_PSM_CT32));
 
-                texPngReadPixels = &texPngReadPixels4;
+                texPngReadPixels = &texReadPixels4;
             } else if (bitDepth == 8) {
                 texture->PSM = GS_PSM_T8;
                 texture->Clut = memalign(128, gsKit_texture_size_ee(16, 16, GS_PSM_CT32));
                 memset(texture->Clut, 0, gsKit_texture_size_ee(16, 16, GS_PSM_CT32));
 
-                texPngReadPixels = &texPngReadPixels8;
+                texPngReadPixels = &texReadPixels8;
             } else
-                return texPngEnd(pngPtr, infoPtr, pFileBuffer, ERR_BAD_DEPTH);
+                return texEnd(pngPtr, infoPtr, pFileBuffer, ERR_BAD_DEPTH);
             break;
         default:
-            return texPngEnd(pngPtr, infoPtr, pFileBuffer, ERR_BAD_DEPTH);
+            return texEnd(pngPtr, infoPtr, pFileBuffer, ERR_BAD_DEPTH);
     }
 
     if (texSizeValidate(texture->Width, texture->Height, texture->PSM) < 0) {
         texFree(texture);
 
-        return texPngEnd(pngPtr, infoPtr, pFileBuffer, ERR_BAD_DIMENSION);
+        return texEnd(pngPtr, infoPtr, pFileBuffer, ERR_BAD_DIMENSION);
     }
 
-    texPngReadData(texture, pngPtr, infoPtr, texPngReadPixels);
+    texReadData(texture, pngPtr, infoPtr, texPngReadPixels);
 
-    return texPngEnd(pngPtr, infoPtr, pFileBuffer, 0);
+    return texEnd(pngPtr, infoPtr, pFileBuffer, 0);
 }
 
-static int texPngLoad(GSTEXTURE *texture, const char *filePath)
+static int texLoad(GSTEXTURE *texture, const char *filePath)
 {
-    return texPngLoadAll(texture, filePath, -1);
+    return texLoadAll(texture, filePath, -1);
 }
 
-static int texPngLoadInternal(GSTEXTURE *texture, int texId)
+int texLoadInternal(GSTEXTURE *texture, int texId)
 {
-    return texPngLoadAll(texture, NULL, texId);
+    return texLoadAll(texture, NULL, texId);
+}
+
+int texDiscoverLoad(GSTEXTURE *texture, const char *path, int texId)
+{
+    char filePath[256];
+
+    LOG("texDiscoverLoad(%s)\n", path);
+
+    if (texId != -1)
+        snprintf(filePath, sizeof(filePath), "%s%s.%s", path, internalDefault[texId].name, "png");
+    else
+        snprintf(filePath, sizeof(filePath), "%s.%s", path, "png");
+
+    int fd = open(filePath, O_RDONLY);
+    if (fd > 0) {
+        // File found, load it
+        close(fd);
+        return (texLoad(texture, filePath) >= 0) ? 0 : ERR_BAD_FILE;
+    }
+
+    return ERR_BAD_FILE;
 }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
It removes the .jpg and .bmp format as png is very used and optimized than the both formats, This also reduces the executable size. 
I would like to thanks to: @hardlevel for testing, @KrahJohlito, @AKuHAK, @NathanNeurotic, for ideas. There´s more upcoming...