### PR TITLE
Fixed a bug related to "remember last played game"

### DIFF
--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -372,8 +372,8 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
                             LOG("BDMSUPPORT Cluster Chain OK\n");
                             have_error = 0;
                             bdm_vmc_infos.active = 1;
-                            bdm_vmc_infos.start_sector = (u32)startingLBA;
-                            LOG("BDMSUPPORT VMC slot %d start: 0x%X\n", vmc_id, (u32)startingLBA);
+                            bdm_vmc_infos.start_sector = startingLBA;
+                            LOG("BDMSUPPORT VMC slot %d start: 0x%08x%08x\n", vmc_id, ((u32 *)&startingLBA)[1], ((u32 *)&startingLBA)[0]);
                         } else {
                             LOG("BDMSUPPORT Cluster Chain NG\n");
                             have_error = 2;

--- a/src/gui.c
+++ b/src/gui.c
@@ -1006,24 +1006,18 @@ static void guiHandleOp(struct gui_update_t *item)
             break;
 
         case GUI_OP_APPEND_MENU:
-            result = submenuAppendItem(item->menu.subMenu, item->submenu.icon_id,
-                                       item->submenu.text, item->submenu.id, item->submenu.text_id);
-
-            if (!item->menu.menu->submenu) { // first subitem in list
+            result = submenuAppendItem(item->menu.subMenu, item->submenu.icon_id, item->submenu.text, item->submenu.id, item->submenu.text_id);
+            item->menu.menu->current = result;
+            item->menu.menu->pagestart = result;
+            if (!item->menu.menu->submenu) // first subitem in list
                 item->menu.menu->submenu = result;
-                item->menu.menu->current = result;
-                item->menu.menu->pagestart = result;
-            }
             if (item->submenu.selected) { // remember last played game feature
-                item->menu.menu->current = result;
-                item->menu.menu->pagestart = result;
                 item->menu.menu->remindLast = 1;
 
                 // Last Played Auto Start
                 if ((gAutoStartLastPlayed) && !(KeyPressedOnce))
                     DisableCron = 0; // Release Auto Start Last Played counter
             }
-
             break;
 
         case GUI_OP_SELECT_MENU:

--- a/src/gui.c
+++ b/src/gui.c
@@ -1013,7 +1013,8 @@ static void guiHandleOp(struct gui_update_t *item)
                 item->menu.menu->submenu = result;
                 item->menu.menu->current = result;
                 item->menu.menu->pagestart = result;
-            } else if (item->submenu.selected) { // remember last played game feature
+            }
+            if (item->submenu.selected) { // remember last played game feature
                 item->menu.menu->current = result;
                 item->menu.menu->pagestart = result;
                 item->menu.menu->remindLast = 1;

--- a/src/gui.c
+++ b/src/gui.c
@@ -1006,18 +1006,24 @@ static void guiHandleOp(struct gui_update_t *item)
             break;
 
         case GUI_OP_APPEND_MENU:
-            result = submenuAppendItem(item->menu.subMenu, item->submenu.icon_id, item->submenu.text, item->submenu.id, item->submenu.text_id);
-            item->menu.menu->current = result;
-            item->menu.menu->pagestart = result;
-            if (!item->menu.menu->submenu) // first subitem in list
+            result = submenuAppendItem(item->menu.subMenu, item->submenu.icon_id,
+                                       item->submenu.text, item->submenu.id, item->submenu.text_id);
+
+            if (!item->menu.menu->submenu) { // first subitem in list
                 item->menu.menu->submenu = result;
+                item->menu.menu->current = result;
+                item->menu.menu->pagestart = result;
+            }
             if (item->submenu.selected) { // remember last played game feature
+                item->menu.menu->current = result;
+                item->menu.menu->pagestart = result;
                 item->menu.menu->remindLast = 1;
 
                 // Last Played Auto Start
                 if ((gAutoStartLastPlayed) && !(KeyPressedOnce))
                     DisableCron = 0; // Release Auto Start Last Played counter
             }
+
             break;
 
         case GUI_OP_SELECT_MENU:

--- a/src/gui.c
+++ b/src/gui.c
@@ -1006,13 +1006,13 @@ static void guiHandleOp(struct gui_update_t *item)
             break;
 
         case GUI_OP_APPEND_MENU:
-            result = submenuAppendItem(item->menu.subMenu, item->submenu.icon_id,
-                                       item->submenu.text, item->submenu.id, item->submenu.text_id);
-
+            result = submenuAppendItem(item->menu.subMenu, item->submenu.icon_id, item->submenu.text, item->submenu.id, item->submenu.text_id);
             if (!item->menu.menu->submenu) { // first subitem in list
                 item->menu.menu->submenu = result;
-                item->menu.menu->current = result;
-                item->menu.menu->pagestart = result;
+                if (!item->submenu.selected) {
+                    item->menu.menu->current = result;
+                    item->menu.menu->pagestart = result;
+                }
             }
             if (item->submenu.selected) { // remember last played game feature
                 item->menu.menu->current = result;


### PR DESCRIPTION
When the first game in "gUpdateList" is the "last played game" but doesn't appear at the top of the GameList when "automatic sorting" is enabled, then "remember last played game" will not function.

## Pull Request checklist

Note: these are not necessarily requirements

I reformatted the code with clang-format
I checked to make sure my submission worked