### PR TITLE
Load HDD modules on BDM config load/save

### DIFF
--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -52,5 +52,6 @@ void bdmEnumerateDevices();
 
 void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData);
 int bdmWaitForDevice(int deviceId, u32 timeoutMs);
+int bdmHDDIsPresent();
 
 #endif

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -51,5 +51,6 @@ void bdmInitSemaphore();
 void bdmEnumerateDevices();
 
 void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData);
+int bdmWaitForDevice(int deviceId, u32 timeoutMs);
 
 #endif

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -48,6 +48,15 @@ typedef struct
     vmc_spec_t specs;           /* Card specifications */
 } hdd_vmc_infos_t;
 
+typedef enum {
+    HDD_LOADMODULES_STATUS_ERROR = -2,
+    HDD_LOADMODULES_STATUS_UNK = -1,
+    HDD_LOADMODULES_STATUS_NOERROR,
+    HDD_LOADMODULES_STATUS_ALREADYLOADED,
+    HDD_LOADMODULES_STATUS_BUSYLOADING,
+    HDD_LOADMODULES_STATUS_COUNT,
+} hdd_loadmodules_status;
+
 int hddCheck(void);
 u32 hddGetTotalSectors(void);
 int hddIs48bit(void);
@@ -61,7 +70,7 @@ int hddDeleteHDLGame(hdl_game_info_t *ginfo);
 
 void hddInit(item_list_t *itemList);
 item_list_t *hddGetObject(int initOnly);
-void hddLoadModules(void);
+int hddLoadModules(void);
 void hddLoadSupportModules(void);
 void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet);
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -886,3 +886,10 @@ int bdmWaitForDevice(int deviceId, u32 timeoutMs)
         DelayThread(RETRY_DELAY * 1000);
     }
 }
+
+int bdmHDDIsPresent()
+{
+    // the only thing that currently uses ata_device_identify is ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, so this is the best method to check for presence via xhdd (for now anyways)
+    // ideally, we'd only have ata_device_identify
+    return fileXioDevctl("xhdd0:", ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, NULL, 0, NULL, 0) >= 0;
+}

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -18,6 +18,7 @@
 #include <ps2sdkapi.h>
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioIoctl, fileXioDevctl
+#include <delaythread.h>
 
 static int iLinkModLoaded = 0;
 static int mx4sioModLoaded = 0;
@@ -857,4 +858,31 @@ int bdmUpdateDeviceData(item_list_t *itemList)
     if (dir >= 0)
         fileXioDclose(dir);
     return 0;
+}
+
+int bdmWaitForDevice(int deviceId, u32 timeoutMs)
+{
+    const int RETRY_DELAY = 100;
+    char path[16];
+
+    u32 start = GetTimerSystemTime();
+    sprintf(path, "mass%d:/", deviceId);
+
+    while (1) {
+        int dir = fileXioDopen(path);
+
+        if (dir >= 0) {
+            fileXioDclose(dir);
+            return 1; // ready
+        }
+
+        u32 now = GetTimerSystemTime();
+        u32 elapsed_ms = (now - start) / (kBUSCLK / 1000);
+
+        if (elapsed_ms > timeoutMs) {
+            return 0; // timeout
+        }
+
+        DelayThread(RETRY_DELAY * 1000);
+    }
 }

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -30,6 +30,7 @@ extern u8 IOBuffer[2048];
 static unsigned char hddForceUpdate = 0;
 static unsigned char hddHDProKitDetected = 0;
 static unsigned char hddModulesLoadCount = 0;
+static unsigned char hddModulesLoaded = 0;
 static unsigned char hddSupportModulesLoaded = 0;
 
 static char *hddPrefix = "pfs0:";
@@ -174,11 +175,15 @@ static int hddCreateOPLPartition(const char *name)
     return result;
 }
 
-void hddLoadModules(void)
+int hddLoadModules(void)
 {
-    int ret;
+    int retLoadModule;
+    int retStatus = HDD_LOADMODULES_STATUS_UNK;
 
     LOG("HDDSUPPORT LoadModules %d\n", hddModulesLoadCount);
+
+    if (hddModulesLoaded)
+        retStatus = HDD_LOADMODULES_STATUS_ALREADYLOADED;
 
     if (hddModulesLoadCount == 0) {
         // Increment the load count as soon as possible to prevent thread scheduling from allowing another thread to
@@ -193,25 +198,32 @@ void hddLoadModules(void)
         hddHDProKitDetected = hddCheckHDProKit();
         if (hddHDProKitDetected) {
             LOG("[ATAD_HDPRO]:\n");
-            ret = sysLoadModuleBuffer(&hdpro_atad_irx, size_hdpro_atad_irx, 0, NULL);
+            retLoadModule = sysLoadModuleBuffer(&hdpro_atad_irx, size_hdpro_atad_irx, 0, NULL);
             LOG("[XHDD]:\n");
             sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 6, "-hdpro");
         } else {
             LOG("[ATAD]:\n");
-            ret = sysLoadModuleBuffer(&ps2atad_irx, size_ps2atad_irx, 0, NULL);
+            retLoadModule = sysLoadModuleBuffer(&ps2atad_irx, size_ps2atad_irx, 0, NULL);
             LOG("[XHDD]:\n");
             sysLoadModuleBuffer(&xhdd_irx, size_xhdd_irx, 0, NULL);
         }
 
-        if (ret < 0) {
+        if (retLoadModule < 0) {
             LOG("HDD: No HardDisk Drive detected.\n");
             setErrorMessageWithCode(_STR_HDD_NOT_CONNECTED_ERROR, ERROR_HDD_IF_NOT_DETECTED);
-            return;
+            retStatus = HDD_LOADMODULES_STATUS_ERROR;
+        } else {
+            retStatus = HDD_LOADMODULES_STATUS_NOERROR;
+            hddModulesLoaded = 1;
         }
-    } else
+    } else {
         hddModulesLoadCount++;
+        if (!hddModulesLoaded)
+            retStatus = HDD_LOADMODULES_STATUS_BUSYLOADING;
+    }
 
     LOG("HDDSUPPORT LoadModules done\n");
+    return retStatus;
 }
 
 // Returns 1 for MBR/GPT, 0 for APA, and -1 if an error occured

--- a/src/opl.c
+++ b/src/opl.c
@@ -790,7 +790,7 @@ static int checkLoadConfigBDM(int types)
         if (bdm_result)
             is_hdd = 1;
     }
-  
+
     if (bdm_result) {
         configEnd();
         configInit(path);
@@ -1019,7 +1019,7 @@ static int trySaveConfigBDM(int types)
         hddLoadModules();
         bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);
     }
-    
+
     if (bdm_result) {
         configSetMove(path);
         return configWriteMulti(types);

--- a/src/opl.c
+++ b/src/opl.c
@@ -779,6 +779,8 @@ static int checkLoadConfigBDM(int types)
     char path[64];
     int value;
 
+    hddLoadModules();
+
     // check USB
     if (bdmFindPartition(path, "conf_opl.cfg", 0)) {
         configEnd();
@@ -996,6 +998,7 @@ static int trySaveConfigBDM(int types)
 {
     char path[64];
 
+    hddLoadModules();
     // check USB
     if (bdmFindPartition(path, "conf_opl.cfg", 1)) {
         configSetMove(path);

--- a/src/opl.c
+++ b/src/opl.c
@@ -785,15 +785,16 @@ static int checkLoadConfigBDM(int types)
     bdm_result = bdmFindPartition(path, "conf_opl.cfg", 0);
     // if not on USB, check BDM HDD
     if (bdm_result == 0) {
-        hddLoadModules();
-        // we can safely assume mass0 in this instance because this should be the only device if the previous checks failed...
-        // wait for up to 5 seconds for the HDD to spin up and become accessible...
-        if (!bdmWaitForDevice(0, 5000))
-            LOG("checkLoadConfigBDM: HDD check timeout!");
+        if (hddLoadModules() >= 0 && bdmHDDIsPresent()) {
+            // we can safely assume mass0 in this instance because this should be the only device if the previous checks failed...
+            // wait for up to 5 seconds for the HDD to spin up and become accessible...
+            if (!bdmWaitForDevice(0, 5000))
+                LOG("checkLoadConfigBDM: HDD check timeout!");
 
-        bdm_result = bdmFindPartition(path, "conf_opl.cfg", 0);
-        if (bdm_result)
-            is_hdd = 1;
+            bdm_result = bdmFindPartition(path, "conf_opl.cfg", 0);
+            if (bdm_result)
+                is_hdd = 1;
+        }
     }
 
     if (bdm_result) {
@@ -1021,13 +1022,14 @@ static int trySaveConfigBDM(int types)
     bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);
     // if not on USB, check BDM HDD
     if (bdm_result == 0) {
-        hddLoadModules();
-        // we can safely assume mass0 in this instance because this should be the only device if the previous checks failed...
-        // wait for up to 5 seconds for the HDD to spin up and become accessible...
-        if (!bdmWaitForDevice(0, 5000))
-            LOG("trySaveConfigBDM: HDD check timeout!");
+        if (hddLoadModules() >= 0 && bdmHDDIsPresent()) {
+            // we can safely assume mass0 in this instance because this should be the only device if the previous checks failed...
+            // wait for up to 5 seconds for the HDD to spin up and become accessible...
+            if (!bdmWaitForDevice(0, 5000))
+                LOG("trySaveConfigBDM: HDD check timeout!");
 
-        bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);
+            bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);
+        }
     }
 
     if (bdm_result) {

--- a/src/opl.c
+++ b/src/opl.c
@@ -786,6 +786,11 @@ static int checkLoadConfigBDM(int types)
     // if not on USB, check BDM HDD
     if (bdm_result == 0) {
         hddLoadModules();
+        // we can safely assume mass0 in this instance because this should be the only device if the previous checks failed...
+        // wait for up to 5 seconds for the HDD to spin up and become accessible...
+        if (!bdmWaitForDevice(0, 5000))
+            LOG("checkLoadConfigBDM: HDD check timeout!");
+
         bdm_result = bdmFindPartition(path, "conf_opl.cfg", 0);
         if (bdm_result)
             is_hdd = 1;
@@ -1017,6 +1022,11 @@ static int trySaveConfigBDM(int types)
     // if not on USB, check BDM HDD
     if (bdm_result == 0) {
         hddLoadModules();
+        // we can safely assume mass0 in this instance because this should be the only device if the previous checks failed...
+        // wait for up to 5 seconds for the HDD to spin up and become accessible...
+        if (!bdmWaitForDevice(0, 5000))
+            LOG("trySaveConfigBDM: HDD check timeout!");
+
         bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);
     }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Repeat of: https://github.com/ps2homebrew/Open-PS2-Loader/pull/1491

Loading of HDD modules before doing BDM operations ensures that the configs can be read off of the internal HDD partition at boot up.

Since last time, I've also implemented a 5s wait timeout for the HDD to spin up. I've noticed that my previous code broke with a HDD (while it worked fine on an SSD). This is implemented through a new function `bdmWaitForDevice` which simply polls the directory every 100ms until it becomes available within a certain timeout.

Fixes https://github.com/ps2homebrew/Open-PS2-Loader/issues/1489