### PR TITLE
atad: implement readiness checks during init

### DIFF
--- a/modules/iopcore/cdvdman/atad.c
+++ b/modules/iopcore/cdvdman/atad.c
@@ -37,7 +37,7 @@
 #include <errno.h>
 #endif
 
-//#define NETLOG_DEBUG
+// #define NETLOG_DEBUG
 
 #ifdef NETLOG_DEBUG
 // !!! netlog exports functions pointers !!!
@@ -119,6 +119,47 @@ static void ata_set_dir(int dir);
 static void ata_shutdown_cb(void);
 
 int ata_device_sector_io_internal(int device, void *buf, u64 lba, u32 nsectors, int dir);
+
+/* Wait until the ATA device becomes basically ready for commands.
+   BUSY must be clear (spin-up / firmware init done).
+   DRDY is validated later by ata_wait_for_ready() according to ATA spec.
+*/
+static int ata_wait_for_busy_clear(int timeout)
+{
+    USE_ATA_REGS;
+
+    for (int waited = 0; waited < timeout; waited++) {
+        if (!(ata_hwport->r_status & ATA_STAT_BUSY))
+            return 0;
+
+        DelayThread(1000);
+    }
+
+    M_PRINTF("ata_wait_for_busy_clear TIMEOUT after %d ms\n", timeout);
+    return ATA_RES_ERR_TIMEOUT;
+}
+
+static int ata_wait_for_ready(int timeout)
+{
+    USE_ATA_REGS;
+
+    for (int waited = 0; waited < timeout; waited++) {
+        u8 status = ata_hwport->r_status;
+
+        if (!(status & ATA_STAT_BUSY) && (status & ATA_STAT_READY))
+            return 0;
+
+        if (status & ATA_STAT_ERR) {
+            M_PRINTF("ata_wait_for_ready ERR: status=0x%02x err=0x%02x\n", status, sceAtaGetError());
+            return ATA_RES_ERR_IO;
+        }
+
+        DelayThread(1000);
+    }
+
+    M_PRINTF("ata_wait_for_ready TIMEOUT after %d ms\n", timeout);
+    return ATA_RES_ERR_TIMEOUT;
+}
 
 /* In v1.04, DMA was enabled in ata_set_dir() instead. */
 static void ata_pre_dma_cb(int bcr, int dir)
@@ -205,6 +246,14 @@ int atad_start(void)
     bdm_connect_bd(&g_ata_bd);
 #endif
 
+    res = ata_wait_for_busy_clear(30000);
+    if (res < 0)
+        goto out;
+
+    res = ata_wait_for_ready(5000);
+    if (res < 0)
+        goto out;
+
     res = 0;
     M_PRINTF("Driver loaded.\n");
 out:
@@ -241,7 +290,7 @@ int sceAtaGetError(void)
 #define ata_wait_bus_busy() gen_ata_wait_busy(ATA_WAIT_BUSBUSY)
 
 /* 0x80 for busy, 0x88 for bus busy.
-	In the original ATAD, the busy and bus-busy functions were separate, but similar.  */
+    In the original ATAD, the busy and bus-busy functions were separate, but similar.  */
 static int gen_ata_wait_busy(int bits)
 {
     USE_ATA_REGS;
@@ -293,20 +342,20 @@ static int ata_device_select(int device)
     /* Select the device.  */
     ata_hwport->r_select = (device & 1) << 4;
     (void)(ata_hwport->r_control);
-    (void)(ata_hwport->r_control); //Only done once in v1.04.
+    (void)(ata_hwport->r_control); // Only done once in v1.04.
 
     return ata_wait_bus_busy();
 }
 
 /* Export 6 */
 /*
-	28-bit LBA:
-		sector	(7:0)	-> LBA (7:0)
-		lcyl	(7:0)	-> LBA (15:8)
-		hcyl	(7:0)	-> LBA (23:16)
-		device	(3:0)	-> LBA (27:24)
+    28-bit LBA:
+        sector	(7:0)	-> LBA (7:0)
+        lcyl	(7:0)	-> LBA (15:8)
+        hcyl	(7:0)	-> LBA (23:16)
+        device	(3:0)	-> LBA (27:24)
 
-	48-bit LBA just involves writing the upper 24 bits in the format above into each respective register on the first write pass, before writing the lower 24 bits in the 2nd write pass. The LBA bits within the device field are not used in either write pass.
+    48-bit LBA just involves writing the upper 24 bits in the format above into each respective register on the first write pass, before writing the lower 24 bits in the 2nd write pass. The LBA bits within the device field are not used in either write pass.
 */
 int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector, u16 lcyl, u16 hcyl, u16 select, u16 command)
 {
@@ -323,7 +372,7 @@ int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector,
         return res;
 
     /* For the SCE and SMART commands, we need to search on the subcommand
-	specified in the feature register.  */
+    specified in the feature register.  */
     if (command == ATA_C_SMART) {
         cmd_table = smart_cmd_table;
         cmd_table_size = SMART_CMD_TABLE_SIZE;
@@ -342,7 +391,7 @@ int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector,
         }
     }
 
-    if (!(atad_cmd_state.type = type & 0x7F)) //Non-SONY: ignore the 48-bit LBA flag.
+    if (!(atad_cmd_state.type = type & 0x7F)) // Non-SONY: ignore the 48-bit LBA flag.
         return ATA_RES_ERR_CMD;
 
     atad_cmd_state.buf = buf;
@@ -365,7 +414,7 @@ int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector,
 
     /* Does this command need a timeout?  */
     using_timeout = 0;
-    switch (type & 0x7F) { //Non-SONY: ignore the 48-bit LBA flag.
+    switch (type & 0x7F) { // Non-SONY: ignore the 48-bit LBA flag.
         case 1:
         case 6:
             using_timeout = 1;
@@ -391,11 +440,11 @@ int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector,
     /* Finally!  We send off the ATA command with arguments.  */
     ata_hwport->r_control = (using_timeout == 0) << 1;
 
-    if (type & 0x80) { //For the sake of achieving (greatly) improved performance, write the registers twice only if required! This is also required for compatibility with the buggy firmware of certain PSX units.
+    if (type & 0x80) { // For the sake of achieving (greatly) improved performance, write the registers twice only if required! This is also required for compatibility with the buggy firmware of certain PSX units.
         /* 48-bit LBA requires writing to the address registers twice,
-		   24 bits of the LBA address is written each time.
-		   Writing to registers twice does not affect 28-bit LBA since
-		   only the latest data stored in address registers is used.  */
+           24 bits of the LBA address is written each time.
+           Writing to registers twice does not affect 28-bit LBA since
+           only the latest data stored in address registers is used.  */
         ata_hwport->r_feature = (feature >> 8) & 0xff;
         ata_hwport->r_nsector = (nsector >> 8) & 0xff;
         ata_hwport->r_sector = (sector >> 8) & 0xff;
@@ -408,7 +457,7 @@ int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector,
     ata_hwport->r_sector = sector & 0xff;
     ata_hwport->r_lcyl = lcyl & 0xff;
     ata_hwport->r_hcyl = hcyl & 0xff;
-    ata_hwport->r_select = (select | ATA_SEL_LBA) & 0xff; //In v1.04, LBA was enabled in the sceAtaDmaTransfer function.
+    ata_hwport->r_select = (select | ATA_SEL_LBA) & 0xff; // In v1.04, LBA was enabled in the sceAtaDmaTransfer function.
     ata_hwport->r_command = command & 0xff;
 
     /* Turn on the LED.  */
@@ -691,7 +740,7 @@ static void ata_set_dir(int dir)
     val = SPD_REG16(SPD_R_IF_CTRL) & 1;
     val |= (dir == ATA_DIR_WRITE) ? 0x4c : 0x4e;
     SPD_REG16(SPD_R_IF_CTRL) = val;
-    SPD_REG16(SPD_R_XFR_CTRL) = dir | (ata_gamestar_workaround ? 0x86 : 0x6); //In v1.04, DMA was enabled here (0x86 instead of 0x6)
+    SPD_REG16(SPD_R_XFR_CTRL) = dir | (ata_gamestar_workaround ? 0x86 : 0x6); // In v1.04, DMA was enabled here (0x86 instead of 0x6)
 }
 
 static int ata_device_standby_immediate(int device)

--- a/modules/iopcore/cdvdman/atad.c
+++ b/modules/iopcore/cdvdman/atad.c
@@ -37,7 +37,7 @@
 #include <errno.h>
 #endif
 
-// #define NETLOG_DEBUG
+//#define NETLOG_DEBUG
 
 #ifdef NETLOG_DEBUG
 // !!! netlog exports functions pointers !!!
@@ -290,7 +290,7 @@ int sceAtaGetError(void)
 #define ata_wait_bus_busy() gen_ata_wait_busy(ATA_WAIT_BUSBUSY)
 
 /* 0x80 for busy, 0x88 for bus busy.
-    In the original ATAD, the busy and bus-busy functions were separate, but similar.  */
+	In the original ATAD, the busy and bus-busy functions were separate, but similar.  */
 static int gen_ata_wait_busy(int bits)
 {
     USE_ATA_REGS;
@@ -342,20 +342,20 @@ static int ata_device_select(int device)
     /* Select the device.  */
     ata_hwport->r_select = (device & 1) << 4;
     (void)(ata_hwport->r_control);
-    (void)(ata_hwport->r_control); // Only done once in v1.04.
+    (void)(ata_hwport->r_control); //Only done once in v1.04.
 
     return ata_wait_bus_busy();
 }
 
 /* Export 6 */
 /*
-    28-bit LBA:
-        sector	(7:0)	-> LBA (7:0)
-        lcyl	(7:0)	-> LBA (15:8)
-        hcyl	(7:0)	-> LBA (23:16)
-        device	(3:0)	-> LBA (27:24)
+	28-bit LBA:
+		sector	(7:0)	-> LBA (7:0)
+		lcyl	(7:0)	-> LBA (15:8)
+		hcyl	(7:0)	-> LBA (23:16)
+		device	(3:0)	-> LBA (27:24)
 
-    48-bit LBA just involves writing the upper 24 bits in the format above into each respective register on the first write pass, before writing the lower 24 bits in the 2nd write pass. The LBA bits within the device field are not used in either write pass.
+	48-bit LBA just involves writing the upper 24 bits in the format above into each respective register on the first write pass, before writing the lower 24 bits in the 2nd write pass. The LBA bits within the device field are not used in either write pass.
 */
 int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector, u16 lcyl, u16 hcyl, u16 select, u16 command)
 {
@@ -372,7 +372,7 @@ int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector,
         return res;
 
     /* For the SCE and SMART commands, we need to search on the subcommand
-    specified in the feature register.  */
+	specified in the feature register.  */
     if (command == ATA_C_SMART) {
         cmd_table = smart_cmd_table;
         cmd_table_size = SMART_CMD_TABLE_SIZE;
@@ -391,7 +391,7 @@ int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector,
         }
     }
 
-    if (!(atad_cmd_state.type = type & 0x7F)) // Non-SONY: ignore the 48-bit LBA flag.
+    if (!(atad_cmd_state.type = type & 0x7F)) //Non-SONY: ignore the 48-bit LBA flag.
         return ATA_RES_ERR_CMD;
 
     atad_cmd_state.buf = buf;
@@ -414,7 +414,7 @@ int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector,
 
     /* Does this command need a timeout?  */
     using_timeout = 0;
-    switch (type & 0x7F) { // Non-SONY: ignore the 48-bit LBA flag.
+    switch (type & 0x7F) { //Non-SONY: ignore the 48-bit LBA flag.
         case 1:
         case 6:
             using_timeout = 1;
@@ -440,11 +440,11 @@ int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector,
     /* Finally!  We send off the ATA command with arguments.  */
     ata_hwport->r_control = (using_timeout == 0) << 1;
 
-    if (type & 0x80) { // For the sake of achieving (greatly) improved performance, write the registers twice only if required! This is also required for compatibility with the buggy firmware of certain PSX units.
+    if (type & 0x80) { //For the sake of achieving (greatly) improved performance, write the registers twice only if required! This is also required for compatibility with the buggy firmware of certain PSX units.
         /* 48-bit LBA requires writing to the address registers twice,
-           24 bits of the LBA address is written each time.
-           Writing to registers twice does not affect 28-bit LBA since
-           only the latest data stored in address registers is used.  */
+		   24 bits of the LBA address is written each time.
+		   Writing to registers twice does not affect 28-bit LBA since
+		   only the latest data stored in address registers is used.  */
         ata_hwport->r_feature = (feature >> 8) & 0xff;
         ata_hwport->r_nsector = (nsector >> 8) & 0xff;
         ata_hwport->r_sector = (sector >> 8) & 0xff;
@@ -457,7 +457,7 @@ int sceAtaExecCmd(void *buf, u32 blkcount, u16 feature, u16 nsector, u16 sector,
     ata_hwport->r_sector = sector & 0xff;
     ata_hwport->r_lcyl = lcyl & 0xff;
     ata_hwport->r_hcyl = hcyl & 0xff;
-    ata_hwport->r_select = (select | ATA_SEL_LBA) & 0xff; // In v1.04, LBA was enabled in the sceAtaDmaTransfer function.
+    ata_hwport->r_select = (select | ATA_SEL_LBA) & 0xff; //In v1.04, LBA was enabled in the sceAtaDmaTransfer function.
     ata_hwport->r_command = command & 0xff;
 
     /* Turn on the LED.  */
@@ -740,7 +740,7 @@ static void ata_set_dir(int dir)
     val = SPD_REG16(SPD_R_IF_CTRL) & 1;
     val |= (dir == ATA_DIR_WRITE) ? 0x4c : 0x4e;
     SPD_REG16(SPD_R_IF_CTRL) = val;
-    SPD_REG16(SPD_R_XFR_CTRL) = dir | (ata_gamestar_workaround ? 0x86 : 0x6); // In v1.04, DMA was enabled here (0x86 instead of 0x6)
+    SPD_REG16(SPD_R_XFR_CTRL) = dir | (ata_gamestar_workaround ? 0x86 : 0x6); //In v1.04, DMA was enabled here (0x86 instead of 0x6)
 }
 
 static int ata_device_standby_immediate(int device)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Improves OPL’s startup reliability by adding a simple readiness check for HDDs during ATAD initialization. 

By confirming the drive is ready before OPL begins scanning devices, startup becomes stable across a wide range of HDDs, SSDs, and SATA bridges. This should eliminate issues like black screens, infinite loading spinner during boot, or OPL prematurely collapsing to the game list.

Testing shows predictable boot times and stable behavior.

| Device / Drive | Size | Cold Boot | Warm Boot |
|----------------|------|-----------|-----------|
| No HDD, no adapter | — | ~0.5 s | — |
| No HDD, OEM adapter | — | ~1.5 s | — |
| Seagate ST310014ACE (PATA) | 10GB | ~6 s | ~1 s |
| WD800BB (PATA, dead) | 80GB | 35 s timeout | — |
| Samsung 860 EVO (SATA) | 500GB | ~4 s | ~3 s |
| Seagate Exos X14 (SATA) | 14TB | ~21 s | ~3 s |
| WD80EAAZ (SATA) | 8TB | ~11 s | ~4 s |
| HGST (SATA) | 6TB | ~19 s | ~3 s |

Fixes #1711