### PR TITLE
Revert "Using `exit` instead of `Exit`"

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -379,7 +379,7 @@ void sysExecExit(void)
 {
     // Deinitialize without shutting down active devices.
     deinit(NO_EXCEPTION, IO_MODE_SELECTED_ALL);
-    exit(0);
+    Exit(0);
 }
 
 // Module bits


### PR DESCRIPTION
This pr broke some legacy apps (like popstarter) that relies on OPL environment to not be destroyed.

Reverts ps2homebrew/Open-PS2-Loader#1276

Fixes #1415  #1398 
