### PR TITLE
Add aligned_alloc instead of memalign.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ endif
 EE_CFLAGS += -fsingle-precision-constant -DOPL_VERSION=\"$(OPL_VERSION)\"
 
 # There are a few places where the config key/value are truncated, so disable these warnings
-EE_CFLAGS += -Wno-format-truncation -Wno-stringop-truncation
+EE_CFLAGS += -Wno-format-truncation -Wno-stringop-truncation -std=gnu11
 # Generate .d files to track header file dependencies of each object file
 EE_CFLAGS += -MMD -MP
 EE_OBJS += $(FRONTEND_OBJS) $(GFX_OBJS) $(AUDIO_OBJS) $(MISC_OBJS) $(EECORE_OBJS) $(IOP_OBJS)

--- a/src/atlas.c
+++ b/src/atlas.c
@@ -95,7 +95,7 @@ atlas_t *atlasNew(size_t width, size_t height, u8 psm)
 
     size_t txtsize = gsKit_texture_size(width, height, psm);
     atlas->surface.PSM = psm;
-    atlas->surface.Mem = (u32 *)memalign(128, txtsize);
+    atlas->surface.Mem = (u32 *)aligned_alloc(128, txtsize);
     atlas->surface.Vram = 0;
 
     // defaults to no clut

--- a/src/opl.c
+++ b/src/opl.c
@@ -1275,7 +1275,7 @@ static void compatUpdate(item_list_t *support, unsigned char mode, config_set_t 
     result = 0;
     LOG("CompatUpdate: updating for: device %d game %d\n", device, configSet == NULL ? -1 : id);
 
-    if ((HttpBuffer = memalign(64, HTTP_IOBUF_SIZE)) != NULL) {
+    if ((HttpBuffer = aligned_alloc(64, HTTP_IOBUF_SIZE)) != NULL) {
         count = configSet != NULL ? 1 : support->itemGetCount(support);
 
         if (count > 0) {

--- a/src/util.c
+++ b/src/util.c
@@ -194,7 +194,7 @@ void *readFile(char *path, int align, int *size)
         }
 
         if (align > 0)
-            buffer = memalign(64, realSize); // The allocation is aligned to aid the DMA transfers
+            buffer = aligned_alloc(64, realSize); // The allocation is aligned to aid the DMA transfers
         else
             buffer = malloc(realSize);
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [ ] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
aligned_alloc is a c11 function that checks the allignment of the power of two, This was inspired by @israpps suggestion about iop alloc