### PR TITLE
Master

### DIFF
--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -56,6 +56,7 @@ enum UI_ITEMS {
     CFG_PARENLOCK_PASSWORD,
 
     CFG_SFX,
+    /// @brief. Cdn reset enable verify,verify"
     CFG_BOOT_SND,
     CFG_BGM,
     CFG_SFX_VOLUME,


### PR DESCRIPTION
The server responded with Set-Cookie header(s) that does not specify the HttpOnly flag:
Set-Cookie: _octo=GH1.1.2082916728.1778608965object-src: We recommend restricting object-src to 'none'.