### PR TITLE
Improve boot speed

### DIFF
--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -294,8 +294,6 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
     int cacheLoaded = loadISOGameListCache(path, &cache) == 0;
 
     if ((dir = opendir(path)) != NULL) {
-        struct stat statbuf;
-
         size_t base_path_len = strlen(path);
         strcpy(fullpath, path);
         fullpath[base_path_len] = '/';
@@ -353,13 +351,7 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
             game->parts = 1;
             game->media = type;
             game->format = format;
-
-
-            if (stat(fullpath, &statbuf) == 0) {
-                game->sizeMB = statbuf.st_size >> 20;
-            } else {
-                game->sizeMB = 0;
-            }
+            game->sizeMB = 0;
 
             count++;
         }
@@ -763,9 +755,23 @@ void sbRename(base_game_info_t **list, const char *prefix, const char *sep, int 
 config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const char *sep)
 {
     char path[256];
+    struct stat st;
+
     snprintf(path, sizeof(path), "%sCFG%s%s.cfg", prefix, sep, game->startup);
     config_set_t *config = configAlloc(0, NULL, path);
     configRead(config); // Does not matter if the config file could be loaded or not.
+
+    // Get game size if not already set
+    if ((game->sizeMB == 0) && (game->format != GAME_FORMAT_OLD_ISO)) {
+        char gamepath[256];
+
+        snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, game->name, game->extension);
+
+        if (stat(gamepath, &st) == 0)
+            game->sizeMB = st.st_size >> 20;
+        else
+            game->sizeMB = 0;
+    }
 
     configSetStr(config, CONFIG_ITEM_NAME, game->name);
     configSetInt(config, CONFIG_ITEM_SIZE, game->sizeMB);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
By refactoring the scanForISO function we can save a bit of time at launch and by removing the stat calls we can improve the loading times even further.. size is only used to display on the info page so it doesn't make much sense to populate it at boot for every game. This was tested on my fork (which uses an older build environment) but produced great results.

Cache build time from 9 mins down to 3-5mins and cache read time down to 7 seconds from like 5 mins.. has not been tested with "latest" environment so tests are welcome. This will have no affect on APA HDD as it uses different functions which I haven't touched so BDM and SMB only.

Thanks to @mystyq for testing.