### PR TITLE
fonts: add per font sizing for themes

### DIFF
--- a/include/fntsys.h
+++ b/include/fntsys.h
@@ -6,6 +6,8 @@
 /// Value returned on errors
 #define FNT_ERROR   (-1)
 
+#define FNTSYS_DEFAULT_SIZE 17
+
 /** Initializes the font subsystem */
 void fntInit();
 
@@ -15,7 +17,7 @@ void fntEnd();
 /** Loads a font from a file path
  * @param path The path to the font file
  * @return font slot id (negative value means error happened) */
-int fntLoadFile(char *path);
+int fntLoadFile(char *path, int fontSize);
 
 /** Reloads the default font */
 int fntLoadDefault(char *path);

--- a/src/themes.c
+++ b/src/themes.c
@@ -1224,8 +1224,18 @@ static void thmLoadFonts(config_set_t *themeConfig, const char *themePath, theme
         const char *fntFile;
         if (configGetStr(themeConfig, fntKey, &fntFile)) {
             snprintf(fullPath, sizeof(fullPath), "%s%s", themePath, fntFile);
-            int fntHandle = fntLoadFile(fullPath);
 
+            int fontSize;
+            char sizeKey[64];
+            if (fntID == 0)
+                snprintf(sizeKey, sizeof(sizeKey), "default_font_size");
+            else
+                snprintf(sizeKey, sizeof(sizeKey), "font%d_size", fntID);
+
+            if (!configGetInt(themeConfig, sizeKey, &fontSize) || fontSize <= 0)
+                fontSize = FNTSYS_DEFAULT_SIZE;
+
+            int fntHandle = fntLoadFile(fullPath, fontSize);
             // Do we have a valid font? Assign the font handle to the theme font slot
             if (fntHandle != FNT_ERROR)
                 theme->fonts[fntID] = fntHandle;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
This adds per font sizing for custom themes.. I wanted per element but might cause performance issues so I think this is a fair compromise.

- cfg entry example: 
```
default_font=myDefaultFont.ttf
default_font_size=20

font1=myOtherFont.ttf
font1_size=12

main3:
 type=ItemsList
 font=0
main4:
 type=ItemText
 font=1
```

so in this example the games list has a font size of 20 using myDefaultFont.ttf and the game id uses a font size of 12 using myOtherFont.ttf.