### PR TITLE
use generic stub for unsuported IOP device OPS

### DIFF
--- a/modules/debug/ps2link/net_fsys.c
+++ b/modules/debug/ps2link/net_fsys.c
@@ -50,13 +50,6 @@ static int fsys_pid = 0;
 // static iop_device_t fsys_driver;
 
 ////////////////////////////////////////////////////////////////////////
-static int dummy5()
-{
-    printf("dummy function called\n");
-    return -5;
-}
-
-////////////////////////////////////////////////////////////////////////
 static void fsysInit(iop_device_t *driver)
 {
     struct _iop_thread mythread;
@@ -303,12 +296,25 @@ static int fsysDclose(int fd)
     return ret;
 }
 
-iop_device_ops_t fsys_functarray = {(void *)fsysInit, (void *)fsysDestroy, (void *)dummy5,
-                                    (void *)fsysOpen, (void *)fsysClose, (void *)fsysRead,
-                                    (void *)fsysWrite, (void *)fsysLseek, (void *)dummy5,
-                                    (void *)fsysRemove, (void *)fsysMkdir, (void *)fsysRmdir,
-                                    (void *)fsysDopen, (void *)fsysDclose, (void *)fsysDread,
-                                    (void *)dummy5, (void *)dummy5};
+iop_device_ops_t fsys_functarray = {
+    (void *)fsysInit,
+    (void *)fsysDestroy,
+    NOT_SUPPORTED,
+    (void *)fsysOpen,
+    (void *)fsysClose,
+    (void *)fsysRead,
+    (void *)fsysWrite,
+    (void *)fsysLseek,
+    NOT_SUPPORTED,
+    (void *)fsysRemove,
+    (void *)fsysMkdir,
+    (void *)fsysRmdir,
+    (void *)fsysDopen,
+    (void *)fsysDclose,
+    (void *)fsysDread,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+};
 
 iop_device_t fsys_driver = {fsname, 16, 1, "fsys driver",
                             &fsys_functarray};

--- a/modules/debug/udptty-ingame/udptty.c
+++ b/modules/debug/udptty-ingame/udptty.c
@@ -41,27 +41,26 @@ static int tty_init(iop_device_t *device);
 static int tty_deinit(iop_device_t *device);
 static int tty_stdout_fd(void);
 static int tty_write(iop_file_t *file, void *buf, size_t size);
-static int tty_error(void);
 
 /* device ops */
 static iop_device_ops_t tty_ops = {
     tty_init,
     tty_deinit,
-    (void *)tty_error,
+    NOT_SUPPORTED,
     (void *)tty_stdout_fd,
     (void *)tty_stdout_fd,
-    (void *)tty_error,
+    NOT_SUPPORTED,
     (void *)tty_write,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error,
-    (void *)tty_error};
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED};
 
 /* device descriptor */
 static iop_device_t tty_device = {
@@ -265,9 +264,4 @@ static int tty_write(iop_file_t *file, void *buf, size_t size)
     SignalSema(tty_sema);
 
     return res;
-}
-
-static int tty_error(void)
-{
-    return -EIO;
 }

--- a/modules/hdd/xhdd/xhdd.c
+++ b/modules/hdd/xhdd/xhdd.c
@@ -18,11 +18,6 @@ static int xhddInit(iop_device_t *device)
     return 0;
 }
 
-static int xhddUnsupported(void)
-{
-    return -1;
-}
-
 static int xhddDevctl(iop_file_t *fd, const char *name, int cmd, void *arg, unsigned int arglen, void *buf, unsigned int buflen)
 {
     ata_devinfo_t *devinfo;
@@ -45,28 +40,28 @@ static int xhddDevctl(iop_file_t *fd, const char *name, int cmd, void *arg, unsi
 
 static iop_device_ops_t xhdd_ops = {
     &xhddInit,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
-    (void *)&xhddUnsupported,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
     &xhddDevctl,
 };
 

--- a/modules/iopcore/cdvdman/dev9.c
+++ b/modules/iopcore/cdvdman/dev9.c
@@ -81,7 +81,6 @@ static int pcmcia_init(void);
 static void expbay_set_stat(int stat);
 static int expbay_init(void);
 
-static int dev9x_dummy(void) { return 0; }
 static int dev9x_devctl(iop_file_t *f, const char *name, int cmd, void *args, int arglen, void *buf, int buflen)
 {
     switch (cmd) {
@@ -98,30 +97,31 @@ static int dev9x_devctl(iop_file_t *f, const char *name, int cmd, void *args, in
 
 /* driver ops func tab */
 static iop_device_ops_t dev9x_ops = {
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
-    (void *)dev9x_dummy,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
     (void *)dev9x_devctl};
+
 
 /* driver descriptor */
 static iop_device_t dev9x_dev = {

--- a/modules/iopcore/imgdrv/imgdrv.c
+++ b/modules/iopcore/imgdrv/imgdrv.c
@@ -10,11 +10,6 @@ unsigned int ioprpimg = 0xDEC1DEC1;
 int ioprpsiz = 0xDEC2DEC2;
 const char name[] = "host";
 
-int dummy_fs()
-{
-    return 0;
-}
-
 int lseek_fs(iop_file_t *fd, int offset, int whence)
 {
     if (whence == SEEK_END) {
@@ -59,15 +54,15 @@ typedef struct _iop_device_ops_tm
 
 iop_device_ops_t my_device_ops =
     {
-        dummy_fs, // init
-        dummy_fs, // deinit
-        NULL,     // dummy_fs,// format
-        dummy_fs, // open_fs,// open
-        close_fs, // close
-        read_fs,  // read
-        NULL,     // dummy_fs,// write
-        lseek_fs, // lseek
-                  /*
+        NOT_SUPPORTED, // init
+        NOT_SUPPORTED, // deinit
+        NOT_SUPPORTED, // format
+        NOT_SUPPORTED, // open
+        NOT_SUPPORTED, // close
+        NOT_SUPPORTED, // read
+        NOT_SUPPORTED, // write
+        NOT_SUPPORTED, // lseek
+                       /*
         dummy_fs, // ioctl
         dummy_fs, // remove
         dummy_fs, // mkdir

--- a/modules/isofs/isofs.c
+++ b/modules/isofs/isofs.c
@@ -67,11 +67,6 @@ struct MountData
 static struct MountData MountPoint;
 static unsigned char cdvdman_buf[2048];
 
-static int IsofsUnsupported(void)
-{
-    return -1;
-}
-
 static int IsofsInit(iop_device_t *device)
 {
     iop_sema_t SemaData;
@@ -603,31 +598,31 @@ static int IsofsUmount(iop_file_t *f, const char *fsname)
 static iop_device_ops_t IsofsDeviceOps = {
     &IsofsInit,
     &IsofsDeinit,
-    (void *)&IsofsUnsupported,
+    NOT_SUPPORTED,
     &IsofsOpen,
     &IsofsClose,
     &IsofsRead,
-    (void *)&IsofsUnsupported,
+    NOT_SUPPORTED,
     &IsofsLseek,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
     &IsofsMount,
     &IsofsUmount,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported,
-    (void *)&IsofsUnsupported};
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED};
 
 static iop_device_t IsofsDevice = {
     "iso",

--- a/modules/vmc/genvmc/genvmc.c
+++ b/modules/vmc/genvmc/genvmc.c
@@ -32,7 +32,6 @@
 IRX_ID(MODNAME, 1, 1);
 
 // driver ops protypes
-static int genvmc_dummy(void);
 static int genvmc_init(iop_device_t *dev);
 static int genvmc_deinit(iop_device_t *dev);
 static int genvmc_devctl(iop_file_t *f, const char *name, int cmd, void *args, unsigned int arglen, void *buf, unsigned int buflen);
@@ -41,31 +40,31 @@ static int genvmc_devctl(iop_file_t *f, const char *name, int cmd, void *args, u
 static iop_device_ops_t genvmc_ops = {
     &genvmc_init,
     &genvmc_deinit,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
     &genvmc_devctl,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy,
-    (void *)genvmc_dummy};
+    NOT_SUPPORTED,
+    NOT_SUPPORTED,
+    NOT_SUPPORTED};
 
 // driver descriptor
 static iop_device_t genvmc_dev = {
@@ -521,12 +520,6 @@ err_out:
     close(genvmc_fh);
 
     return r;
-}
-
-//--------------------------------------------------------------
-static int genvmc_dummy(void)
-{
-    return -EPERM;
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
since ps2dev/ps2sdk/pull/625 was merged

This streamlines the unsuported operations by using the same function and also by returning always the same value: `ENOTSUP`

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
