### PR TITLE
fix: SMB games show Size: 0 MiB

### DIFF
--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -762,15 +762,30 @@ config_set_t *sbPopulateConfig(base_game_info_t *game, const char *prefix, const
     configRead(config); // Does not matter if the config file could be loaded or not.
 
     // Get game size if not already set
-    if ((game->sizeMB == 0) && (game->format != GAME_FORMAT_OLD_ISO)) {
+    if (game->sizeMB == 0) {
         char gamepath[256];
 
-        snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, game->name, game->extension);
+        if (game->format == GAME_FORMAT_ISO) {
+            snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, game->name, game->extension);
 
-        if (stat(gamepath, &st) == 0)
-            game->sizeMB = st.st_size >> 20;
-        else
-            game->sizeMB = 0;
+            if (stat(gamepath, &st) == 0)
+                game->sizeMB = st.st_size >> 20;
+        } else if (game->format == GAME_FORMAT_OLD_ISO) {
+            snprintf(gamepath, sizeof(gamepath), "%s%s%s%s%s.%s%s", prefix, sep, game->media == SCECdPS2CD ? "CD" : "DVD", sep, game->startup, game->name, game->extension);
+
+            if (stat(gamepath, &st) == 0)
+                game->sizeMB = st.st_size >> 20;
+        } else if (game->format == GAME_FORMAT_USBLD) {
+            // Calculate total size for multi-part USBLD games
+            int part;
+            unsigned int name_checksum = USBA_crc32(game->name);
+
+            for (part = 0; part < game->parts; part++) {
+                snprintf(gamepath, sizeof(gamepath), "%sul.%08X.%s.%02x", prefix, name_checksum, game->startup, part);
+                if (stat(gamepath, &st) == 0)
+                    game->sizeMB += (st.st_size >> 20);
+            }
+        }
     }
 
     configSetStr(config, CONFIG_ITEM_NAME, game->name);


### PR DESCRIPTION
## Description

Fixes #1670

This PR fixes the issue where SMB games show "Size: 0 MiB" in the game list.

## Root Cause

The sbPopulateConfig function had two issues:
1. It explicitly excluded GAME_FORMAT_OLD_ISO from size calculation
2. It didn't handle GAME_FORMAT_USBLD (multi-part games) at all

## Changes

- Added size calculation for GAME_FORMAT_OLD_ISO with correct path format
- Added size calculation for GAME_FORMAT_USBLD that sums all parts

## Testing

The fix ensures game sizes are calculated for all three game formats:
- ISO: Standard ISO files  
- OLD_ISO: Legacy ISO format with startup prefix
- USBLD: USBExtreme multi-part format

---
*This PR was created with assistance from an AI agent (ClawOSS).*
