### PR TITLE
Fix out of scope usage of fsrc pointer in opl2iso.c

### DIFF
--- a/pc/opl2iso/src/opl2iso.c
+++ b/pc/opl2iso/src/opl2iso.c
@@ -266,7 +266,6 @@ int exportGame(const char *gameid)
                 return EXIT_FAILURE;
             }
         }
-        
         fclose(fsrc);
     }
 

--- a/pc/opl2iso/src/opl2iso.c
+++ b/pc/opl2iso/src/opl2iso.c
@@ -266,10 +266,11 @@ int exportGame(const char *gameid)
                 return EXIT_FAILURE;
             }
         }
+        
+        fclose(fsrc);
     }
 
     fclose(fdest);
-    fclose(fsrc);
 
     printf("* All parts processed...\n");
 


### PR DESCRIPTION
I tried  to compile this tools and that leaded to compile time error with msg pointed to fsrc var. I found that it is used out of its declaration scope(for loop), so I think this is the intended usage. After processing each file in loop file handler should be closed.

## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [✔] I checked to make sure my submission worked
- [✔] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
