### PR TITLE
Cheatman: Add user cheat selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ that contains the preferred partition name (for example `__common`).
 </details>
 
 <details>
+  <summary> <b> Cheats </b> </summary>
+<p>
+
+OPL accepts `.cht` files in PS2RD format. Each cheat file corresponds to a specific game and must be stored in the `CHT` directory on your device.
+Cheats are structured as hexadecimal codes, with proper headers as descriptions to identify their function.
+You can activate cheats via OPL's graphical interface. Navigate to a games settings, enable cheats and select the desired mode.
+
+### cheat modes
+
+  * Auto Select Cheats:  
+This mode will enable and apply all cheat codes in your `.cht` file to your game automatically.
+
+  * Select Game Cheats:  
+When enabled a cheat selection menu will appear when you launch a game. You can navigate the menu and disable undesired cheats for this launch session. `Mastercode`s cannot be disabled as they are required for any other cheats to be applied.
+
+</p>
+</details>
+
+<details>
   <summary> <b> NBD Server </b> </summary>
 <p>
 

--- a/ee_core/include/coreconfig.h
+++ b/ee_core/include/coreconfig.h
@@ -45,7 +45,7 @@ struct EECoreConfig_t
     char g_ps2_gateway[16];
     unsigned char g_ps2_ETHOpMode;
 
-    unsigned int *gCheatList; // Store hooks/codes addr+val pairs
+    u32 *gCheatList; // Store hooks/codes addr+val pairs
 
     void *eeloadCopy;
     void *initUserMemory;

--- a/include/cheatman.h
+++ b/include/cheatman.h
@@ -34,11 +34,12 @@
 #include <ctype.h>
 #include <string.h>
 
-#define CHEAT_VERSION "0.5.3.65.g774d1"
+#define CHEAT_VERSION "0.5.3.7"
 
-#define MAX_HOOKS     5
-#define MAX_CODES     250
-#define MAX_CHEATLIST (MAX_HOOKS * 2 + MAX_CODES * 2)
+#define MAX_HOOKS      5
+#define MAX_CODES      250
+#define MAX_CHEATLIST  (MAX_HOOKS * 2 + MAX_CODES * 2)
+#define CHEAT_NAME_MAX 128
 
 /* Some character defines */
 #define NUL         0x00
@@ -59,9 +60,19 @@ typedef struct
     u32 val;
 } code_t;
 
+typedef struct
+{
+    char name[CHEAT_NAME_MAX + 1];
+    code_t codes[MAX_CHEATLIST];
+    int enabled;
+} cheat_entry_t;
+
+extern cheat_entry_t gCheats[MAX_CODES];
+
 void InitCheatsConfig(config_set_t *configSet);
 int GetCheatsEnabled(void);
 const u32 *GetCheatsList(void);
 int load_cheats(const char *cheatfile);
+void set_cheats_list(void);
 
 #endif /* _CHEATMAN_H_ */

--- a/include/gui.h
+++ b/include/gui.h
@@ -156,4 +156,6 @@ int guiConfirmVideoMode(void);
 
 int guiGameShowRemoveSettings(config_set_t *configSet, config_set_t *configGame);
 
+void guiManageCheats(void);
+
 #endif

--- a/lng_tmpl/_base.yml
+++ b/lng_tmpl/_base.yml
@@ -690,3 +690,5 @@ gui_strings:
   string: Analog Y-Axis Sensitivity
 - label: FILE_COUNT
   string: 'Files found: %i'
+- label: CHEAT_SELECTION
+  string: Cheat Selection

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -10,6 +10,7 @@
 #include "include/pggsm.h"
 #include "include/cheatman.h"
 #include "include/ps2cnf.h"
+#include "include/gui.h"
 
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioMount("iso:", ***), fileXioUmount("iso:")
@@ -838,28 +839,20 @@ void sbCreateFolders(const char *path, int createDiscImgFolders)
 int sbLoadCheats(const char *path, const char *file)
 {
     char cheatfile[64];
-    const u32 *cheatList;
-    int result;
+    int cheatMode = 0;
 
     if (GetCheatsEnabled()) {
         snprintf(cheatfile, sizeof(cheatfile), "%sCHT/%s.cht", path, file);
         LOG("Loading Cheat File %s\n", cheatfile);
-        if ((result = load_cheats(cheatfile)) < 0) {
-            LOG("Error: failed to load cheats\n");
-        } else {
-            cheatList = GetCheatsList();
 
-            if (!((cheatList[0] == 0) && (cheatList[1] == 0))) {
-                LOG("Cheats found\n");
-                result = 0;
-            } else {
-                LOG("No cheats found\n");
-                result = -ENOENT;
-            }
+        if ((cheatMode = load_cheats(cheatfile)) < 0)
+            LOG("Error: failed to load cheats\n");
+        else {
+            LOG("Cheats found\n");
+            if ((gAutoLaunchGame == NULL) && (gAutoLaunchBDMGame == NULL) && (cheatMode == 1))
+                guiManageCheats();
         }
-    } else {
-        result = 0;
     }
 
-    return result;
+    return cheatMode;
 }

--- a/src/system.c
+++ b/src/system.c
@@ -900,8 +900,13 @@ void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdv
 
     config->EnableDebug = gEnableDebug;
     config->HDDSpindown = gHDDSpindown;
-    config->gCheatList = GetCheatsEnabled() ? (unsigned int *)GetCheatsList() : NULL;
     config->g_ps2_ETHOpMode = gETHOpMode;
+
+    if (GetCheatsEnabled()) {
+        set_cheats_list();
+        config->gCheatList = GetCheatsList();
+    } else
+        config->gCheatList = NULL;
 
     sprintf(config->g_ps2_ip, "%u.%u.%u.%u", local_ip_address[0], local_ip_address[1], local_ip_address[2], local_ip_address[3]);
     sprintf(config->g_ps2_netmask, "%u.%u.%u.%u", local_netmask[0], local_netmask[1], local_netmask[2], local_netmask[3]);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
This adds a cheat selection menu at game launch if the cheat mode is selected in cheat settings. It will read your cht file and group the title description to the code below and it is that title that will be displayed in the menu, for this reason its a good idea to have your cht files descriptive and concise. See screenshots below for examples.

Also just some general clean ups to the cheat system.

![chtexample](https://github.com/user-attachments/assets/28cfa763-802a-4d6d-a8c2-00b249478e1e)
![mode](https://github.com/user-attachments/assets/1f25796c-143e-4e2d-a5a7-93e4dafffbc0)
![menuss](https://github.com/user-attachments/assets/c6220ebd-561e-4c82-b12a-956c19a559ec)