### PR TITLE
improve BDM HDD detection logic

### DIFF
--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -52,6 +52,7 @@ void bdmEnumerateDevices();
 
 void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData);
 int bdmWaitForDevice(int deviceId, u32 timeoutMs);
+int bdmDeviceIsPresent(int deviceId);
 int bdmHDDIsPresent();
 
 #endif

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -51,8 +51,6 @@ void bdmInitSemaphore();
 void bdmEnumerateDevices();
 
 void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData);
-int bdmWaitForDevice(int deviceId, u32 timeoutMs);
-int bdmDeviceIsPresent(int deviceId);
-int bdmHDDIsPresent();
+int bdmHDDIsPresent(u32 timeoutMs);
 
 #endif

--- a/include/hddsupport.h
+++ b/include/hddsupport.h
@@ -73,5 +73,6 @@ item_list_t *hddGetObject(int initOnly);
 int hddLoadModules(void);
 void hddLoadSupportModules(void);
 void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet);
+int hddIsPresent();
 
 #endif

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -974,7 +974,6 @@ int bdmHDDIsPresent(u32 timeoutMs)
         // if we haven't timed out already, then we need to wait for the devices to wake up... wait for the timeout...
         LOG("bdmHDDIsPresent: waiting for timeout before scanning again...\n", hdd_id);
         DelayThread(timeoutMs * 1000);
-        timedout = 1;
     }
 
     return bdmGetATADeviceId() >= 0;

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -887,6 +887,20 @@ int bdmWaitForDevice(int deviceId, u32 timeoutMs)
     }
 }
 
+int bdmDeviceIsPresent(int deviceId)
+{
+    char path[16];
+    sprintf(path, "mass%d:/", deviceId);
+    int dir = fileXioDopen(path);
+
+    if (dir >= 0) {
+        fileXioDclose(dir);
+        return 1; // ready
+    }
+
+    return 0;
+}
+
 int bdmHDDIsPresent()
 {
     // the only thing that currently uses ata_device_identify is ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, so this is the best method to check for presence via xhdd (for now anyways)

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -860,7 +860,7 @@ int bdmUpdateDeviceData(item_list_t *itemList)
     return 0;
 }
 
-int bdmWaitForDevice(int deviceId, u32 timeoutMs)
+static int bdmWaitForDevice(int deviceId, u32 timeoutMs)
 {
     const int RETRY_DELAY = 100;
     char path[16];
@@ -887,7 +887,14 @@ int bdmWaitForDevice(int deviceId, u32 timeoutMs)
     }
 }
 
-int bdmDeviceIsPresent(int deviceId)
+static int bdmHDDDeviceIsPresent()
+{
+    // the only thing that currently uses ata_device_identify is ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, so this is the best method to check for presence via xhdd (for now anyways)
+    // ideally, we'd only have ata_device_identify
+    return fileXioDevctl("xhdd0:", ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, NULL, 0, NULL, 0) >= 0;
+}
+
+static int bdmDeviceIsPresent(int deviceId)
 {
     char path[16];
     sprintf(path, "mass%d:/", deviceId);
@@ -901,9 +908,74 @@ int bdmDeviceIsPresent(int deviceId)
     return 0;
 }
 
-int bdmHDDIsPresent()
+static int bdmDeviceIsATA(int deviceId)
 {
-    // the only thing that currently uses ata_device_identify is ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, so this is the best method to check for presence via xhdd (for now anyways)
-    // ideally, we'd only have ata_device_identify
-    return fileXioDevctl("xhdd0:", ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, NULL, 0, NULL, 0) >= 0;
+    char path[16];
+    bdm_device_data_t data;
+
+    sprintf(path, "mass%d:/", deviceId);
+    int dir = fileXioDopen(path);
+    if (dir < 0)
+        return 0;
+
+    fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, &data.bdmDriver, sizeof(data.bdmDriver) - 1);
+    fileXioDclose(dir);
+
+    return (!strcmp(data.bdmDriver, "ata") && strlen(data.bdmDriver) == 3);
+}
+
+static int bdmGetATADeviceId()
+{
+    for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+        if (bdmDeviceIsATA(i)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int bdmHDDIsPresent(u32 timeoutMs)
+{
+    int hdd_id = -1;
+    int timedout = 0;
+
+    if (!bdmHDDDeviceIsPresent())
+        return 0;
+
+    // 1. scan via normal methods first...
+    hdd_id = bdmGetATADeviceId();
+    if (hdd_id >= 0)
+        return 1;
+
+    // 2. try to scan as fast as possible if the previous scan fails...
+    hdd_id = 0;
+
+    for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+        // find the first inaccessible device - this one should be the HDD once it's mounted (we don't have access to device data at this point yet!)
+        if (!bdmDeviceIsPresent(i)) {
+            hdd_id = i;
+            break;
+        }
+    }
+
+    if (bdmWaitForDevice(hdd_id, timeoutMs)) {
+        // double-check to see if this indeed is the HDD, and if it is, we can exit early without stalling any further
+        if (bdmDeviceIsATA(hdd_id)) {
+            return 1;
+        } else
+            LOG("bdmHDDIsPresent: device at id %d is not an ATA HDD...\n", hdd_id);
+    } else {
+        timedout = 1;
+        LOG("bdmHDDIsPresent: waiting for hdd at id %d timed out...\n", hdd_id);
+    }
+
+    // 3. last resort - time out (if needed) and scan again...
+    if (!timedout) {
+        // if we haven't timed out already, then we need to wait for the devices to wake up... wait for the timeout...
+        LOG("bdmHDDIsPresent: waiting for timeout before scanning again...\n", hdd_id);
+        DelayThread(timeoutMs * 1000);
+        timedout = 1;
+    }
+
+    return bdmGetATADeviceId() >= 0;
 }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -887,13 +887,6 @@ static int bdmWaitForDevice(int deviceId, u32 timeoutMs)
     }
 }
 
-static int bdmHDDDeviceIsPresent()
-{
-    // the only thing that currently uses ata_device_identify is ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, so this is the best method to check for presence via xhdd (for now anyways)
-    // ideally, we'd only have ata_device_identify
-    return fileXioDevctl("xhdd0:", ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, NULL, 0, NULL, 0) >= 0;
-}
-
 static int bdmDeviceIsPresent(int deviceId)
 {
     char path[16];
@@ -939,7 +932,7 @@ int bdmHDDIsPresent(u32 timeoutMs)
     int hdd_id = -1;
     int timedout = 0;
 
-    if (!bdmHDDDeviceIsPresent())
+    if (!hddIsPresent())
         return 0;
 
     // 1. scan via normal methods first...

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -816,6 +816,13 @@ static int hddUpdateGameListCache(hdl_games_list_t *cache, hdl_games_list_t *gam
     return result;
 }
 
+int hddIsPresent()
+{
+    // the only thing that currently uses ata_device_identify is ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, so this is the best method to check for presence via xhdd (for now anyways)
+    // ideally, we'd only have ata_device_identify
+    return fileXioDevctl("xhdd0:", ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, NULL, 0, NULL, 0) >= 0;
+}
+
 static char *hddGetPrefix(item_list_t *itemList)
 {
     return gHDDPrefix;

--- a/src/opl.c
+++ b/src/opl.c
@@ -780,25 +780,13 @@ static int checkLoadConfigBDM(int types)
     int value;
     int bdm_result;
     int is_hdd = 0;
-    int hdd_id = BDM_TYPE_ATA;
 
     // check USB
     bdm_result = bdmFindPartition(path, "conf_opl.cfg", 0);
     // if not on USB, check BDM HDD
     if (bdm_result == 0) {
-        // find the first inaccessible device - this one should be the HDD once it's mounted (we don't have access to device data at this point yet!)
-        for (int i = 0; i < MAX_BDM_DEVICES; i++) {
-            if (!bdmDeviceIsPresent(i)) {
-                hdd_id = i;
-                break;
-            }
-        }
-
-        if (hddLoadModules() >= 0 && bdmHDDIsPresent()) {
-            // wait for up to 5 seconds for the HDD to spin up and become accessible...
-            if (!bdmWaitForDevice(hdd_id, 5000))
-                LOG("checkLoadConfigBDM: HDD check timeout!");
-
+        // wait for up to 5 seconds for the HDD to spin up and become accessible...
+        if (hddLoadModules() >= 0 && bdmHDDIsPresent(5000)) {
             bdm_result = bdmFindPartition(path, "conf_opl.cfg", 0);
             if (bdm_result)
                 is_hdd = 1;
@@ -1025,25 +1013,13 @@ static int trySaveConfigBDM(int types)
 {
     char path[64];
     int bdm_result;
-    int hdd_id = BDM_TYPE_ATA;
 
     // check USB
     bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);
     // if not on USB, check BDM HDD
     if (bdm_result == 0) {
-        // find the first inaccessible device - this one should be the HDD once it's mounted (we don't have access to device data at this point yet!)
-        for (int i = 0; i < MAX_BDM_DEVICES; i++) {
-            if (!bdmDeviceIsPresent(i)) {
-                hdd_id = i;
-                break;
-            }
-        }
-
-        if (hddLoadModules() >= 0 && bdmHDDIsPresent()) {
-            // wait for up to 5 seconds for the HDD to spin up and become accessible...
-            if (!bdmWaitForDevice(hdd_id, 5000))
-                LOG("trySaveConfigBDM: HDD check timeout!");
-
+        // wait for up to 5 seconds for the HDD to spin up and become accessible...
+        if (hddLoadModules() >= 0 && bdmHDDIsPresent(5000)) {
             bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);
         }
     }

--- a/src/opl.c
+++ b/src/opl.c
@@ -780,15 +780,23 @@ static int checkLoadConfigBDM(int types)
     int value;
     int bdm_result;
     int is_hdd = 0;
+    int hdd_id = BDM_TYPE_ATA;
 
     // check USB
     bdm_result = bdmFindPartition(path, "conf_opl.cfg", 0);
     // if not on USB, check BDM HDD
     if (bdm_result == 0) {
+        // find the first inaccessible device - this one should be the HDD once it's mounted (we don't have access to device data at this point yet!)
+        for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+            if (!bdmDeviceIsPresent(i)) {
+                hdd_id = i;
+                break;
+            }
+        }
+
         if (hddLoadModules() >= 0 && bdmHDDIsPresent()) {
-            // we can safely assume mass0 in this instance because this should be the only device if the previous checks failed...
             // wait for up to 5 seconds for the HDD to spin up and become accessible...
-            if (!bdmWaitForDevice(0, 5000))
+            if (!bdmWaitForDevice(hdd_id, 5000))
                 LOG("checkLoadConfigBDM: HDD check timeout!");
 
             bdm_result = bdmFindPartition(path, "conf_opl.cfg", 0);
@@ -1017,15 +1025,23 @@ static int trySaveConfigBDM(int types)
 {
     char path[64];
     int bdm_result;
+    int hdd_id = BDM_TYPE_ATA;
 
     // check USB
     bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);
     // if not on USB, check BDM HDD
     if (bdm_result == 0) {
+        // find the first inaccessible device - this one should be the HDD once it's mounted (we don't have access to device data at this point yet!)
+        for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+            if (!bdmDeviceIsPresent(i)) {
+                hdd_id = i;
+                break;
+            }
+        }
+
         if (hddLoadModules() >= 0 && bdmHDDIsPresent()) {
-            // we can safely assume mass0 in this instance because this should be the only device if the previous checks failed...
             // wait for up to 5 seconds for the HDD to spin up and become accessible...
-            if (!bdmWaitForDevice(0, 5000))
+            if (!bdmWaitForDevice(hdd_id, 5000))
                 LOG("trySaveConfigBDM: HDD check timeout!");
 
             bdm_result = bdmFindPartition(path, "conf_opl.cfg", 1);


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Improved the BDM HDD detection logic. 

Instead of assuming mass0 for the HDD, it will now try to find the first unmounted device, which should resolve the edge case of the user having another BDM device without an OPL config on it.

Fixes: https://github.com/ps2homebrew/Open-PS2-Loader/issues/1696