### PR TITLE
fix(compat): add SLES-51114 audio compatibility settings

### DIFF
--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -547,6 +547,17 @@ int sbProbeISO9660(const char *path, base_game_info_t *game, u32 layer1_offset)
     return result;
 }
 
+// Known game-specific default compat settings.
+// Returns compatmask to use when no per-game config exists.
+static int sbGetDefaultCompatForGame(const char *gameid)
+{
+    // Pro Evolution Soccer 2 (Europe) - audio streaming issues need Accurate Reads
+    if (!strncmp("SLES_511.14", gameid, 11))
+        return COMPAT_MODE_1; // Accurate Reads
+
+    return 0;
+}
+
 static const struct cdvdman_settings_common cdvdman_settings_common_sample = CDVDMAN_SETTINGS_DEFAULT_COMMON;
 
 int sbPrepare(base_game_info_t *game, config_set_t *configSet, int size_cdvdman, void **cdvdman_irx, int *patchindex)
@@ -559,6 +570,13 @@ int sbPrepare(base_game_info_t *game, config_set_t *configSet, int size_cdvdman,
 
     char gameid[5];
     configGetDiscIDBinary(configSet, gameid);
+
+    // Apply known defaults for specific games when no per-game config exists.
+    if (compatmask == 0) {
+        int defaultCompat = sbGetDefaultCompatForGame(gameid);
+        if (defaultCompat != 0)
+            compatmask = defaultCompat;
+    }
 
     for (i = 0, settings = NULL; i < size_cdvdman; i += 4) {
         if (!memcmp((void *)((u8 *)cdvdman_irx + i), &cdvdman_settings_common_sample, sizeof(cdvdman_settings_common_sample))) {


### PR DESCRIPTION
## Description

Pro Evolution Soccer 2 (SLES-51114) has audio streaming issues when loading via Open-PS2-Loader. This fix adds Accurate Reads (COMPAT_MODE_1) as the default compat setting for this specific game ID, so audio plays correctly without requiring users to manually create a per-game config file.

## Fix Details

The fix adds a `sbGetDefaultCompatForGame()` function in `src/supportbase.c` that returns known-good default compat settings for specific games. When no per-game config exists (`compatmask == 0`), this function is consulted to apply defaults.

Currently applied defaults:
- **SLES_511.14** (Pro Evolution Soccer 2 Europe): `COMPAT_MODE_1` (Accurate Reads) - fixes audio streaming issues

## Testing

Users can test by:
1. Loading Pro Evolution Soccer 2 (SLES-51114) via OPL
2. Checking if audio plays correctly during gameplay

If audio still has issues, users can create a per-game config file `SLES_51114.cfg` in their OPL config directory with additional settings.

Fixes #1686