### PR TITLE
Limit max BDM UDMA mode to UDMA4 to avoid compatibility issues with various SATA/IDE2SD adapters

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -766,9 +766,13 @@ void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData)
 
     // Query the drive for the highest UDMA mode.
     pDeviceData->ataHighestUDMAMode = fileXioDevctl("xhdd0:", ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, NULL, 0, NULL, 0);
-    if (pDeviceData->ataHighestUDMAMode < 0 || pDeviceData->ataHighestUDMAMode > 7) {
+    if (pDeviceData->ataHighestUDMAMode < 0) {
         // Failed to query highest UDMA mode supported.
-        LOG("Mass device %d is backed by ATA but failed to get highest UDMA mode %d\n", pDeviceData->ataHighestUDMAMode);
+        LOG("Mass device %d is backed by ATA but failed to get highest UDMA mode %d\n", pDeviceData->massDeviceIndex, pDeviceData->ataHighestUDMAMode);
+        pDeviceData->ataHighestUDMAMode = 4;
+    } else if (pDeviceData->ataHighestUDMAMode > 4) {
+        // Limit max UDMA mode to 4 to avoid compatibility issues
+        LOG("Mass device %d supports up to UDMA mode %d, limiting to UDMA 4\n", pDeviceData->massDeviceIndex, pDeviceData->ataHighestUDMAMode);
         pDeviceData->ataHighestUDMAMode = 4;
     }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author

## Pull Request description

Currently, BDM ATA sets UDMA mode to the highest mode supported by device.
This can completely break HDD support as some SATA and IDE2SD adapters are unstable at speeds higher than UDMA 4, even if the drive itself supports higher UDMA modes.

The most compatible solution is to limit max UDMA mode to 4 to avoid all compatibility issues altogether.
Not to mention that using anything higher provides very minimal benefits that are, in my opinion, are not worth the headache.

Fixes #1437, fixes #1463, fixes #1478.
