### PR TITLE
fix cache at theme change

### DIFF
--- a/src/opl.c
+++ b/src/opl.c
@@ -1177,6 +1177,13 @@ void applyConfig(int themeID, int langID, int skipDeviceRefresh)
 
             moduleUpdateMenuInternal(&list_support[i], changed, langChanged);
         }
+    } else {
+        if (changed) {
+            for (int i = 0; i < MODE_COUNT; i++) {
+                if (list_support[i].support && list_support[i].subMenu)
+                    submenuRebuildCache(list_support[i].subMenu);
+            }
+        }
     }
 
     bgmUnMute();


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
This fixes a bug introduced after the multi mass merge. To reproduce the bug load some artwork (covs), change theme and scroll your list; some cached game covers won't match title because device refresh was being skipped at theme change which skipped the cache also. now fixed